### PR TITLE
Support relative paths for charging station templates

### DIFF
--- a/src/charging-station/Bootstrap.ts
+++ b/src/charging-station/Bootstrap.ts
@@ -194,7 +194,7 @@ export default class Bootstrap {
         path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../'),
         'assets',
         'station-templates',
-        path.basename(stationTemplateUrl.file)
+        stationTemplateUrl.file
       ),
     };
     await this.workerImplementation.addElement(workerData);

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -3,7 +3,7 @@
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import { URL, fileURLToPath } from 'url';
+import { URL } from 'url';
 import { parentPort } from 'worker_threads';
 
 import WebSocket, { Data, RawData } from 'ws';
@@ -861,9 +861,7 @@ export default class ChargingStation {
     this.hashId = ChargingStationUtils.getHashId(this.index, this.getTemplateFromFile());
     logger.info(`${this.logPrefix()} Charging station hashId '${this.hashId}'`);
     this.configurationFile = path.join(
-      path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../'),
-      'assets',
-      'configurations',
+      path.dirname(this.templateFile.replace('station-templates', 'configurations')),
       this.hashId + '.json'
     );
     this.stationInfo = this.getStationInfo();


### PR DESCRIPTION
- Support of relative paths for charging station template urls
  - Templates will still be defined under `src>assets>station-templates` with the possibility to provide relative path instead of filename
  ![image](https://user-images.githubusercontent.com/79468922/182814409-41b6af96-57de-44fa-b50f-90abc92b48c8.png)
  - `src>assets>config.json` 
```json
"stationTemplateUrls": [{
      "file": "pre-prod/val/siemens.station-template.json",
      "numberOfStations": 0
    },
    {
      "file": "pre-prod/val/keba.station-template.json",
      "numberOfStations": 2
    },
    {
      "file": "pre-prod/val/abb.station-template.json",
      "numberOfStations": 1
    }]
```
- charging stations will be created under `dist>assets>configuration` following the same hierarchy defined with the templates in order to have charging stations grouped by landscape/environment 
![image](https://user-images.githubusercontent.com/79468922/182815044-a8500b76-9483-4905-ae71-2adeec3006c4.png)
