### PR TITLE
Fix for failed execution in Docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /usr/app
 COPY --from=builder /usr/builder/webui ./webui
 COPY --from=builder /usr/builder/node_modules ./node_modules
 COPY --from=builder /usr/builder/dist ./dist
-COPY README.md LICENSE package.json ./
+COPY package.json README.md LICENSE ./
 COPY docker/start.sh /start.sh
 COPY docker/autoconfig.sh /autoconfig.sh
 RUN set -ex \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /usr/app
 COPY --from=builder /usr/builder/webui ./webui
 COPY --from=builder /usr/builder/node_modules ./node_modules
 COPY --from=builder /usr/builder/dist ./dist
-COPY README.md LICENSE ./
+COPY README.md LICENSE package.json ./
 COPY docker/start.sh /start.sh
 COPY docker/autoconfig.sh /autoconfig.sh
 RUN set -ex \


### PR DESCRIPTION
Problem:
Encountered the Node.JS module error by executing the application inside a Docker container build by the provided Makefile:
![image](https://github.com/SAP/e-mobility-charging-stations-simulator/assets/69958138/ac2d5243-b801-4a19-81a7-7570d14cf8d3)

This results in failing to establish the WebSocket connection with the corresponding backend for charging station management.

Proposed Solution:
To encounter this problem, the `package.json` has to be part of the Docker container, which serves as execution environment. 