### PR TITLE
SAPEMOBILITY-12982

### DIFF
--- a/src/types/ocpp/1.6/Requests.ts
+++ b/src/types/ocpp/1.6/Requests.ts
@@ -16,10 +16,10 @@ export enum OCPP16AvailabilityType {
 }
 
 export enum OCPP16DataTransferVendorId {
-    SchneiderElectric = 'Schneider Electric',
-    Abb = "ABB",
-    KebaAG = "Keba AG",
-    SIEMENS = "SIEMENS"
+  Abb = 'ABB',
+  KebaAG = 'Keba AG',
+  SchneiderElectric = 'Schneider Electric',
+  SIEMENS = 'SIEMENS',
 }
 
 export enum OCPP16FirmwareStatus {

--- a/src/types/ocpp/1.6/Requests.ts
+++ b/src/types/ocpp/1.6/Requests.ts
@@ -15,7 +15,9 @@ export enum OCPP16AvailabilityType {
   Operative = 'Operative',
 }
 
-export enum OCPP16DataTransferVendorId {}
+export enum OCPP16DataTransferVendorId {
+    SchneiderElectric = 'Schneider Electric'
+}
 
 export enum OCPP16FirmwareStatus {
   Downloaded = 'Downloaded',

--- a/src/types/ocpp/1.6/Requests.ts
+++ b/src/types/ocpp/1.6/Requests.ts
@@ -16,7 +16,10 @@ export enum OCPP16AvailabilityType {
 }
 
 export enum OCPP16DataTransferVendorId {
-    SchneiderElectric = 'Schneider Electric'
+    SchneiderElectric = 'Schneider Electric',
+    Abb = "ABB",
+    KebaAG = "Keba AG",
+    SIEMENS = "SIEMENS"
 }
 
 export enum OCPP16FirmwareStatus {


### PR DESCRIPTION
## Description:

Added vendorID under enum "OCPP16DataTransferVendorId" (Requests.ts).

Fix for issue "UnknownVendorId" for e2e Bruno testing under packages\api-tests\public-api\4-ChargingStation\ChargingStation tests\OCPP\3-Data Transfer\DataTransfer Connected CS.bru

https://jira.tools.sap/browse/SAPEMOBILITY-12982

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
