### PR TITLE
feat(ocpp2): integrate all 8 missing OCPP 2.0.1 outgoing commands into UIService/BroadcastChannel pipeline

### DIFF
--- a/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
+++ b/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
@@ -175,10 +175,7 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
         },
       ],
       [BroadcastChannelProcedureName.START_TRANSACTION, this.handleStartTransaction.bind(this)],
-      [
-        BroadcastChannelProcedureName.STATUS_NOTIFICATION,
-        this.handleStatusNotification.bind(this),
-      ],
+      [BroadcastChannelProcedureName.STATUS_NOTIFICATION, this.handleStatusNotification.bind(this)],
       [
         BroadcastChannelProcedureName.STOP_AUTOMATIC_TRANSACTION_GENERATOR,
         (requestPayload?: BroadcastChannelRequestPayload) => {

--- a/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
+++ b/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
@@ -21,11 +21,33 @@ import {
   type EmptyObject,
   type FirmwareStatusNotificationRequest,
   type FirmwareStatusNotificationResponse,
+  GenericStatus,
+  GetCertificateStatusEnumType,
   type HeartbeatRequest,
   type HeartbeatResponse,
+  Iso15118EVCertificateStatusEnumType,
   type MessageEvent,
   type MeterValuesRequest,
   type MeterValuesResponse,
+  type OCPP20Get15118EVCertificateRequest,
+  type OCPP20Get15118EVCertificateResponse,
+  type OCPP20GetCertificateStatusRequest,
+  type OCPP20GetCertificateStatusResponse,
+  type OCPP20LogStatusNotificationRequest,
+  type OCPP20LogStatusNotificationResponse,
+  type OCPP20MeterValuesRequest,
+  type OCPP20MeterValuesResponse,
+  type OCPP20NotifyCustomerInformationRequest,
+  type OCPP20NotifyCustomerInformationResponse,
+  type OCPP20NotifyReportRequest,
+  type OCPP20NotifyReportResponse,
+  type OCPP20SecurityEventNotificationRequest,
+  type OCPP20SecurityEventNotificationResponse,
+  type OCPP20SignCertificateRequest,
+  type OCPP20SignCertificateResponse,
+  type OCPP20TransactionEventRequest,
+  type OCPP20TransactionEventResponse,
+  OCPPVersion,
   RegistrationStatusEnumType,
   RequestCommand,
   type RequestParams,
@@ -38,6 +60,7 @@ import {
   type StopTransactionRequest,
   type StopTransactionResponse,
 } from '../../types/index.js'
+import { OCPP20AuthorizationStatusEnumType } from '../../types/ocpp/2.0/Transaction.js'
 import { Constants, convertToInt, isAsyncFunction, isEmpty, logger } from '../../utils/index.js'
 import { getConfigurationKey } from '../ConfigurationKeyUtils.js'
 import { buildMeterValue } from '../ocpp/index.js'
@@ -56,6 +79,10 @@ type CommandResponse =
   | DataTransferResponse
   | EmptyObject
   | HeartbeatResponse
+  | OCPP20Get15118EVCertificateResponse
+  | OCPP20GetCertificateStatusResponse
+  | OCPP20SignCertificateResponse
+  | OCPP20TransactionEventResponse
   | StartTransactionResponse
   | StopTransactionResponse
 
@@ -169,6 +196,17 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
       [
         BroadcastChannelProcedureName.METER_VALUES,
         async (requestPayload?: BroadcastChannelRequestPayload) => {
+          if (this.chargingStation.stationInfo?.ocppVersion === OCPPVersion.VERSION_201) {
+            return await this.chargingStation.ocppRequestService.requestHandler<
+              OCPP20MeterValuesRequest,
+              OCPP20MeterValuesResponse
+            >(
+              this.chargingStation,
+              RequestCommand.METER_VALUES,
+              requestPayload as OCPP20MeterValuesRequest,
+              requestParams
+            )
+          }
           const configuredMeterValueSampleInterval = getConfigurationKey(
             chargingStation,
             StandardParametersKey.MeterValueSampleInterval
@@ -287,6 +325,110 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
             requestParams
           ),
       ],
+      [
+        BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE,
+        async (requestPayload?: BroadcastChannelRequestPayload) =>
+          await this.chargingStation.ocppRequestService.requestHandler<
+            OCPP20Get15118EVCertificateRequest,
+            OCPP20Get15118EVCertificateResponse
+          >(
+            this.chargingStation,
+            RequestCommand.GET_15118_EV_CERTIFICATE,
+            requestPayload as OCPP20Get15118EVCertificateRequest,
+            requestParams
+          ),
+      ],
+      [
+        BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS,
+        async (requestPayload?: BroadcastChannelRequestPayload) =>
+          await this.chargingStation.ocppRequestService.requestHandler<
+            OCPP20GetCertificateStatusRequest,
+            OCPP20GetCertificateStatusResponse
+          >(
+            this.chargingStation,
+            RequestCommand.GET_CERTIFICATE_STATUS,
+            requestPayload as OCPP20GetCertificateStatusRequest,
+            requestParams
+          ),
+      ],
+      [
+        BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION,
+        async (requestPayload?: BroadcastChannelRequestPayload) =>
+          await this.chargingStation.ocppRequestService.requestHandler<
+            OCPP20LogStatusNotificationRequest,
+            OCPP20LogStatusNotificationResponse
+          >(
+            this.chargingStation,
+            RequestCommand.LOG_STATUS_NOTIFICATION,
+            requestPayload as OCPP20LogStatusNotificationRequest,
+            requestParams
+          ),
+      ],
+      [
+        BroadcastChannelProcedureName.NOTIFY_CUSTOMER_INFORMATION,
+        async (requestPayload?: BroadcastChannelRequestPayload) =>
+          await this.chargingStation.ocppRequestService.requestHandler<
+            OCPP20NotifyCustomerInformationRequest,
+            OCPP20NotifyCustomerInformationResponse
+          >(
+            this.chargingStation,
+            RequestCommand.NOTIFY_CUSTOMER_INFORMATION,
+            requestPayload as OCPP20NotifyCustomerInformationRequest,
+            requestParams
+          ),
+      ],
+      [
+        BroadcastChannelProcedureName.NOTIFY_REPORT,
+        async (requestPayload?: BroadcastChannelRequestPayload) =>
+          await this.chargingStation.ocppRequestService.requestHandler<
+            OCPP20NotifyReportRequest,
+            OCPP20NotifyReportResponse
+          >(
+            this.chargingStation,
+            RequestCommand.NOTIFY_REPORT,
+            requestPayload as OCPP20NotifyReportRequest,
+            requestParams
+          ),
+      ],
+      [
+        BroadcastChannelProcedureName.SECURITY_EVENT_NOTIFICATION,
+        async (requestPayload?: BroadcastChannelRequestPayload) =>
+          await this.chargingStation.ocppRequestService.requestHandler<
+            OCPP20SecurityEventNotificationRequest,
+            OCPP20SecurityEventNotificationResponse
+          >(
+            this.chargingStation,
+            RequestCommand.SECURITY_EVENT_NOTIFICATION,
+            requestPayload as OCPP20SecurityEventNotificationRequest,
+            requestParams
+          ),
+      ],
+      [
+        BroadcastChannelProcedureName.SIGN_CERTIFICATE,
+        async (requestPayload?: BroadcastChannelRequestPayload) =>
+          await this.chargingStation.ocppRequestService.requestHandler<
+            OCPP20SignCertificateRequest,
+            OCPP20SignCertificateResponse
+          >(
+            this.chargingStation,
+            RequestCommand.SIGN_CERTIFICATE,
+            requestPayload as OCPP20SignCertificateRequest,
+            requestParams
+          ),
+      ],
+      [
+        BroadcastChannelProcedureName.TRANSACTION_EVENT,
+        async (requestPayload?: BroadcastChannelRequestPayload) =>
+          await this.chargingStation.ocppRequestService.requestHandler<
+            OCPP20TransactionEventRequest,
+            OCPP20TransactionEventResponse
+          >(
+            this.chargingStation,
+            RequestCommand.TRANSACTION_EVENT,
+            requestPayload as OCPP20TransactionEventRequest,
+            requestParams
+          ),
+      ],
     ])
     this.chargingStation = chargingStation
     this.onmessage = this.requestHandler.bind(this) as (message: unknown) => void
@@ -385,6 +527,39 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
       case BroadcastChannelProcedureName.METER_VALUES:
       case BroadcastChannelProcedureName.STATUS_NOTIFICATION:
         if (isEmpty(commandResponse)) {
+          return ResponseStatus.SUCCESS
+        }
+        return ResponseStatus.FAILURE
+      case BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE:
+        if (
+          (commandResponse as OCPP20Get15118EVCertificateResponse).status ===
+          Iso15118EVCertificateStatusEnumType.Accepted
+        ) {
+          return ResponseStatus.SUCCESS
+        }
+        return ResponseStatus.FAILURE
+      case BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS:
+        if (
+          (commandResponse as OCPP20GetCertificateStatusResponse).status ===
+          GetCertificateStatusEnumType.Accepted
+        ) {
+          return ResponseStatus.SUCCESS
+        }
+        return ResponseStatus.FAILURE
+      case BroadcastChannelProcedureName.SIGN_CERTIFICATE:
+        if (
+          (commandResponse as OCPP20SignCertificateResponse).status === GenericStatus.Accepted
+        ) {
+          return ResponseStatus.SUCCESS
+        }
+        return ResponseStatus.FAILURE
+      case BroadcastChannelProcedureName.TRANSACTION_EVENT:
+        if (
+          isEmpty(commandResponse) ||
+          (commandResponse as OCPP20TransactionEventResponse).idTokenInfo == null ||
+          (commandResponse as OCPP20TransactionEventResponse).idTokenInfo?.status ===
+            OCPP20AuthorizationStatusEnumType.Accepted
+        ) {
           return ResponseStatus.SUCCESS
         }
         return ResponseStatus.FAILURE

--- a/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
+++ b/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
@@ -29,6 +29,7 @@ import {
   type MessageEvent,
   type MeterValuesRequest,
   type MeterValuesResponse,
+  OCPP20AuthorizationStatusEnumType,
   type OCPP20Get15118EVCertificateRequest,
   type OCPP20Get15118EVCertificateResponse,
   type OCPP20GetCertificateStatusRequest,
@@ -60,7 +61,6 @@ import {
   type StopTransactionRequest,
   type StopTransactionResponse,
 } from '../../types/index.js'
-import { OCPP20AuthorizationStatusEnumType } from '../../types/ocpp/2.0/Transaction.js'
 import { Constants, convertToInt, isAsyncFunction, isEmpty, logger } from '../../utils/index.js'
 import { getConfigurationKey } from '../ConfigurationKeyUtils.js'
 import { buildMeterValue } from '../ocpp/index.js'
@@ -540,7 +540,11 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
           return ResponseStatus.SUCCESS
         }
         return ResponseStatus.FAILURE
+      case BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION:
       case BroadcastChannelProcedureName.METER_VALUES:
+      case BroadcastChannelProcedureName.NOTIFY_CUSTOMER_INFORMATION:
+      case BroadcastChannelProcedureName.NOTIFY_REPORT:
+      case BroadcastChannelProcedureName.SECURITY_EVENT_NOTIFICATION:
       case BroadcastChannelProcedureName.STATUS_NOTIFICATION:
         if (isEmpty(commandResponse)) {
           return ResponseStatus.SUCCESS

--- a/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
+++ b/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
@@ -547,9 +547,7 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
         }
         return ResponseStatus.FAILURE
       case BroadcastChannelProcedureName.SIGN_CERTIFICATE:
-        if (
-          (commandResponse as OCPP20SignCertificateResponse).status === GenericStatus.Accepted
-        ) {
+        if ((commandResponse as OCPP20SignCertificateResponse).status === GenericStatus.Accepted) {
           return ResponseStatus.SUCCESS
         }
         return ResponseStatus.FAILURE

--- a/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
+++ b/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
@@ -89,65 +89,23 @@ type CommandResponse =
 export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChannel {
   private readonly chargingStation: ChargingStation
   private readonly commandHandlers: Map<BroadcastChannelProcedureName, CommandHandler>
+  private readonly requestParams: RequestParams = {
+    throwError: true,
+  }
 
   constructor (chargingStation: ChargingStation) {
     super()
-    const requestParams: RequestParams = {
-      throwError: true,
-    }
+    this.chargingStation = chargingStation
     this.commandHandlers = new Map<BroadcastChannelProcedureName, CommandHandler>([
-      [
-        BroadcastChannelProcedureName.AUTHORIZE,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            AuthorizeRequest,
-            AuthorizeResponse
-          >(
-            this.chargingStation,
-            RequestCommand.AUTHORIZE,
-            requestPayload as AuthorizeRequest,
-            requestParams
-          ),
-      ],
-      [
-        BroadcastChannelProcedureName.BOOT_NOTIFICATION,
-        async (requestPayload?: BroadcastChannelRequestPayload) => {
-          return await this.chargingStation.ocppRequestService.requestHandler<
-            BootNotificationRequest,
-            BootNotificationResponse
-          >(
-            this.chargingStation,
-            RequestCommand.BOOT_NOTIFICATION,
-            {
-              ...this.chargingStation.bootNotificationRequest,
-              ...requestPayload,
-            } as BootNotificationRequest,
-            {
-              skipBufferingOnError: true,
-              throwError: true,
-            }
-          )
-        },
-      ],
+      [BroadcastChannelProcedureName.AUTHORIZE, this.handleAuthorize.bind(this)],
+      [BroadcastChannelProcedureName.BOOT_NOTIFICATION, this.handleBootNotification.bind(this)],
       [
         BroadcastChannelProcedureName.CLOSE_CONNECTION,
         () => {
           this.chargingStation.closeWSConnection()
         },
       ],
-      [
-        BroadcastChannelProcedureName.DATA_TRANSFER,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            DataTransferRequest,
-            DataTransferResponse
-          >(
-            this.chargingStation,
-            RequestCommand.DATA_TRANSFER,
-            requestPayload as DataTransferRequest,
-            requestParams
-          ),
-      ],
+      [BroadcastChannelProcedureName.DATA_TRANSFER, this.handleDataTransfer.bind(this)],
       [
         BroadcastChannelProcedureName.DELETE_CHARGING_STATIONS,
         async (requestPayload?: BroadcastChannelRequestPayload) => {
@@ -156,153 +114,31 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
       ],
       [
         BroadcastChannelProcedureName.DIAGNOSTICS_STATUS_NOTIFICATION,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            DiagnosticsStatusNotificationRequest,
-            DiagnosticsStatusNotificationResponse
-          >(
-            this.chargingStation,
-            RequestCommand.DIAGNOSTICS_STATUS_NOTIFICATION,
-            requestPayload as DiagnosticsStatusNotificationRequest,
-            requestParams
-          ),
+        this.handleDiagnosticsStatusNotification.bind(this),
       ],
       [
         BroadcastChannelProcedureName.FIRMWARE_STATUS_NOTIFICATION,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            FirmwareStatusNotificationRequest,
-            FirmwareStatusNotificationResponse
-          >(
-            this.chargingStation,
-            RequestCommand.FIRMWARE_STATUS_NOTIFICATION,
-            requestPayload as FirmwareStatusNotificationRequest,
-            requestParams
-          ),
+        this.handleFirmwareStatusNotification.bind(this),
       ],
       [
         BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            OCPP20Get15118EVCertificateRequest,
-            OCPP20Get15118EVCertificateResponse
-          >(
-            this.chargingStation,
-            RequestCommand.GET_15118_EV_CERTIFICATE,
-            requestPayload as OCPP20Get15118EVCertificateRequest,
-            requestParams
-          ),
+        this.handleGet15118EVCertificate.bind(this),
       ],
       [
         BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            OCPP20GetCertificateStatusRequest,
-            OCPP20GetCertificateStatusResponse
-          >(
-            this.chargingStation,
-            RequestCommand.GET_CERTIFICATE_STATUS,
-            requestPayload as OCPP20GetCertificateStatusRequest,
-            requestParams
-          ),
+        this.handleGetCertificateStatus.bind(this),
       ],
-      [
-        BroadcastChannelProcedureName.HEARTBEAT,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            HeartbeatRequest,
-            HeartbeatResponse
-          >(
-            this.chargingStation,
-            RequestCommand.HEARTBEAT,
-            requestPayload as HeartbeatRequest,
-            requestParams
-          ),
-      ],
+      [BroadcastChannelProcedureName.HEARTBEAT, this.handleHeartbeat.bind(this)],
       [
         BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            OCPP20LogStatusNotificationRequest,
-            OCPP20LogStatusNotificationResponse
-          >(
-            this.chargingStation,
-            RequestCommand.LOG_STATUS_NOTIFICATION,
-            requestPayload as OCPP20LogStatusNotificationRequest,
-            requestParams
-          ),
+        this.handleLogStatusNotification.bind(this),
       ],
-      [
-        BroadcastChannelProcedureName.METER_VALUES,
-        async (requestPayload?: BroadcastChannelRequestPayload) => {
-          if (this.chargingStation.stationInfo?.ocppVersion === OCPPVersion.VERSION_201) {
-            return await this.chargingStation.ocppRequestService.requestHandler<
-              OCPP20MeterValuesRequest,
-              OCPP20MeterValuesResponse
-            >(
-              this.chargingStation,
-              RequestCommand.METER_VALUES,
-              requestPayload as OCPP20MeterValuesRequest,
-              requestParams
-            )
-          }
-          const configuredMeterValueSampleInterval = getConfigurationKey(
-            chargingStation,
-            StandardParametersKey.MeterValueSampleInterval
-          )
-          const connectorId = requestPayload?.connectorId
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const transactionId = this.chargingStation.getConnectorStatus(connectorId!)?.transactionId
-          return await this.chargingStation.ocppRequestService.requestHandler<
-            MeterValuesRequest,
-            MeterValuesResponse
-          >(
-            this.chargingStation,
-            RequestCommand.METER_VALUES,
-            {
-              meterValue: [
-                buildMeterValue(
-                  this.chargingStation,
-                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                  connectorId!,
-                  convertToInt(transactionId),
-                  configuredMeterValueSampleInterval != null
-                    ? secondsToMilliseconds(convertToInt(configuredMeterValueSampleInterval.value))
-                    : Constants.DEFAULT_METER_VALUES_INTERVAL
-                ),
-              ],
-              ...requestPayload,
-            } as MeterValuesRequest,
-            requestParams
-          )
-        },
-      ],
+      [BroadcastChannelProcedureName.METER_VALUES, this.handleMeterValues.bind(this)],
       [
         BroadcastChannelProcedureName.NOTIFY_CUSTOMER_INFORMATION,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            OCPP20NotifyCustomerInformationRequest,
-            OCPP20NotifyCustomerInformationResponse
-          >(
-            this.chargingStation,
-            RequestCommand.NOTIFY_CUSTOMER_INFORMATION,
-            requestPayload as OCPP20NotifyCustomerInformationRequest,
-            requestParams
-          ),
+        this.handleNotifyCustomerInformation.bind(this),
       ],
-      [
-        BroadcastChannelProcedureName.NOTIFY_REPORT,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            OCPP20NotifyReportRequest,
-            OCPP20NotifyReportResponse
-          >(
-            this.chargingStation,
-            RequestCommand.NOTIFY_REPORT,
-            requestPayload as OCPP20NotifyReportRequest,
-            requestParams
-          ),
-      ],
+      [BroadcastChannelProcedureName.NOTIFY_REPORT, this.handleNotifyReport.bind(this)],
       [
         BroadcastChannelProcedureName.OPEN_CONNECTION,
         () => {
@@ -311,16 +147,7 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
       ],
       [
         BroadcastChannelProcedureName.SECURITY_EVENT_NOTIFICATION,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            OCPP20SecurityEventNotificationRequest,
-            OCPP20SecurityEventNotificationResponse
-          >(
-            this.chargingStation,
-            RequestCommand.SECURITY_EVENT_NOTIFICATION,
-            requestPayload as OCPP20SecurityEventNotificationRequest,
-            requestParams
-          ),
+        this.handleSecurityEventNotification.bind(this),
       ],
       [
         BroadcastChannelProcedureName.SET_SUPERVISION_URL,
@@ -334,19 +161,7 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
           this.chargingStation.setSupervisionUrl(url)
         },
       ],
-      [
-        BroadcastChannelProcedureName.SIGN_CERTIFICATE,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            OCPP20SignCertificateRequest,
-            OCPP20SignCertificateResponse
-          >(
-            this.chargingStation,
-            RequestCommand.SIGN_CERTIFICATE,
-            requestPayload as OCPP20SignCertificateRequest,
-            requestParams
-          ),
-      ],
+      [BroadcastChannelProcedureName.SIGN_CERTIFICATE, this.handleSignCertificate.bind(this)],
       [
         BroadcastChannelProcedureName.START_AUTOMATIC_TRANSACTION_GENERATOR,
         (requestPayload?: BroadcastChannelRequestPayload) => {
@@ -359,31 +174,10 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
           this.chargingStation.start()
         },
       ],
-      [
-        BroadcastChannelProcedureName.START_TRANSACTION,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            StartTransactionRequest,
-            StartTransactionResponse
-          >(
-            this.chargingStation,
-            RequestCommand.START_TRANSACTION,
-            requestPayload as StartTransactionRequest,
-            requestParams
-          ),
-      ],
+      [BroadcastChannelProcedureName.START_TRANSACTION, this.handleStartTransaction.bind(this)],
       [
         BroadcastChannelProcedureName.STATUS_NOTIFICATION,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            StatusNotificationRequest,
-            StatusNotificationResponse
-          >(
-            this.chargingStation,
-            RequestCommand.STATUS_NOTIFICATION,
-            requestPayload as StatusNotificationRequest,
-            requestParams
-          ),
+        this.handleStatusNotification.bind(this),
       ],
       [
         BroadcastChannelProcedureName.STOP_AUTOMATIC_TRANSACTION_GENERATOR,
@@ -397,40 +191,9 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
           await this.chargingStation.stop()
         },
       ],
-      [
-        BroadcastChannelProcedureName.STOP_TRANSACTION,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            StopTransactionRequest,
-            StopTransactionResponse
-          >(
-            this.chargingStation,
-            RequestCommand.STOP_TRANSACTION,
-            {
-              meterStop: this.chargingStation.getEnergyActiveImportRegisterByTransactionId(
-                requestPayload?.transactionId,
-                true
-              ),
-              ...requestPayload,
-            } as StopTransactionRequest,
-            requestParams
-          ),
-      ],
-      [
-        BroadcastChannelProcedureName.TRANSACTION_EVENT,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            OCPP20TransactionEventRequest,
-            OCPP20TransactionEventResponse
-          >(
-            this.chargingStation,
-            RequestCommand.TRANSACTION_EVENT,
-            requestPayload as OCPP20TransactionEventRequest,
-            requestParams
-          ),
-      ],
+      [BroadcastChannelProcedureName.STOP_TRANSACTION, this.handleStopTransaction.bind(this)],
+      [BroadcastChannelProcedureName.TRANSACTION_EVENT, this.handleTransactionEvent.bind(this)],
     ])
-    this.chargingStation = chargingStation
     this.onmessage = this.requestHandler.bind(this) as (message: unknown) => void
     this.onmessageerror = this.messageErrorHandler.bind(this) as (message: unknown) => void
   }
@@ -568,6 +331,301 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
       default:
         return ResponseStatus.FAILURE
     }
+  }
+
+  private async handleAuthorize (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<AuthorizeResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      AuthorizeRequest,
+      AuthorizeResponse
+    >(
+      this.chargingStation,
+      RequestCommand.AUTHORIZE,
+      requestPayload as AuthorizeRequest,
+      this.requestParams
+    )
+  }
+
+  private async handleBootNotification (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<BootNotificationResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      BootNotificationRequest,
+      BootNotificationResponse
+    >(
+      this.chargingStation,
+      RequestCommand.BOOT_NOTIFICATION,
+      {
+        ...this.chargingStation.bootNotificationRequest,
+        ...requestPayload,
+      } as BootNotificationRequest,
+      {
+        skipBufferingOnError: true,
+        throwError: true,
+      }
+    )
+  }
+
+  private async handleDataTransfer (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<DataTransferResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      DataTransferRequest,
+      DataTransferResponse
+    >(
+      this.chargingStation,
+      RequestCommand.DATA_TRANSFER,
+      requestPayload as DataTransferRequest,
+      this.requestParams
+    )
+  }
+
+  private async handleDiagnosticsStatusNotification (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<DiagnosticsStatusNotificationResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      DiagnosticsStatusNotificationRequest,
+      DiagnosticsStatusNotificationResponse
+    >(
+      this.chargingStation,
+      RequestCommand.DIAGNOSTICS_STATUS_NOTIFICATION,
+      requestPayload as DiagnosticsStatusNotificationRequest,
+      this.requestParams
+    )
+  }
+
+  private async handleFirmwareStatusNotification (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<FirmwareStatusNotificationResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      FirmwareStatusNotificationRequest,
+      FirmwareStatusNotificationResponse
+    >(
+      this.chargingStation,
+      RequestCommand.FIRMWARE_STATUS_NOTIFICATION,
+      requestPayload as FirmwareStatusNotificationRequest,
+      this.requestParams
+    )
+  }
+
+  private async handleGet15118EVCertificate (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<OCPP20Get15118EVCertificateResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      OCPP20Get15118EVCertificateRequest,
+      OCPP20Get15118EVCertificateResponse
+    >(
+      this.chargingStation,
+      RequestCommand.GET_15118_EV_CERTIFICATE,
+      requestPayload as OCPP20Get15118EVCertificateRequest,
+      this.requestParams
+    )
+  }
+
+  private async handleGetCertificateStatus (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<OCPP20GetCertificateStatusResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      OCPP20GetCertificateStatusRequest,
+      OCPP20GetCertificateStatusResponse
+    >(
+      this.chargingStation,
+      RequestCommand.GET_CERTIFICATE_STATUS,
+      requestPayload as OCPP20GetCertificateStatusRequest,
+      this.requestParams
+    )
+  }
+
+  private async handleHeartbeat (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<HeartbeatResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      HeartbeatRequest,
+      HeartbeatResponse
+    >(
+      this.chargingStation,
+      RequestCommand.HEARTBEAT,
+      requestPayload as HeartbeatRequest,
+      this.requestParams
+    )
+  }
+
+  private async handleLogStatusNotification (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<OCPP20LogStatusNotificationResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      OCPP20LogStatusNotificationRequest,
+      OCPP20LogStatusNotificationResponse
+    >(
+      this.chargingStation,
+      RequestCommand.LOG_STATUS_NOTIFICATION,
+      requestPayload as OCPP20LogStatusNotificationRequest,
+      this.requestParams
+    )
+  }
+
+  private async handleMeterValues (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<MeterValuesResponse> {
+    if (this.chargingStation.stationInfo?.ocppVersion === OCPPVersion.VERSION_201) {
+      return await this.chargingStation.ocppRequestService.requestHandler<
+        OCPP20MeterValuesRequest,
+        OCPP20MeterValuesResponse
+      >(
+        this.chargingStation,
+        RequestCommand.METER_VALUES,
+        requestPayload as OCPP20MeterValuesRequest,
+        this.requestParams
+      )
+    }
+    const configuredMeterValueSampleInterval = getConfigurationKey(
+      this.chargingStation,
+      StandardParametersKey.MeterValueSampleInterval
+    )
+    const connectorId = requestPayload?.connectorId
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const transactionId = this.chargingStation.getConnectorStatus(connectorId!)?.transactionId
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      MeterValuesRequest,
+      MeterValuesResponse
+    >(
+      this.chargingStation,
+      RequestCommand.METER_VALUES,
+      {
+        meterValue: [
+          buildMeterValue(
+            this.chargingStation,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            connectorId!,
+            convertToInt(transactionId),
+            configuredMeterValueSampleInterval != null
+              ? secondsToMilliseconds(convertToInt(configuredMeterValueSampleInterval.value))
+              : Constants.DEFAULT_METER_VALUES_INTERVAL
+          ),
+        ],
+        ...requestPayload,
+      } as MeterValuesRequest,
+      this.requestParams
+    )
+  }
+
+  private async handleNotifyCustomerInformation (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<OCPP20NotifyCustomerInformationResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      OCPP20NotifyCustomerInformationRequest,
+      OCPP20NotifyCustomerInformationResponse
+    >(
+      this.chargingStation,
+      RequestCommand.NOTIFY_CUSTOMER_INFORMATION,
+      requestPayload as OCPP20NotifyCustomerInformationRequest,
+      this.requestParams
+    )
+  }
+
+  private async handleNotifyReport (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<OCPP20NotifyReportResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      OCPP20NotifyReportRequest,
+      OCPP20NotifyReportResponse
+    >(
+      this.chargingStation,
+      RequestCommand.NOTIFY_REPORT,
+      requestPayload as OCPP20NotifyReportRequest,
+      this.requestParams
+    )
+  }
+
+  private async handleSecurityEventNotification (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<OCPP20SecurityEventNotificationResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      OCPP20SecurityEventNotificationRequest,
+      OCPP20SecurityEventNotificationResponse
+    >(
+      this.chargingStation,
+      RequestCommand.SECURITY_EVENT_NOTIFICATION,
+      requestPayload as OCPP20SecurityEventNotificationRequest,
+      this.requestParams
+    )
+  }
+
+  private async handleSignCertificate (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<OCPP20SignCertificateResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      OCPP20SignCertificateRequest,
+      OCPP20SignCertificateResponse
+    >(
+      this.chargingStation,
+      RequestCommand.SIGN_CERTIFICATE,
+      requestPayload as OCPP20SignCertificateRequest,
+      this.requestParams
+    )
+  }
+
+  private async handleStartTransaction (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<StartTransactionResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      StartTransactionRequest,
+      StartTransactionResponse
+    >(
+      this.chargingStation,
+      RequestCommand.START_TRANSACTION,
+      requestPayload as StartTransactionRequest,
+      this.requestParams
+    )
+  }
+
+  private async handleStatusNotification (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<StatusNotificationResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      StatusNotificationRequest,
+      StatusNotificationResponse
+    >(
+      this.chargingStation,
+      RequestCommand.STATUS_NOTIFICATION,
+      requestPayload as StatusNotificationRequest,
+      this.requestParams
+    )
+  }
+
+  private async handleStopTransaction (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<StopTransactionResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      StopTransactionRequest,
+      StopTransactionResponse
+    >(
+      this.chargingStation,
+      RequestCommand.STOP_TRANSACTION,
+      {
+        meterStop: this.chargingStation.getEnergyActiveImportRegisterByTransactionId(
+          requestPayload?.transactionId,
+          true
+        ),
+        ...requestPayload,
+      } as StopTransactionRequest,
+      this.requestParams
+    )
+  }
+
+  private async handleTransactionEvent (
+    requestPayload?: BroadcastChannelRequestPayload
+  ): Promise<OCPP20TransactionEventResponse> {
+    return await this.chargingStation.ocppRequestService.requestHandler<
+      OCPP20TransactionEventRequest,
+      OCPP20TransactionEventResponse
+    >(
+      this.chargingStation,
+      RequestCommand.TRANSACTION_EVENT,
+      requestPayload as OCPP20TransactionEventRequest,
+      this.requestParams
+    )
   }
 
   private messageErrorHandler (messageEvent: MessageEvent): void {

--- a/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
+++ b/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
@@ -181,6 +181,32 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
           ),
       ],
       [
+        BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE,
+        async (requestPayload?: BroadcastChannelRequestPayload) =>
+          await this.chargingStation.ocppRequestService.requestHandler<
+            OCPP20Get15118EVCertificateRequest,
+            OCPP20Get15118EVCertificateResponse
+          >(
+            this.chargingStation,
+            RequestCommand.GET_15118_EV_CERTIFICATE,
+            requestPayload as OCPP20Get15118EVCertificateRequest,
+            requestParams
+          ),
+      ],
+      [
+        BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS,
+        async (requestPayload?: BroadcastChannelRequestPayload) =>
+          await this.chargingStation.ocppRequestService.requestHandler<
+            OCPP20GetCertificateStatusRequest,
+            OCPP20GetCertificateStatusResponse
+          >(
+            this.chargingStation,
+            RequestCommand.GET_CERTIFICATE_STATUS,
+            requestPayload as OCPP20GetCertificateStatusRequest,
+            requestParams
+          ),
+      ],
+      [
         BroadcastChannelProcedureName.HEARTBEAT,
         async (requestPayload?: BroadcastChannelRequestPayload) =>
           await this.chargingStation.ocppRequestService.requestHandler<
@@ -190,6 +216,19 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
             this.chargingStation,
             RequestCommand.HEARTBEAT,
             requestPayload as HeartbeatRequest,
+            requestParams
+          ),
+      ],
+      [
+        BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION,
+        async (requestPayload?: BroadcastChannelRequestPayload) =>
+          await this.chargingStation.ocppRequestService.requestHandler<
+            OCPP20LogStatusNotificationRequest,
+            OCPP20LogStatusNotificationResponse
+          >(
+            this.chargingStation,
+            RequestCommand.LOG_STATUS_NOTIFICATION,
+            requestPayload as OCPP20LogStatusNotificationRequest,
             requestParams
           ),
       ],
@@ -239,10 +278,49 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
         },
       ],
       [
+        BroadcastChannelProcedureName.NOTIFY_CUSTOMER_INFORMATION,
+        async (requestPayload?: BroadcastChannelRequestPayload) =>
+          await this.chargingStation.ocppRequestService.requestHandler<
+            OCPP20NotifyCustomerInformationRequest,
+            OCPP20NotifyCustomerInformationResponse
+          >(
+            this.chargingStation,
+            RequestCommand.NOTIFY_CUSTOMER_INFORMATION,
+            requestPayload as OCPP20NotifyCustomerInformationRequest,
+            requestParams
+          ),
+      ],
+      [
+        BroadcastChannelProcedureName.NOTIFY_REPORT,
+        async (requestPayload?: BroadcastChannelRequestPayload) =>
+          await this.chargingStation.ocppRequestService.requestHandler<
+            OCPP20NotifyReportRequest,
+            OCPP20NotifyReportResponse
+          >(
+            this.chargingStation,
+            RequestCommand.NOTIFY_REPORT,
+            requestPayload as OCPP20NotifyReportRequest,
+            requestParams
+          ),
+      ],
+      [
         BroadcastChannelProcedureName.OPEN_CONNECTION,
         () => {
           this.chargingStation.openWSConnection()
         },
+      ],
+      [
+        BroadcastChannelProcedureName.SECURITY_EVENT_NOTIFICATION,
+        async (requestPayload?: BroadcastChannelRequestPayload) =>
+          await this.chargingStation.ocppRequestService.requestHandler<
+            OCPP20SecurityEventNotificationRequest,
+            OCPP20SecurityEventNotificationResponse
+          >(
+            this.chargingStation,
+            RequestCommand.SECURITY_EVENT_NOTIFICATION,
+            requestPayload as OCPP20SecurityEventNotificationRequest,
+            requestParams
+          ),
       ],
       [
         BroadcastChannelProcedureName.SET_SUPERVISION_URL,
@@ -255,6 +333,19 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
           }
           this.chargingStation.setSupervisionUrl(url)
         },
+      ],
+      [
+        BroadcastChannelProcedureName.SIGN_CERTIFICATE,
+        async (requestPayload?: BroadcastChannelRequestPayload) =>
+          await this.chargingStation.ocppRequestService.requestHandler<
+            OCPP20SignCertificateRequest,
+            OCPP20SignCertificateResponse
+          >(
+            this.chargingStation,
+            RequestCommand.SIGN_CERTIFICATE,
+            requestPayload as OCPP20SignCertificateRequest,
+            requestParams
+          ),
       ],
       [
         BroadcastChannelProcedureName.START_AUTOMATIC_TRANSACTION_GENERATOR,
@@ -322,97 +413,6 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
               ),
               ...requestPayload,
             } as StopTransactionRequest,
-            requestParams
-          ),
-      ],
-      [
-        BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            OCPP20Get15118EVCertificateRequest,
-            OCPP20Get15118EVCertificateResponse
-          >(
-            this.chargingStation,
-            RequestCommand.GET_15118_EV_CERTIFICATE,
-            requestPayload as OCPP20Get15118EVCertificateRequest,
-            requestParams
-          ),
-      ],
-      [
-        BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            OCPP20GetCertificateStatusRequest,
-            OCPP20GetCertificateStatusResponse
-          >(
-            this.chargingStation,
-            RequestCommand.GET_CERTIFICATE_STATUS,
-            requestPayload as OCPP20GetCertificateStatusRequest,
-            requestParams
-          ),
-      ],
-      [
-        BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            OCPP20LogStatusNotificationRequest,
-            OCPP20LogStatusNotificationResponse
-          >(
-            this.chargingStation,
-            RequestCommand.LOG_STATUS_NOTIFICATION,
-            requestPayload as OCPP20LogStatusNotificationRequest,
-            requestParams
-          ),
-      ],
-      [
-        BroadcastChannelProcedureName.NOTIFY_CUSTOMER_INFORMATION,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            OCPP20NotifyCustomerInformationRequest,
-            OCPP20NotifyCustomerInformationResponse
-          >(
-            this.chargingStation,
-            RequestCommand.NOTIFY_CUSTOMER_INFORMATION,
-            requestPayload as OCPP20NotifyCustomerInformationRequest,
-            requestParams
-          ),
-      ],
-      [
-        BroadcastChannelProcedureName.NOTIFY_REPORT,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            OCPP20NotifyReportRequest,
-            OCPP20NotifyReportResponse
-          >(
-            this.chargingStation,
-            RequestCommand.NOTIFY_REPORT,
-            requestPayload as OCPP20NotifyReportRequest,
-            requestParams
-          ),
-      ],
-      [
-        BroadcastChannelProcedureName.SECURITY_EVENT_NOTIFICATION,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            OCPP20SecurityEventNotificationRequest,
-            OCPP20SecurityEventNotificationResponse
-          >(
-            this.chargingStation,
-            RequestCommand.SECURITY_EVENT_NOTIFICATION,
-            requestPayload as OCPP20SecurityEventNotificationRequest,
-            requestParams
-          ),
-      ],
-      [
-        BroadcastChannelProcedureName.SIGN_CERTIFICATE,
-        async (requestPayload?: BroadcastChannelRequestPayload) =>
-          await this.chargingStation.ocppRequestService.requestHandler<
-            OCPP20SignCertificateRequest,
-            OCPP20SignCertificateResponse
-          >(
-            this.chargingStation,
-            RequestCommand.SIGN_CERTIFICATE,
-            requestPayload as OCPP20SignCertificateRequest,
             requestParams
           ),
       ],
@@ -519,17 +519,6 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
           return ResponseStatus.SUCCESS
         }
         return ResponseStatus.FAILURE
-      case BroadcastChannelProcedureName.HEARTBEAT:
-        if ('currentTime' in commandResponse) {
-          return ResponseStatus.SUCCESS
-        }
-        return ResponseStatus.FAILURE
-      case BroadcastChannelProcedureName.METER_VALUES:
-      case BroadcastChannelProcedureName.STATUS_NOTIFICATION:
-        if (isEmpty(commandResponse)) {
-          return ResponseStatus.SUCCESS
-        }
-        return ResponseStatus.FAILURE
       case BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE:
         if (
           (commandResponse as OCPP20Get15118EVCertificateResponse).status ===
@@ -543,6 +532,17 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
           (commandResponse as OCPP20GetCertificateStatusResponse).status ===
           GetCertificateStatusEnumType.Accepted
         ) {
+          return ResponseStatus.SUCCESS
+        }
+        return ResponseStatus.FAILURE
+      case BroadcastChannelProcedureName.HEARTBEAT:
+        if ('currentTime' in commandResponse) {
+          return ResponseStatus.SUCCESS
+        }
+        return ResponseStatus.FAILURE
+      case BroadcastChannelProcedureName.METER_VALUES:
+      case BroadcastChannelProcedureName.STATUS_NOTIFICATION:
+        if (isEmpty(commandResponse)) {
           return ResponseStatus.SUCCESS
         }
         return ResponseStatus.FAILURE

--- a/src/charging-station/ocpp/2.0/OCPP20RequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20RequestService.ts
@@ -593,10 +593,13 @@ export class OCPP20RequestService extends OCPPRequestService {
       case OCPP20RequestCommand.BOOT_NOTIFICATION:
         return commandParams as unknown as Request
       case OCPP20RequestCommand.FIRMWARE_STATUS_NOTIFICATION:
+      case OCPP20RequestCommand.GET_15118_EV_CERTIFICATE:
+      case OCPP20RequestCommand.GET_CERTIFICATE_STATUS:
       case OCPP20RequestCommand.LOG_STATUS_NOTIFICATION:
       case OCPP20RequestCommand.METER_VALUES:
       case OCPP20RequestCommand.NOTIFY_CUSTOMER_INFORMATION:
       case OCPP20RequestCommand.SECURITY_EVENT_NOTIFICATION:
+      case OCPP20RequestCommand.SIGN_CERTIFICATE:
         return commandParams as unknown as Request
       case OCPP20RequestCommand.HEARTBEAT:
         return OCPP20Constants.OCPP_RESPONSE_EMPTY as unknown as Request

--- a/src/charging-station/ui-server/ui-services/AbstractUIService.ts
+++ b/src/charging-station/ui-server/ui-services/AbstractUIService.ts
@@ -54,10 +54,23 @@ export abstract class AbstractUIService {
       ProcedureName.FIRMWARE_STATUS_NOTIFICATION,
       BroadcastChannelProcedureName.FIRMWARE_STATUS_NOTIFICATION,
     ],
+    [ProcedureName.GET_15118_EV_CERTIFICATE, BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE],
+    [ProcedureName.GET_CERTIFICATE_STATUS, BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS],
     [ProcedureName.HEARTBEAT, BroadcastChannelProcedureName.HEARTBEAT],
+    [ProcedureName.LOG_STATUS_NOTIFICATION, BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION],
     [ProcedureName.METER_VALUES, BroadcastChannelProcedureName.METER_VALUES],
+    [
+      ProcedureName.NOTIFY_CUSTOMER_INFORMATION,
+      BroadcastChannelProcedureName.NOTIFY_CUSTOMER_INFORMATION,
+    ],
+    [ProcedureName.NOTIFY_REPORT, BroadcastChannelProcedureName.NOTIFY_REPORT],
     [ProcedureName.OPEN_CONNECTION, BroadcastChannelProcedureName.OPEN_CONNECTION],
+    [
+      ProcedureName.SECURITY_EVENT_NOTIFICATION,
+      BroadcastChannelProcedureName.SECURITY_EVENT_NOTIFICATION,
+    ],
     [ProcedureName.SET_SUPERVISION_URL, BroadcastChannelProcedureName.SET_SUPERVISION_URL],
+    [ProcedureName.SIGN_CERTIFICATE, BroadcastChannelProcedureName.SIGN_CERTIFICATE],
     [
       ProcedureName.START_AUTOMATIC_TRANSACTION_GENERATOR,
       BroadcastChannelProcedureName.START_AUTOMATIC_TRANSACTION_GENERATOR,
@@ -71,6 +84,7 @@ export abstract class AbstractUIService {
     ],
     [ProcedureName.STOP_CHARGING_STATION, BroadcastChannelProcedureName.STOP_CHARGING_STATION],
     [ProcedureName.STOP_TRANSACTION, BroadcastChannelProcedureName.STOP_TRANSACTION],
+    [ProcedureName.TRANSACTION_EVENT, BroadcastChannelProcedureName.TRANSACTION_EVENT],
   ])
 
   protected readonly requestHandlers: Map<ProcedureName, ProtocolRequestHandler>

--- a/src/charging-station/ui-server/ui-services/AbstractUIService.ts
+++ b/src/charging-station/ui-server/ui-services/AbstractUIService.ts
@@ -54,7 +54,10 @@ export abstract class AbstractUIService {
       ProcedureName.FIRMWARE_STATUS_NOTIFICATION,
       BroadcastChannelProcedureName.FIRMWARE_STATUS_NOTIFICATION,
     ],
-    [ProcedureName.GET_15118_EV_CERTIFICATE, BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE],
+    [
+      ProcedureName.GET_15118_EV_CERTIFICATE,
+      BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE,
+    ],
     [ProcedureName.GET_CERTIFICATE_STATUS, BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS],
     [ProcedureName.HEARTBEAT, BroadcastChannelProcedureName.HEARTBEAT],
     [ProcedureName.LOG_STATUS_NOTIFICATION, BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION],

--- a/src/types/UIProtocol.ts
+++ b/src/types/UIProtocol.ts
@@ -21,13 +21,20 @@ export enum ProcedureName {
   DELETE_CHARGING_STATIONS = 'deleteChargingStations',
   DIAGNOSTICS_STATUS_NOTIFICATION = 'diagnosticsStatusNotification',
   FIRMWARE_STATUS_NOTIFICATION = 'firmwareStatusNotification',
+  GET_15118_EV_CERTIFICATE = 'get15118EVCertificate',
+  GET_CERTIFICATE_STATUS = 'getCertificateStatus',
   HEARTBEAT = 'heartbeat',
   LIST_CHARGING_STATIONS = 'listChargingStations',
   LIST_TEMPLATES = 'listTemplates',
+  LOG_STATUS_NOTIFICATION = 'logStatusNotification',
   METER_VALUES = 'meterValues',
+  NOTIFY_CUSTOMER_INFORMATION = 'notifyCustomerInformation',
+  NOTIFY_REPORT = 'notifyReport',
   OPEN_CONNECTION = 'openConnection',
   PERFORMANCE_STATISTICS = 'performanceStatistics',
+  SECURITY_EVENT_NOTIFICATION = 'securityEventNotification',
   SET_SUPERVISION_URL = 'setSupervisionUrl',
+  SIGN_CERTIFICATE = 'signCertificate',
   SIMULATOR_STATE = 'simulatorState',
   START_AUTOMATIC_TRANSACTION_GENERATOR = 'startAutomaticTransactionGenerator',
   START_CHARGING_STATION = 'startChargingStation',
@@ -38,6 +45,7 @@ export enum ProcedureName {
   STOP_CHARGING_STATION = 'stopChargingStation',
   STOP_SIMULATOR = 'stopSimulator',
   STOP_TRANSACTION = 'stopTransaction',
+  TRANSACTION_EVENT = 'transactionEvent',
 }
 
 export enum Protocol {

--- a/src/types/WorkerBroadcastChannel.ts
+++ b/src/types/WorkerBroadcastChannel.ts
@@ -1,4 +1,4 @@
-import type { JsonObject } from './JsonType.js'
+import type { OCPP20IdTokenType, OCPP20TransactionType } from './ocpp/2.0/Transaction.js'
 import type { RequestPayload, ResponsePayload } from './UIProtocol.js'
 import type { UUIDv4 } from './UUID.js'
 
@@ -41,9 +41,9 @@ export interface BroadcastChannelRequestPayload extends RequestPayload {
   connectorId?: number
   eventType?: string
   evseId?: number
-  idToken?: JsonObject
-  transactionData?: JsonObject
+  idToken?: OCPP20IdTokenType
   transactionId?: number
+  transactionInfo?: OCPP20TransactionType
 }
 
 export type BroadcastChannelResponse = [UUIDv4, BroadcastChannelResponsePayload]

--- a/src/types/WorkerBroadcastChannel.ts
+++ b/src/types/WorkerBroadcastChannel.ts
@@ -1,3 +1,4 @@
+import type { JsonObject } from './JsonType.js'
 import type { RequestPayload, ResponsePayload } from './UIProtocol.js'
 import type { UUIDv4 } from './UUID.js'
 
@@ -9,10 +10,17 @@ export enum BroadcastChannelProcedureName {
   DELETE_CHARGING_STATIONS = 'deleteChargingStations',
   DIAGNOSTICS_STATUS_NOTIFICATION = 'diagnosticsStatusNotification',
   FIRMWARE_STATUS_NOTIFICATION = 'firmwareStatusNotification',
+  GET_15118_EV_CERTIFICATE = 'get15118EVCertificate',
+  GET_CERTIFICATE_STATUS = 'getCertificateStatus',
   HEARTBEAT = 'heartbeat',
+  LOG_STATUS_NOTIFICATION = 'logStatusNotification',
   METER_VALUES = 'meterValues',
+  NOTIFY_CUSTOMER_INFORMATION = 'notifyCustomerInformation',
+  NOTIFY_REPORT = 'notifyReport',
   OPEN_CONNECTION = 'openConnection',
+  SECURITY_EVENT_NOTIFICATION = 'securityEventNotification',
   SET_SUPERVISION_URL = 'setSupervisionUrl',
+  SIGN_CERTIFICATE = 'signCertificate',
   START_AUTOMATIC_TRANSACTION_GENERATOR = 'startAutomaticTransactionGenerator',
   START_CHARGING_STATION = 'startChargingStation',
   START_TRANSACTION = 'startTransaction',
@@ -20,6 +28,7 @@ export enum BroadcastChannelProcedureName {
   STOP_AUTOMATIC_TRANSACTION_GENERATOR = 'stopAutomaticTransactionGenerator',
   STOP_CHARGING_STATION = 'stopChargingStation',
   STOP_TRANSACTION = 'stopTransaction',
+  TRANSACTION_EVENT = 'transactionEvent',
 }
 
 export type BroadcastChannelRequest = [
@@ -30,6 +39,10 @@ export type BroadcastChannelRequest = [
 
 export interface BroadcastChannelRequestPayload extends RequestPayload {
   connectorId?: number
+  eventType?: string
+  evseId?: number
+  idToken?: JsonObject
+  transactionData?: JsonObject
   transactionId?: number
 }
 

--- a/src/types/WorkerBroadcastChannel.ts
+++ b/src/types/WorkerBroadcastChannel.ts
@@ -1,4 +1,3 @@
-import type { OCPP20IdTokenType, OCPP20TransactionType } from './ocpp/2.0/Transaction.js'
 import type { RequestPayload, ResponsePayload } from './UIProtocol.js'
 import type { UUIDv4 } from './UUID.js'
 
@@ -39,11 +38,7 @@ export type BroadcastChannelRequest = [
 
 export interface BroadcastChannelRequestPayload extends RequestPayload {
   connectorId?: number
-  eventType?: string
-  evseId?: number
-  idToken?: OCPP20IdTokenType
   transactionId?: number
-  transactionInfo?: OCPP20TransactionType
 }
 
 export type BroadcastChannelResponse = [UUIDv4, BroadcastChannelResponsePayload]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -264,6 +264,7 @@ export type {
 } from './ocpp/2.0/Responses.js'
 export {
   type ComponentType,
+  OCPP20AuthorizationStatusEnumType,
   OCPP20ChargingProfileKindEnumType,
   OCPP20ChargingProfilePurposeEnumType,
   type OCPP20ChargingProfileType,

--- a/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
+++ b/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
@@ -2,10 +2,11 @@
  * @file Tests for ChargingStationWorkerBroadcastChannel
  * @description Verifies OCPP 2.0.1 UIService pipeline integration: enums, mappings,
  * response status logic, payload building, and handler routing for the 8 new broadcast
- * channel procedures. 53 tests across 6 groups.
+ * channel procedures. 59 tests across 7 groups.
  */
 
 import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
 import { afterEach, describe, it } from 'node:test'
 
 import { ChargingStationWorkerBroadcastChannel } from '../../../src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.js'
@@ -53,11 +54,16 @@ interface TestableAbstractUIService {
 }
 
 interface TestableWorkerBroadcastChannel {
+  commandHandler: (
+    command: BroadcastChannelProcedureName,
+    requestPayload: BroadcastChannelRequestPayload
+  ) => Promise<unknown>
   commandHandlers: Map<BroadcastChannelProcedureName, CommandHandler>
   commandResponseToResponseStatus: (
     command: BroadcastChannelProcedureName,
     commandResponse: unknown
   ) => ResponseStatus
+  requestHandler: (messageEvent: { data: unknown }) => void
 }
 
 /**
@@ -70,8 +76,10 @@ function createTestableWorkerBroadcastChannel (
 ): TestableWorkerBroadcastChannel {
   const testable = instance as unknown as TestableWorkerBroadcastChannel
   return {
+    commandHandler: testable.commandHandler.bind(instance),
     commandHandlers: testable.commandHandlers,
     commandResponseToResponseStatus: testable.commandResponseToResponseStatus.bind(instance),
+    requestHandler: testable.requestHandler.bind(instance),
   }
 }
 
@@ -676,130 +684,242 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
   })
 
   // ==========================================================================
-  // Group 6: commandHandlers behavioral — verify requestHandler invocation (8 tests)
+  // Group 6: commandHandler dispatch pipeline — verify full dispatch (8 tests)
   // ==========================================================================
 
-  await describe('commandHandlers OCPP 2.0.1 behavioral', async () => {
-    await it('should invoke requestHandler with GET_15118_EV_CERTIFICATE command', async () => {
+  await describe('commandHandler OCPP 2.0.1 dispatch pipeline', async () => {
+    await it('should dispatch GET_15118_EV_CERTIFICATE through commandHandler', async () => {
       const { sentRequests, station } = createMockStationWithRequestTracking()
 
       instance = new ChargingStationWorkerBroadcastChannel(station)
       const testable = createTestableWorkerBroadcastChannel(instance)
 
-      const handler = testable.commandHandlers.get(
-        BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE
-      )
-      assert.ok(handler != null)
-      await handler({})
+      await testable.commandHandler(BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE, {})
 
       assert.strictEqual(sentRequests.length, 1)
       assert.strictEqual(sentRequests[0].command, RequestCommand.GET_15118_EV_CERTIFICATE)
     })
 
-    await it('should invoke requestHandler with GET_CERTIFICATE_STATUS command', async () => {
+    await it('should dispatch GET_CERTIFICATE_STATUS through commandHandler', async () => {
       const { sentRequests, station } = createMockStationWithRequestTracking()
 
       instance = new ChargingStationWorkerBroadcastChannel(station)
       const testable = createTestableWorkerBroadcastChannel(instance)
 
-      const handler = testable.commandHandlers.get(
-        BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS
-      )
-      assert.ok(handler != null)
-      await handler({})
+      await testable.commandHandler(BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS, {})
 
       assert.strictEqual(sentRequests.length, 1)
       assert.strictEqual(sentRequests[0].command, RequestCommand.GET_CERTIFICATE_STATUS)
     })
 
-    await it('should invoke requestHandler with LOG_STATUS_NOTIFICATION command', async () => {
+    await it('should dispatch LOG_STATUS_NOTIFICATION through commandHandler', async () => {
       const { sentRequests, station } = createMockStationWithRequestTracking()
 
       instance = new ChargingStationWorkerBroadcastChannel(station)
       const testable = createTestableWorkerBroadcastChannel(instance)
 
-      const handler = testable.commandHandlers.get(
-        BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION
-      )
-      assert.ok(handler != null)
-      await handler({})
+      await testable.commandHandler(BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION, {})
 
       assert.strictEqual(sentRequests.length, 1)
       assert.strictEqual(sentRequests[0].command, RequestCommand.LOG_STATUS_NOTIFICATION)
     })
 
-    await it('should invoke requestHandler with NOTIFY_CUSTOMER_INFORMATION command', async () => {
+    await it('should dispatch NOTIFY_CUSTOMER_INFORMATION through commandHandler', async () => {
       const { sentRequests, station } = createMockStationWithRequestTracking()
 
       instance = new ChargingStationWorkerBroadcastChannel(station)
       const testable = createTestableWorkerBroadcastChannel(instance)
 
-      const handler = testable.commandHandlers.get(
-        BroadcastChannelProcedureName.NOTIFY_CUSTOMER_INFORMATION
-      )
-      assert.ok(handler != null)
-      await handler({})
+      await testable.commandHandler(BroadcastChannelProcedureName.NOTIFY_CUSTOMER_INFORMATION, {})
 
       assert.strictEqual(sentRequests.length, 1)
       assert.strictEqual(sentRequests[0].command, RequestCommand.NOTIFY_CUSTOMER_INFORMATION)
     })
 
-    await it('should invoke requestHandler with NOTIFY_REPORT command', async () => {
+    await it('should dispatch NOTIFY_REPORT through commandHandler', async () => {
       const { sentRequests, station } = createMockStationWithRequestTracking()
 
       instance = new ChargingStationWorkerBroadcastChannel(station)
       const testable = createTestableWorkerBroadcastChannel(instance)
 
-      const handler = testable.commandHandlers.get(BroadcastChannelProcedureName.NOTIFY_REPORT)
-      assert.ok(handler != null)
-      await handler({})
+      await testable.commandHandler(BroadcastChannelProcedureName.NOTIFY_REPORT, {})
 
       assert.strictEqual(sentRequests.length, 1)
       assert.strictEqual(sentRequests[0].command, RequestCommand.NOTIFY_REPORT)
     })
 
-    await it('should invoke requestHandler with SECURITY_EVENT_NOTIFICATION command', async () => {
+    await it('should dispatch SECURITY_EVENT_NOTIFICATION through commandHandler', async () => {
       const { sentRequests, station } = createMockStationWithRequestTracking()
 
       instance = new ChargingStationWorkerBroadcastChannel(station)
       const testable = createTestableWorkerBroadcastChannel(instance)
 
-      const handler = testable.commandHandlers.get(
-        BroadcastChannelProcedureName.SECURITY_EVENT_NOTIFICATION
-      )
-      assert.ok(handler != null)
-      await handler({})
+      await testable.commandHandler(BroadcastChannelProcedureName.SECURITY_EVENT_NOTIFICATION, {})
 
       assert.strictEqual(sentRequests.length, 1)
       assert.strictEqual(sentRequests[0].command, RequestCommand.SECURITY_EVENT_NOTIFICATION)
     })
 
-    await it('should invoke requestHandler with SIGN_CERTIFICATE command', async () => {
+    await it('should dispatch SIGN_CERTIFICATE through commandHandler', async () => {
       const { sentRequests, station } = createMockStationWithRequestTracking()
 
       instance = new ChargingStationWorkerBroadcastChannel(station)
       const testable = createTestableWorkerBroadcastChannel(instance)
 
-      const handler = testable.commandHandlers.get(BroadcastChannelProcedureName.SIGN_CERTIFICATE)
-      assert.ok(handler != null)
-      await handler({})
+      await testable.commandHandler(BroadcastChannelProcedureName.SIGN_CERTIFICATE, {})
 
       assert.strictEqual(sentRequests.length, 1)
       assert.strictEqual(sentRequests[0].command, RequestCommand.SIGN_CERTIFICATE)
     })
 
-    await it('should invoke requestHandler with TRANSACTION_EVENT command', async () => {
+    await it('should dispatch TRANSACTION_EVENT through commandHandler', async () => {
       const { sentRequests, station } = createMockStationWithRequestTracking()
 
       instance = new ChargingStationWorkerBroadcastChannel(station)
       const testable = createTestableWorkerBroadcastChannel(instance)
 
-      const handler = testable.commandHandlers.get(BroadcastChannelProcedureName.TRANSACTION_EVENT)
-      assert.ok(handler != null)
-      await handler({})
+      await testable.commandHandler(BroadcastChannelProcedureName.TRANSACTION_EVENT, {})
 
       assert.strictEqual(sentRequests.length, 1)
       assert.strictEqual(sentRequests[0].command, RequestCommand.TRANSACTION_EVENT)
+    })
+  })
+
+  // ==========================================================================
+  // Group 7: requestHandler full pipeline — exercise handler dispatch via message events (6 tests)
+  // ==========================================================================
+
+  await describe('requestHandler full pipeline OCPP 2.0.1', async () => {
+    await it('should dispatch GET_15118_EV_CERTIFICATE via requestHandler', async () => {
+      const { sentRequests, station } = createMockStationWithRequestTracking()
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      testable.requestHandler({
+        data: [
+          randomUUID(),
+          BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE,
+          { hashIds: [station.stationInfo?.hashId] },
+        ],
+      })
+
+      await new Promise(resolve => {
+        setTimeout(resolve, 50)
+      })
+
+      assert.strictEqual(sentRequests.length, 1)
+      assert.strictEqual(sentRequests[0].command, RequestCommand.GET_15118_EV_CERTIFICATE)
+    })
+
+    await it('should dispatch LOG_STATUS_NOTIFICATION via requestHandler', async () => {
+      const { sentRequests, station } = createMockStationWithRequestTracking()
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      testable.requestHandler({
+        data: [
+          randomUUID(),
+          BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION,
+          { hashIds: [station.stationInfo?.hashId] },
+        ],
+      })
+
+      await new Promise(resolve => {
+        setTimeout(resolve, 50)
+      })
+
+      assert.strictEqual(sentRequests.length, 1)
+      assert.strictEqual(sentRequests[0].command, RequestCommand.LOG_STATUS_NOTIFICATION)
+    })
+
+    await it('should dispatch NOTIFY_CUSTOMER_INFORMATION via requestHandler', async () => {
+      const { sentRequests, station } = createMockStationWithRequestTracking()
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      testable.requestHandler({
+        data: [
+          randomUUID(),
+          BroadcastChannelProcedureName.NOTIFY_CUSTOMER_INFORMATION,
+          { hashIds: [station.stationInfo?.hashId] },
+        ],
+      })
+
+      await new Promise(resolve => {
+        setTimeout(resolve, 50)
+      })
+
+      assert.strictEqual(sentRequests.length, 1)
+      assert.strictEqual(sentRequests[0].command, RequestCommand.NOTIFY_CUSTOMER_INFORMATION)
+    })
+
+    await it('should dispatch NOTIFY_REPORT via requestHandler', async () => {
+      const { sentRequests, station } = createMockStationWithRequestTracking()
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      testable.requestHandler({
+        data: [
+          randomUUID(),
+          BroadcastChannelProcedureName.NOTIFY_REPORT,
+          { hashIds: [station.stationInfo?.hashId] },
+        ],
+      })
+
+      await new Promise(resolve => {
+        setTimeout(resolve, 50)
+      })
+
+      assert.strictEqual(sentRequests.length, 1)
+      assert.strictEqual(sentRequests[0].command, RequestCommand.NOTIFY_REPORT)
+    })
+
+    await it('should dispatch SECURITY_EVENT_NOTIFICATION via requestHandler', async () => {
+      const { sentRequests, station } = createMockStationWithRequestTracking()
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      testable.requestHandler({
+        data: [
+          randomUUID(),
+          BroadcastChannelProcedureName.SECURITY_EVENT_NOTIFICATION,
+          { hashIds: [station.stationInfo?.hashId] },
+        ],
+      })
+
+      await new Promise(resolve => {
+        setTimeout(resolve, 50)
+      })
+
+      assert.strictEqual(sentRequests.length, 1)
+      assert.strictEqual(sentRequests[0].command, RequestCommand.SECURITY_EVENT_NOTIFICATION)
+    })
+
+    await it('should dispatch METER_VALUES for OCPP 2.0.1 via requestHandler', async () => {
+      const { sentRequests, station } = createMockStationWithRequestTracking()
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      testable.requestHandler({
+        data: [
+          randomUUID(),
+          BroadcastChannelProcedureName.METER_VALUES,
+          { hashIds: [station.stationInfo?.hashId] },
+        ],
+      })
+
+      await new Promise(resolve => {
+        setTimeout(resolve, 50)
+      })
+
+      assert.strictEqual(sentRequests.length, 1)
+      assert.strictEqual(sentRequests[0].command, RequestCommand.METER_VALUES)
     })
   })
 })

--- a/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
+++ b/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
@@ -1,0 +1,627 @@
+/**
+ * @file Tests for ChargingStationWorkerBroadcastChannel
+ * @description Verifies OCPP 2.0.1 UIService pipeline integration: enums, mappings,
+ * command handlers, and response status logic for the 8 new broadcast channel procedures.
+ */
+
+import assert from 'node:assert/strict'
+import { afterEach, describe, it } from 'node:test'
+
+import { ChargingStationWorkerBroadcastChannel } from '../../../src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.js'
+import { AbstractUIService } from '../../../src/charging-station/ui-server/ui-services/AbstractUIService.js'
+import {
+  BroadcastChannelProcedureName,
+  type BroadcastChannelRequestPayload,
+  GenericStatus,
+  GetCertificateStatusEnumType,
+  Iso15118EVCertificateStatusEnumType,
+  OCPPVersion,
+  ProcedureName,
+  ResponseStatus,
+} from '../../../src/types/index.js'
+import { OCPP20AuthorizationStatusEnumType } from '../../../src/types/ocpp/2.0/Transaction.js'
+import { Constants } from '../../../src/utils/index.js'
+import { standardCleanup } from '../../helpers/TestLifecycleHelpers.js'
+import { createMockChargingStation } from '../ChargingStationTestUtils.js'
+
+// ============================================================================
+// Testable Interfaces
+// ============================================================================
+// Type-safe access to private/protected members for testing, following the
+// pattern from OCPP20TestUtils.ts to avoid `as any` casts.
+// ============================================================================
+
+/**
+ * Interface exposing private members of ChargingStationWorkerBroadcastChannel for testing.
+ */
+interface TestableWorkerBroadcastChannel {
+  commandHandlers: Map<BroadcastChannelProcedureName, unknown>
+  commandResponseToResponseStatus: (
+    command: BroadcastChannelProcedureName,
+    commandResponse: unknown
+  ) => ResponseStatus
+}
+
+/**
+ * Interface exposing protected static members of AbstractUIService for testing.
+ */
+interface TestableAbstractUIService {
+  ProcedureNameToBroadCastChannelProcedureNameMapping: Map<
+    ProcedureName,
+    BroadcastChannelProcedureName
+  >
+}
+
+/**
+ * Create a testable wrapper for ChargingStationWorkerBroadcastChannel.
+ * @param instance - The instance to wrap
+ * @returns Testable interface with access to private members
+ */
+function createTestableWorkerBroadcastChannel (
+  instance: ChargingStationWorkerBroadcastChannel
+): TestableWorkerBroadcastChannel {
+  const testable = instance as unknown as TestableWorkerBroadcastChannel
+  return {
+    commandHandlers: testable.commandHandlers,
+    commandResponseToResponseStatus: testable.commandResponseToResponseStatus.bind(instance),
+  }
+}
+
+/**
+ * Get the protected static ProcedureNameToBroadCastChannelProcedureNameMapping.
+ * @returns The mapping from ProcedureName to BroadcastChannelProcedureName
+ */
+function getProcedureNameMapping (): Map<ProcedureName, BroadcastChannelProcedureName> {
+  return (AbstractUIService as unknown as TestableAbstractUIService)
+    .ProcedureNameToBroadCastChannelProcedureNameMapping
+}
+
+await describe('ChargingStationWorkerBroadcastChannel', async () => {
+  let instance: ChargingStationWorkerBroadcastChannel | undefined
+
+  afterEach(() => {
+    if (instance != null) {
+      instance.close()
+      instance = undefined
+    }
+    standardCleanup()
+  })
+
+  // ==========================================================================
+  // Group 1: ProcedureName enum — 8 new OCPP 2.0.1 entries
+  // ==========================================================================
+
+  await describe('ProcedureName enum OCPP 2.0.1 entries', async () => {
+    await it('should have GET_15118_EV_CERTIFICATE in ProcedureName enum', () => {
+      assert.strictEqual(ProcedureName.GET_15118_EV_CERTIFICATE, 'get15118EVCertificate')
+    })
+
+    await it('should have GET_CERTIFICATE_STATUS in ProcedureName enum', () => {
+      assert.strictEqual(ProcedureName.GET_CERTIFICATE_STATUS, 'getCertificateStatus')
+    })
+
+    await it('should have LOG_STATUS_NOTIFICATION in ProcedureName enum', () => {
+      assert.strictEqual(ProcedureName.LOG_STATUS_NOTIFICATION, 'logStatusNotification')
+    })
+
+    await it('should have NOTIFY_CUSTOMER_INFORMATION in ProcedureName enum', () => {
+      assert.strictEqual(
+        ProcedureName.NOTIFY_CUSTOMER_INFORMATION,
+        'notifyCustomerInformation'
+      )
+    })
+
+    await it('should have NOTIFY_REPORT in ProcedureName enum', () => {
+      assert.strictEqual(ProcedureName.NOTIFY_REPORT, 'notifyReport')
+    })
+
+    await it('should have SECURITY_EVENT_NOTIFICATION in ProcedureName enum', () => {
+      assert.strictEqual(
+        ProcedureName.SECURITY_EVENT_NOTIFICATION,
+        'securityEventNotification'
+      )
+    })
+
+    await it('should have SIGN_CERTIFICATE in ProcedureName enum', () => {
+      assert.strictEqual(ProcedureName.SIGN_CERTIFICATE, 'signCertificate')
+    })
+
+    await it('should have TRANSACTION_EVENT in ProcedureName enum', () => {
+      assert.strictEqual(ProcedureName.TRANSACTION_EVENT, 'transactionEvent')
+    })
+  })
+
+  // ==========================================================================
+  // Group 2: BroadcastChannelProcedureName enum — 8 new OCPP 2.0.1 entries
+  // ==========================================================================
+
+  await describe('BroadcastChannelProcedureName enum OCPP 2.0.1 entries', async () => {
+    await it('should have GET_15118_EV_CERTIFICATE in BroadcastChannelProcedureName enum', () => {
+      assert.strictEqual(
+        BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE,
+        'get15118EVCertificate'
+      )
+    })
+
+    await it('should have GET_CERTIFICATE_STATUS in BroadcastChannelProcedureName enum', () => {
+      assert.strictEqual(
+        BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS,
+        'getCertificateStatus'
+      )
+    })
+
+    await it('should have LOG_STATUS_NOTIFICATION in BroadcastChannelProcedureName enum', () => {
+      assert.strictEqual(
+        BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION,
+        'logStatusNotification'
+      )
+    })
+
+    await it('should have NOTIFY_CUSTOMER_INFORMATION in BroadcastChannelProcedureName enum', () => {
+      assert.strictEqual(
+        BroadcastChannelProcedureName.NOTIFY_CUSTOMER_INFORMATION,
+        'notifyCustomerInformation'
+      )
+    })
+
+    await it('should have NOTIFY_REPORT in BroadcastChannelProcedureName enum', () => {
+      assert.strictEqual(BroadcastChannelProcedureName.NOTIFY_REPORT, 'notifyReport')
+    })
+
+    await it('should have SECURITY_EVENT_NOTIFICATION in BroadcastChannelProcedureName enum', () => {
+      assert.strictEqual(
+        BroadcastChannelProcedureName.SECURITY_EVENT_NOTIFICATION,
+        'securityEventNotification'
+      )
+    })
+
+    await it('should have SIGN_CERTIFICATE in BroadcastChannelProcedureName enum', () => {
+      assert.strictEqual(BroadcastChannelProcedureName.SIGN_CERTIFICATE, 'signCertificate')
+    })
+
+    await it('should have TRANSACTION_EVENT in BroadcastChannelProcedureName enum', () => {
+      assert.strictEqual(
+        BroadcastChannelProcedureName.TRANSACTION_EVENT,
+        'transactionEvent'
+      )
+    })
+  })
+
+  // ==========================================================================
+  // Group 3: ProcedureNameToBroadCastChannelProcedureNameMapping — 8 new entries
+  // ==========================================================================
+
+  await describe('ProcedureNameToBroadCastChannelProcedureNameMapping OCPP 2.0.1 entries', async () => {
+    await it('should map GET_15118_EV_CERTIFICATE procedure to broadcast channel procedure', () => {
+      const mapping = getProcedureNameMapping()
+      assert.strictEqual(
+        mapping.get(ProcedureName.GET_15118_EV_CERTIFICATE),
+        BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE
+      )
+    })
+
+    await it('should map GET_CERTIFICATE_STATUS procedure to broadcast channel procedure', () => {
+      const mapping = getProcedureNameMapping()
+      assert.strictEqual(
+        mapping.get(ProcedureName.GET_CERTIFICATE_STATUS),
+        BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS
+      )
+    })
+
+    await it('should map LOG_STATUS_NOTIFICATION procedure to broadcast channel procedure', () => {
+      const mapping = getProcedureNameMapping()
+      assert.strictEqual(
+        mapping.get(ProcedureName.LOG_STATUS_NOTIFICATION),
+        BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION
+      )
+    })
+
+    await it('should map NOTIFY_CUSTOMER_INFORMATION procedure to broadcast channel procedure', () => {
+      const mapping = getProcedureNameMapping()
+      assert.strictEqual(
+        mapping.get(ProcedureName.NOTIFY_CUSTOMER_INFORMATION),
+        BroadcastChannelProcedureName.NOTIFY_CUSTOMER_INFORMATION
+      )
+    })
+
+    await it('should map NOTIFY_REPORT procedure to broadcast channel procedure', () => {
+      const mapping = getProcedureNameMapping()
+      assert.strictEqual(
+        mapping.get(ProcedureName.NOTIFY_REPORT),
+        BroadcastChannelProcedureName.NOTIFY_REPORT
+      )
+    })
+
+    await it('should map SECURITY_EVENT_NOTIFICATION procedure to broadcast channel procedure', () => {
+      const mapping = getProcedureNameMapping()
+      assert.strictEqual(
+        mapping.get(ProcedureName.SECURITY_EVENT_NOTIFICATION),
+        BroadcastChannelProcedureName.SECURITY_EVENT_NOTIFICATION
+      )
+    })
+
+    await it('should map SIGN_CERTIFICATE procedure to broadcast channel procedure', () => {
+      const mapping = getProcedureNameMapping()
+      assert.strictEqual(
+        mapping.get(ProcedureName.SIGN_CERTIFICATE),
+        BroadcastChannelProcedureName.SIGN_CERTIFICATE
+      )
+    })
+
+    await it('should map TRANSACTION_EVENT procedure to broadcast channel procedure', () => {
+      const mapping = getProcedureNameMapping()
+      assert.strictEqual(
+        mapping.get(ProcedureName.TRANSACTION_EVENT),
+        BroadcastChannelProcedureName.TRANSACTION_EVENT
+      )
+    })
+  })
+
+  // ==========================================================================
+  // Group 4: BroadcastChannelRequestPayload — OCPP 2.0.1 optional fields
+  // ==========================================================================
+
+  await describe('BroadcastChannelRequestPayload OCPP 2.0.1 fields', async () => {
+    await it('should accept optional OCPP 2.0.1 fields in BroadcastChannelRequestPayload', () => {
+      // Type-level test: verify the interface accepts OCPP 2.0.1 fields
+      const payload: BroadcastChannelRequestPayload = {
+        eventType: 'Started',
+        evseId: 1,
+        idToken: { idToken: 'test', type: 'Central' },
+        transactionData: { transactionId: 'uuid-123' },
+      }
+
+      assert.strictEqual(payload.evseId, 1)
+      assert.strictEqual(payload.eventType, 'Started')
+    })
+
+    await it('should accept BroadcastChannelRequestPayload with only evseId', () => {
+      const payload: BroadcastChannelRequestPayload = {
+        evseId: 2,
+      }
+
+      assert.strictEqual(payload.evseId, 2)
+    })
+
+    await it('should accept BroadcastChannelRequestPayload with idToken object', () => {
+      const payload: BroadcastChannelRequestPayload = {
+        idToken: { idToken: 'RFID_TOKEN_001', type: 'ISO14443' },
+      }
+
+      assert.deepStrictEqual(payload.idToken, {
+        idToken: 'RFID_TOKEN_001',
+        type: 'ISO14443',
+      })
+    })
+  })
+
+  // ==========================================================================
+  // Group 5: commandResponseToResponseStatus — 4 new command response cases
+  // ==========================================================================
+
+  await describe('commandResponseToResponseStatus OCPP 2.0.1 commands', async () => {
+    // -- SIGN_CERTIFICATE --
+
+    await it('should return SUCCESS for SIGN_CERTIFICATE with Accepted status', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.SIGN_CERTIFICATE,
+        { status: GenericStatus.Accepted }
+      )
+
+      assert.strictEqual(status, ResponseStatus.SUCCESS)
+    })
+
+    await it('should return FAILURE for SIGN_CERTIFICATE with Rejected status', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.SIGN_CERTIFICATE,
+        { status: GenericStatus.Rejected }
+      )
+
+      assert.strictEqual(status, ResponseStatus.FAILURE)
+    })
+
+    // -- GET_15118_EV_CERTIFICATE --
+
+    await it('should return SUCCESS for GET_15118_EV_CERTIFICATE with Accepted status', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE,
+        { exiResponse: 'base64data', status: Iso15118EVCertificateStatusEnumType.Accepted }
+      )
+
+      assert.strictEqual(status, ResponseStatus.SUCCESS)
+    })
+
+    await it('should return FAILURE for GET_15118_EV_CERTIFICATE with Failed status', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE,
+        { exiResponse: 'base64data', status: Iso15118EVCertificateStatusEnumType.Failed }
+      )
+
+      assert.strictEqual(status, ResponseStatus.FAILURE)
+    })
+
+    // -- GET_CERTIFICATE_STATUS --
+
+    await it('should return SUCCESS for GET_CERTIFICATE_STATUS with Accepted status', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS,
+        { status: GetCertificateStatusEnumType.Accepted }
+      )
+
+      assert.strictEqual(status, ResponseStatus.SUCCESS)
+    })
+
+    await it('should return FAILURE for GET_CERTIFICATE_STATUS with Failed status', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS,
+        { status: GetCertificateStatusEnumType.Failed }
+      )
+
+      assert.strictEqual(status, ResponseStatus.FAILURE)
+    })
+
+    // -- TRANSACTION_EVENT --
+
+    await it('should return SUCCESS for TRANSACTION_EVENT with empty response', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      // isEmpty({}) returns true → SUCCESS
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.TRANSACTION_EVENT,
+        {}
+      )
+
+      assert.strictEqual(status, ResponseStatus.SUCCESS)
+    })
+
+    await it('should return SUCCESS for TRANSACTION_EVENT with no idTokenInfo', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      // idTokenInfo == null → SUCCESS
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.TRANSACTION_EVENT,
+        { chargingPriority: 1 }
+      )
+
+      assert.strictEqual(status, ResponseStatus.SUCCESS)
+    })
+
+    await it('should return SUCCESS for TRANSACTION_EVENT with Accepted idTokenInfo', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.TRANSACTION_EVENT,
+        { idTokenInfo: { status: OCPP20AuthorizationStatusEnumType.Accepted } }
+      )
+
+      assert.strictEqual(status, ResponseStatus.SUCCESS)
+    })
+
+    await it('should return FAILURE for TRANSACTION_EVENT with Blocked idTokenInfo', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.TRANSACTION_EVENT,
+        { idTokenInfo: { status: OCPP20AuthorizationStatusEnumType.Blocked } }
+      )
+
+      assert.strictEqual(status, ResponseStatus.FAILURE)
+    })
+  })
+
+  // ==========================================================================
+  // Group 6: commandHandlers Map — 8 new entries registered
+  // ==========================================================================
+
+  await describe('commandHandlers OCPP 2.0.1 entries', async () => {
+    await it('should have GET_15118_EV_CERTIFICATE command handler registered', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      assert.ok(testable.commandHandlers.has(BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE))
+    })
+
+    await it('should have GET_CERTIFICATE_STATUS command handler registered', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      assert.ok(testable.commandHandlers.has(BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS))
+    })
+
+    await it('should have LOG_STATUS_NOTIFICATION command handler registered', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      assert.ok(
+        testable.commandHandlers.has(BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION)
+      )
+    })
+
+    await it('should have NOTIFY_CUSTOMER_INFORMATION command handler registered', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      assert.ok(
+        testable.commandHandlers.has(BroadcastChannelProcedureName.NOTIFY_CUSTOMER_INFORMATION)
+      )
+    })
+
+    await it('should have NOTIFY_REPORT command handler registered', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      assert.ok(testable.commandHandlers.has(BroadcastChannelProcedureName.NOTIFY_REPORT))
+    })
+
+    await it('should have SECURITY_EVENT_NOTIFICATION command handler registered', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      assert.ok(
+        testable.commandHandlers.has(BroadcastChannelProcedureName.SECURITY_EVENT_NOTIFICATION)
+      )
+    })
+
+    await it('should have SIGN_CERTIFICATE command handler registered', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      assert.ok(testable.commandHandlers.has(BroadcastChannelProcedureName.SIGN_CERTIFICATE))
+    })
+
+    await it('should have TRANSACTION_EVENT command handler registered', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      assert.ok(testable.commandHandlers.has(BroadcastChannelProcedureName.TRANSACTION_EVENT))
+    })
+  })
+})

--- a/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
+++ b/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
@@ -922,4 +922,58 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
       assert.strictEqual(sentRequests[0].command, RequestCommand.METER_VALUES)
     })
   })
+
+  await describe('mapping completeness', async () => {
+    const allProcedureNames = new Set(Object.values(ProcedureName))
+    const allBroadcastNames = new Set(Object.values(BroadcastChannelProcedureName))
+    const UI_ONLY_PROCEDURE_NAMES = new Set<string>([
+      ProcedureName.ADD_CHARGING_STATIONS,
+      ProcedureName.LIST_CHARGING_STATIONS,
+      ProcedureName.LIST_TEMPLATES,
+      ProcedureName.PERFORMANCE_STATISTICS,
+      ProcedureName.SIMULATOR_STATE,
+      ProcedureName.START_SIMULATOR,
+      ProcedureName.STOP_SIMULATOR,
+    ])
+
+    await it('should have a matching ProcedureName for every BroadcastChannelProcedureName', () => {
+      const missing = [...allBroadcastNames].filter(
+        name => !allProcedureNames.has(name as unknown as ProcedureName)
+      )
+      assert.deepStrictEqual(missing, [])
+    })
+
+    await it('should have a matching BroadcastChannelProcedureName for every non-UI-only ProcedureName', () => {
+      const missing = [...allProcedureNames].filter(
+        name =>
+          !UI_ONLY_PROCEDURE_NAMES.has(name) &&
+          !allBroadcastNames.has(name as unknown as BroadcastChannelProcedureName)
+      )
+      assert.deepStrictEqual(missing, [])
+    })
+
+    await it('should not have any ProcedureName classified as both UI-only and broadcast-capable', () => {
+      const overlap = [...UI_ONLY_PROCEDURE_NAMES].filter(name =>
+        allBroadcastNames.has(name as unknown as BroadcastChannelProcedureName)
+      )
+      assert.deepStrictEqual(overlap, [])
+    })
+
+    await it('should have a ProcedureNameToBroadCastChannelProcedureNameMapping entry for every BroadcastChannelProcedureName', () => {
+      const mapping = getProcedureNameMapping()
+      const mappedBroadcastNames = new Set(mapping.values())
+      const missing = [...allBroadcastNames].filter(name => !mappedBroadcastNames.has(name))
+      assert.deepStrictEqual(missing, [])
+    })
+
+    await it('should have a commandHandler for every BroadcastChannelProcedureName', () => {
+      const { station } = createMockChargingStation()
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+      const missing = [...allBroadcastNames].filter(
+        name => !testable.commandHandlers.has(name)
+      )
+      assert.deepStrictEqual(missing, [])
+    })
+  })
 })

--- a/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
+++ b/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
@@ -105,10 +105,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
     })
 
     await it('should have NOTIFY_CUSTOMER_INFORMATION in ProcedureName enum', () => {
-      assert.strictEqual(
-        ProcedureName.NOTIFY_CUSTOMER_INFORMATION,
-        'notifyCustomerInformation'
-      )
+      assert.strictEqual(ProcedureName.NOTIFY_CUSTOMER_INFORMATION, 'notifyCustomerInformation')
     })
 
     await it('should have NOTIFY_REPORT in ProcedureName enum', () => {
@@ -116,10 +113,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
     })
 
     await it('should have SECURITY_EVENT_NOTIFICATION in ProcedureName enum', () => {
-      assert.strictEqual(
-        ProcedureName.SECURITY_EVENT_NOTIFICATION,
-        'securityEventNotification'
-      )
+      assert.strictEqual(ProcedureName.SECURITY_EVENT_NOTIFICATION, 'securityEventNotification')
     })
 
     await it('should have SIGN_CERTIFICATE in ProcedureName enum', () => {
@@ -180,10 +174,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
     })
 
     await it('should have TRANSACTION_EVENT in BroadcastChannelProcedureName enum', () => {
-      assert.strictEqual(
-        BroadcastChannelProcedureName.TRANSACTION_EVENT,
-        'transactionEvent'
-      )
+      assert.strictEqual(BroadcastChannelProcedureName.TRANSACTION_EVENT, 'transactionEvent')
     })
   })
 
@@ -517,7 +508,9 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
       instance = new ChargingStationWorkerBroadcastChannel(station)
       const testable = createTestableWorkerBroadcastChannel(instance)
 
-      assert.ok(testable.commandHandlers.has(BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE))
+      assert.ok(
+        testable.commandHandlers.has(BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE)
+      )
     })
 
     await it('should have GET_CERTIFICATE_STATUS command handler registered', () => {
@@ -545,9 +538,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
       instance = new ChargingStationWorkerBroadcastChannel(station)
       const testable = createTestableWorkerBroadcastChannel(instance)
 
-      assert.ok(
-        testable.commandHandlers.has(BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION)
-      )
+      assert.ok(testable.commandHandlers.has(BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION))
     })
 
     await it('should have NOTIFY_CUSTOMER_INFORMATION command handler registered', () => {

--- a/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
+++ b/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
@@ -970,9 +970,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
       const { station } = createMockChargingStation()
       instance = new ChargingStationWorkerBroadcastChannel(station)
       const testable = createTestableWorkerBroadcastChannel(instance)
-      const missing = [...allBroadcastNames].filter(
-        name => !testable.commandHandlers.has(name)
-      )
+      const missing = [...allBroadcastNames].filter(name => !testable.commandHandlers.has(name))
       assert.deepStrictEqual(missing, [])
     })
   })

--- a/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
+++ b/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
@@ -37,7 +37,9 @@ import {
 // pattern from OCPP20TestUtils.ts to avoid `as any` casts.
 // ============================================================================
 
-type CommandHandler = (requestPayload?: BroadcastChannelRequestPayload) => Promise<unknown> | undefined
+type CommandHandler = (
+  requestPayload?: BroadcastChannelRequestPayload
+) => Promise<unknown> | undefined
 
 /**
  * Interface exposing protected static members of AbstractUIService for testing.
@@ -755,9 +757,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
       instance = new ChargingStationWorkerBroadcastChannel(station)
       const testable = createTestableWorkerBroadcastChannel(instance)
 
-      const handler = testable.commandHandlers.get(
-        BroadcastChannelProcedureName.NOTIFY_REPORT
-      )
+      const handler = testable.commandHandlers.get(BroadcastChannelProcedureName.NOTIFY_REPORT)
       assert.ok(handler != null)
       await handler({})
 
@@ -787,9 +787,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
       instance = new ChargingStationWorkerBroadcastChannel(station)
       const testable = createTestableWorkerBroadcastChannel(instance)
 
-      const handler = testable.commandHandlers.get(
-        BroadcastChannelProcedureName.SIGN_CERTIFICATE
-      )
+      const handler = testable.commandHandlers.get(BroadcastChannelProcedureName.SIGN_CERTIFICATE)
       assert.ok(handler != null)
       await handler({})
 
@@ -803,9 +801,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
       instance = new ChargingStationWorkerBroadcastChannel(station)
       const testable = createTestableWorkerBroadcastChannel(instance)
 
-      const handler = testable.commandHandlers.get(
-        BroadcastChannelProcedureName.TRANSACTION_EVENT
-      )
+      const handler = testable.commandHandlers.get(BroadcastChannelProcedureName.TRANSACTION_EVENT)
       assert.ok(handler != null)
       await handler({})
 

--- a/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
+++ b/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
@@ -32,6 +32,16 @@ import { createMockChargingStation } from '../ChargingStationTestUtils.js'
 // ============================================================================
 
 /**
+ * Interface exposing protected static members of AbstractUIService for testing.
+ */
+interface TestableAbstractUIService {
+  ProcedureNameToBroadCastChannelProcedureNameMapping: Map<
+    ProcedureName,
+    BroadcastChannelProcedureName
+  >
+}
+
+/**
  * Interface exposing private members of ChargingStationWorkerBroadcastChannel for testing.
  */
 interface TestableWorkerBroadcastChannel {
@@ -40,16 +50,6 @@ interface TestableWorkerBroadcastChannel {
     command: BroadcastChannelProcedureName,
     commandResponse: unknown
   ) => ResponseStatus
-}
-
-/**
- * Interface exposing protected static members of AbstractUIService for testing.
- */
-interface TestableAbstractUIService {
-  ProcedureNameToBroadCastChannelProcedureNameMapping: Map<
-    ProcedureName,
-    BroadcastChannelProcedureName
-  >
 }
 
 /**

--- a/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
+++ b/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
@@ -15,14 +15,20 @@ import {
   GenericStatus,
   GetCertificateStatusEnumType,
   Iso15118EVCertificateStatusEnumType,
+  OCPP20RequestCommand,
   OCPPVersion,
   ProcedureName,
+  RequestCommand,
   ResponseStatus,
 } from '../../../src/types/index.js'
 import { OCPP20AuthorizationStatusEnumType } from '../../../src/types/ocpp/2.0/Transaction.js'
 import { Constants } from '../../../src/utils/index.js'
 import { standardCleanup } from '../../helpers/TestLifecycleHelpers.js'
 import { createMockChargingStation } from '../ChargingStationTestUtils.js'
+import {
+  createMockStationWithRequestTracking,
+  createOCPP20RequestTestContext,
+} from '../ocpp/2.0/OCPP20TestUtils.js'
 
 // ============================================================================
 // Testable Interfaces
@@ -30,6 +36,8 @@ import { createMockChargingStation } from '../ChargingStationTestUtils.js'
 // Type-safe access to private/protected members for testing, following the
 // pattern from OCPP20TestUtils.ts to avoid `as any` casts.
 // ============================================================================
+
+type CommandHandler = (requestPayload?: BroadcastChannelRequestPayload) => Promise<unknown> | undefined
 
 /**
  * Interface exposing protected static members of AbstractUIService for testing.
@@ -41,11 +49,8 @@ interface TestableAbstractUIService {
   >
 }
 
-/**
- * Interface exposing private members of ChargingStationWorkerBroadcastChannel for testing.
- */
 interface TestableWorkerBroadcastChannel {
-  commandHandlers: Map<BroadcastChannelProcedureName, unknown>
+  commandHandlers: Map<BroadcastChannelProcedureName, CommandHandler>
   commandResponseToResponseStatus: (
     command: BroadcastChannelProcedureName,
     commandResponse: unknown
@@ -613,6 +618,199 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
       const testable = createTestableWorkerBroadcastChannel(instance)
 
       assert.ok(testable.commandHandlers.has(BroadcastChannelProcedureName.TRANSACTION_EVENT))
+    })
+  })
+
+  // ==========================================================================
+  // Group 7: buildRequestPayload — OCPP 2.0.1 certificate passthrough
+  // ==========================================================================
+
+  await describe('buildRequestPayload OCPP 2.0.1 certificate passthrough', async () => {
+    await it('should build GET_15118_EV_CERTIFICATE payload as passthrough', () => {
+      const { station, testableRequestService } = createOCPP20RequestTestContext()
+      const commandParams = {
+        action: 'Install',
+        exiRequest: 'base64encodeddata',
+        iso15118SchemaVersion: 'urn:iso:15118:2:2013:MsgDef',
+      }
+
+      const payload = testableRequestService.buildRequestPayload(
+        station,
+        OCPP20RequestCommand.GET_15118_EV_CERTIFICATE,
+        commandParams
+      )
+
+      assert.deepStrictEqual(payload, commandParams)
+    })
+
+    await it('should build GET_CERTIFICATE_STATUS payload as passthrough', () => {
+      const { station, testableRequestService } = createOCPP20RequestTestContext()
+      const commandParams = {
+        ocspRequestData: {
+          hashAlgorithm: 'SHA256',
+          issuerKeyHash: 'abc123def456issuerkeyhash',
+          issuerNameHash: 'abc123def456issuernamehash',
+          responderURL: 'http://ocsp.example.com',
+          serialNumber: '1234567890',
+        },
+      }
+
+      const payload = testableRequestService.buildRequestPayload(
+        station,
+        OCPP20RequestCommand.GET_CERTIFICATE_STATUS,
+        commandParams
+      )
+
+      assert.deepStrictEqual(payload, commandParams)
+    })
+
+    await it('should build SIGN_CERTIFICATE payload as passthrough', () => {
+      const { station, testableRequestService } = createOCPP20RequestTestContext()
+      const commandParams = {
+        csr: '-----BEGIN CERTIFICATE REQUEST-----\nMIIBkTCB+wIBADBSMQ...\n-----END CERTIFICATE REQUEST-----',
+      }
+
+      const payload = testableRequestService.buildRequestPayload(
+        station,
+        OCPP20RequestCommand.SIGN_CERTIFICATE,
+        commandParams
+      )
+
+      assert.deepStrictEqual(payload, commandParams)
+    })
+  })
+
+  // ==========================================================================
+  // Group 8: commandHandlers behavioral — verify requestHandler invocation
+  // ==========================================================================
+
+  await describe('commandHandlers OCPP 2.0.1 behavioral', async () => {
+    await it('should invoke requestHandler with GET_15118_EV_CERTIFICATE command', async () => {
+      const { sentRequests, station } = createMockStationWithRequestTracking()
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const handler = testable.commandHandlers.get(
+        BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE
+      )
+      assert.ok(handler != null)
+      await handler({})
+
+      assert.strictEqual(sentRequests.length, 1)
+      assert.strictEqual(sentRequests[0].command, RequestCommand.GET_15118_EV_CERTIFICATE)
+    })
+
+    await it('should invoke requestHandler with GET_CERTIFICATE_STATUS command', async () => {
+      const { sentRequests, station } = createMockStationWithRequestTracking()
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const handler = testable.commandHandlers.get(
+        BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS
+      )
+      assert.ok(handler != null)
+      await handler({})
+
+      assert.strictEqual(sentRequests.length, 1)
+      assert.strictEqual(sentRequests[0].command, RequestCommand.GET_CERTIFICATE_STATUS)
+    })
+
+    await it('should invoke requestHandler with LOG_STATUS_NOTIFICATION command', async () => {
+      const { sentRequests, station } = createMockStationWithRequestTracking()
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const handler = testable.commandHandlers.get(
+        BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION
+      )
+      assert.ok(handler != null)
+      await handler({})
+
+      assert.strictEqual(sentRequests.length, 1)
+      assert.strictEqual(sentRequests[0].command, RequestCommand.LOG_STATUS_NOTIFICATION)
+    })
+
+    await it('should invoke requestHandler with NOTIFY_CUSTOMER_INFORMATION command', async () => {
+      const { sentRequests, station } = createMockStationWithRequestTracking()
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const handler = testable.commandHandlers.get(
+        BroadcastChannelProcedureName.NOTIFY_CUSTOMER_INFORMATION
+      )
+      assert.ok(handler != null)
+      await handler({})
+
+      assert.strictEqual(sentRequests.length, 1)
+      assert.strictEqual(sentRequests[0].command, RequestCommand.NOTIFY_CUSTOMER_INFORMATION)
+    })
+
+    await it('should invoke requestHandler with NOTIFY_REPORT command', async () => {
+      const { sentRequests, station } = createMockStationWithRequestTracking()
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const handler = testable.commandHandlers.get(
+        BroadcastChannelProcedureName.NOTIFY_REPORT
+      )
+      assert.ok(handler != null)
+      await handler({})
+
+      assert.strictEqual(sentRequests.length, 1)
+      assert.strictEqual(sentRequests[0].command, RequestCommand.NOTIFY_REPORT)
+    })
+
+    await it('should invoke requestHandler with SECURITY_EVENT_NOTIFICATION command', async () => {
+      const { sentRequests, station } = createMockStationWithRequestTracking()
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const handler = testable.commandHandlers.get(
+        BroadcastChannelProcedureName.SECURITY_EVENT_NOTIFICATION
+      )
+      assert.ok(handler != null)
+      await handler({})
+
+      assert.strictEqual(sentRequests.length, 1)
+      assert.strictEqual(sentRequests[0].command, RequestCommand.SECURITY_EVENT_NOTIFICATION)
+    })
+
+    await it('should invoke requestHandler with SIGN_CERTIFICATE command', async () => {
+      const { sentRequests, station } = createMockStationWithRequestTracking()
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const handler = testable.commandHandlers.get(
+        BroadcastChannelProcedureName.SIGN_CERTIFICATE
+      )
+      assert.ok(handler != null)
+      await handler({})
+
+      assert.strictEqual(sentRequests.length, 1)
+      assert.strictEqual(sentRequests[0].command, RequestCommand.SIGN_CERTIFICATE)
+    })
+
+    await it('should invoke requestHandler with TRANSACTION_EVENT command', async () => {
+      const { sentRequests, station } = createMockStationWithRequestTracking()
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const handler = testable.commandHandlers.get(
+        BroadcastChannelProcedureName.TRANSACTION_EVENT
+      )
+      assert.ok(handler != null)
+      await handler({})
+
+      assert.strictEqual(sentRequests.length, 1)
+      assert.strictEqual(sentRequests[0].command, RequestCommand.TRANSACTION_EVENT)
     })
   })
 })

--- a/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
+++ b/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
@@ -1,7 +1,8 @@
 /**
  * @file Tests for ChargingStationWorkerBroadcastChannel
  * @description Verifies OCPP 2.0.1 UIService pipeline integration: enums, mappings,
- * command handlers, and response status logic for the 8 new broadcast channel procedures.
+ * response status logic, payload building, and handler routing for the 8 new broadcast
+ * channel procedures. 45 tests across 6 groups.
  */
 
 import assert from 'node:assert/strict'
@@ -95,7 +96,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
   })
 
   // ==========================================================================
-  // Group 1: ProcedureName enum — 8 new OCPP 2.0.1 entries
+  // Group 1: ProcedureName enum — 8 new OCPP 2.0.1 entries (8 tests)
   // ==========================================================================
 
   await describe('ProcedureName enum OCPP 2.0.1 entries', async () => {
@@ -133,7 +134,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
   })
 
   // ==========================================================================
-  // Group 2: BroadcastChannelProcedureName enum — 8 new OCPP 2.0.1 entries
+  // Group 2: BroadcastChannelProcedureName enum — 8 new OCPP 2.0.1 entries (8 tests)
   // ==========================================================================
 
   await describe('BroadcastChannelProcedureName enum OCPP 2.0.1 entries', async () => {
@@ -186,7 +187,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
   })
 
   // ==========================================================================
-  // Group 3: ProcedureNameToBroadCastChannelProcedureNameMapping — 8 new entries
+  // Group 3: ProcedureNameToBroadCastChannelProcedureNameMapping — 8 new entries (8 tests)
   // ==========================================================================
 
   await describe('ProcedureNameToBroadCastChannelProcedureNameMapping OCPP 2.0.1 entries', async () => {
@@ -256,45 +257,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
   })
 
   // ==========================================================================
-  // Group 4: BroadcastChannelRequestPayload — OCPP 2.0.1 optional fields
-  // ==========================================================================
-
-  await describe('BroadcastChannelRequestPayload OCPP 2.0.1 fields', async () => {
-    await it('should accept optional OCPP 2.0.1 fields in BroadcastChannelRequestPayload', () => {
-      // Type-level test: verify the interface accepts OCPP 2.0.1 fields
-      const payload: BroadcastChannelRequestPayload = {
-        eventType: 'Started',
-        evseId: 1,
-        idToken: { idToken: 'test', type: 'Central' },
-        transactionData: { transactionId: 'uuid-123' },
-      }
-
-      assert.strictEqual(payload.evseId, 1)
-      assert.strictEqual(payload.eventType, 'Started')
-    })
-
-    await it('should accept BroadcastChannelRequestPayload with only evseId', () => {
-      const payload: BroadcastChannelRequestPayload = {
-        evseId: 2,
-      }
-
-      assert.strictEqual(payload.evseId, 2)
-    })
-
-    await it('should accept BroadcastChannelRequestPayload with idToken object', () => {
-      const payload: BroadcastChannelRequestPayload = {
-        idToken: { idToken: 'RFID_TOKEN_001', type: 'ISO14443' },
-      }
-
-      assert.deepStrictEqual(payload.idToken, {
-        idToken: 'RFID_TOKEN_001',
-        type: 'ISO14443',
-      })
-    })
-  })
-
-  // ==========================================================================
-  // Group 5: commandResponseToResponseStatus — 4 new command response cases
+  // Group 4: commandResponseToResponseStatus — 4 new command response cases (10 tests)
   // ==========================================================================
 
   await describe('commandResponseToResponseStatus OCPP 2.0.1 commands', async () => {
@@ -500,131 +463,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
   })
 
   // ==========================================================================
-  // Group 6: commandHandlers Map — 8 new entries registered
-  // ==========================================================================
-
-  await describe('commandHandlers OCPP 2.0.1 entries', async () => {
-    await it('should have GET_15118_EV_CERTIFICATE command handler registered', () => {
-      const { station } = createMockChargingStation({
-        connectorsCount: 1,
-        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
-        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
-        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
-      })
-
-      instance = new ChargingStationWorkerBroadcastChannel(station)
-      const testable = createTestableWorkerBroadcastChannel(instance)
-
-      assert.ok(
-        testable.commandHandlers.has(BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE)
-      )
-    })
-
-    await it('should have GET_CERTIFICATE_STATUS command handler registered', () => {
-      const { station } = createMockChargingStation({
-        connectorsCount: 1,
-        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
-        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
-        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
-      })
-
-      instance = new ChargingStationWorkerBroadcastChannel(station)
-      const testable = createTestableWorkerBroadcastChannel(instance)
-
-      assert.ok(testable.commandHandlers.has(BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS))
-    })
-
-    await it('should have LOG_STATUS_NOTIFICATION command handler registered', () => {
-      const { station } = createMockChargingStation({
-        connectorsCount: 1,
-        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
-        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
-        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
-      })
-
-      instance = new ChargingStationWorkerBroadcastChannel(station)
-      const testable = createTestableWorkerBroadcastChannel(instance)
-
-      assert.ok(testable.commandHandlers.has(BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION))
-    })
-
-    await it('should have NOTIFY_CUSTOMER_INFORMATION command handler registered', () => {
-      const { station } = createMockChargingStation({
-        connectorsCount: 1,
-        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
-        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
-        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
-      })
-
-      instance = new ChargingStationWorkerBroadcastChannel(station)
-      const testable = createTestableWorkerBroadcastChannel(instance)
-
-      assert.ok(
-        testable.commandHandlers.has(BroadcastChannelProcedureName.NOTIFY_CUSTOMER_INFORMATION)
-      )
-    })
-
-    await it('should have NOTIFY_REPORT command handler registered', () => {
-      const { station } = createMockChargingStation({
-        connectorsCount: 1,
-        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
-        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
-        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
-      })
-
-      instance = new ChargingStationWorkerBroadcastChannel(station)
-      const testable = createTestableWorkerBroadcastChannel(instance)
-
-      assert.ok(testable.commandHandlers.has(BroadcastChannelProcedureName.NOTIFY_REPORT))
-    })
-
-    await it('should have SECURITY_EVENT_NOTIFICATION command handler registered', () => {
-      const { station } = createMockChargingStation({
-        connectorsCount: 1,
-        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
-        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
-        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
-      })
-
-      instance = new ChargingStationWorkerBroadcastChannel(station)
-      const testable = createTestableWorkerBroadcastChannel(instance)
-
-      assert.ok(
-        testable.commandHandlers.has(BroadcastChannelProcedureName.SECURITY_EVENT_NOTIFICATION)
-      )
-    })
-
-    await it('should have SIGN_CERTIFICATE command handler registered', () => {
-      const { station } = createMockChargingStation({
-        connectorsCount: 1,
-        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
-        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
-        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
-      })
-
-      instance = new ChargingStationWorkerBroadcastChannel(station)
-      const testable = createTestableWorkerBroadcastChannel(instance)
-
-      assert.ok(testable.commandHandlers.has(BroadcastChannelProcedureName.SIGN_CERTIFICATE))
-    })
-
-    await it('should have TRANSACTION_EVENT command handler registered', () => {
-      const { station } = createMockChargingStation({
-        connectorsCount: 1,
-        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
-        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
-        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
-      })
-
-      instance = new ChargingStationWorkerBroadcastChannel(station)
-      const testable = createTestableWorkerBroadcastChannel(instance)
-
-      assert.ok(testable.commandHandlers.has(BroadcastChannelProcedureName.TRANSACTION_EVENT))
-    })
-  })
-
-  // ==========================================================================
-  // Group 7: buildRequestPayload — OCPP 2.0.1 certificate passthrough
+  // Group 5: buildRequestPayload — OCPP 2.0.1 certificate passthrough (3 tests)
   // ==========================================================================
 
   await describe('buildRequestPayload OCPP 2.0.1 certificate passthrough', async () => {
@@ -683,7 +522,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
   })
 
   // ==========================================================================
-  // Group 8: commandHandlers behavioral — verify requestHandler invocation
+  // Group 6: commandHandlers behavioral — verify requestHandler invocation (8 tests)
   // ==========================================================================
 
   await describe('commandHandlers OCPP 2.0.1 behavioral', async () => {

--- a/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
+++ b/tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts
@@ -2,7 +2,7 @@
  * @file Tests for ChargingStationWorkerBroadcastChannel
  * @description Verifies OCPP 2.0.1 UIService pipeline integration: enums, mappings,
  * response status logic, payload building, and handler routing for the 8 new broadcast
- * channel procedures. 45 tests across 6 groups.
+ * channel procedures. 53 tests across 6 groups.
  */
 
 import assert from 'node:assert/strict'
@@ -16,13 +16,13 @@ import {
   GenericStatus,
   GetCertificateStatusEnumType,
   Iso15118EVCertificateStatusEnumType,
+  OCPP20AuthorizationStatusEnumType,
   OCPP20RequestCommand,
   OCPPVersion,
   ProcedureName,
   RequestCommand,
   ResponseStatus,
 } from '../../../src/types/index.js'
-import { OCPP20AuthorizationStatusEnumType } from '../../../src/types/ocpp/2.0/Transaction.js'
 import { Constants } from '../../../src/utils/index.js'
 import { standardCleanup } from '../../helpers/TestLifecycleHelpers.js'
 import { createMockChargingStation } from '../ChargingStationTestUtils.js'
@@ -257,7 +257,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
   })
 
   // ==========================================================================
-  // Group 4: commandResponseToResponseStatus — 4 new command response cases (10 tests)
+  // Group 4: commandResponseToResponseStatus — 4 new command response cases (18 tests)
   // ==========================================================================
 
   await describe('commandResponseToResponseStatus OCPP 2.0.1 commands', async () => {
@@ -316,7 +316,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
 
       const status = testable.commandResponseToResponseStatus(
         BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE,
-        { exiResponse: 'base64data', status: Iso15118EVCertificateStatusEnumType.Accepted }
+        { exiResponse: 'base64Data', status: Iso15118EVCertificateStatusEnumType.Accepted }
       )
 
       assert.strictEqual(status, ResponseStatus.SUCCESS)
@@ -335,7 +335,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
 
       const status = testable.commandResponseToResponseStatus(
         BroadcastChannelProcedureName.GET_15118_EV_CERTIFICATE,
-        { exiResponse: 'base64data', status: Iso15118EVCertificateStatusEnumType.Failed }
+        { exiResponse: 'base64Data', status: Iso15118EVCertificateStatusEnumType.Failed }
       )
 
       assert.strictEqual(status, ResponseStatus.FAILURE)
@@ -376,6 +376,160 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
       const status = testable.commandResponseToResponseStatus(
         BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS,
         { status: GetCertificateStatusEnumType.Failed }
+      )
+
+      assert.strictEqual(status, ResponseStatus.FAILURE)
+    })
+
+    // -- Fire-and-forget commands (empty response = SUCCESS) --
+
+    await it('should return SUCCESS for LOG_STATUS_NOTIFICATION with empty response', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION,
+        {}
+      )
+
+      assert.strictEqual(status, ResponseStatus.SUCCESS)
+    })
+
+    await it('should return FAILURE for LOG_STATUS_NOTIFICATION with non-empty response', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION,
+        { unexpected: 'field' }
+      )
+
+      assert.strictEqual(status, ResponseStatus.FAILURE)
+    })
+
+    await it('should return SUCCESS for NOTIFY_CUSTOMER_INFORMATION with empty response', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.NOTIFY_CUSTOMER_INFORMATION,
+        {}
+      )
+
+      assert.strictEqual(status, ResponseStatus.SUCCESS)
+    })
+
+    await it('should return FAILURE for NOTIFY_CUSTOMER_INFORMATION with non-empty response', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.NOTIFY_CUSTOMER_INFORMATION,
+        { unexpected: 'field' }
+      )
+
+      assert.strictEqual(status, ResponseStatus.FAILURE)
+    })
+
+    await it('should return SUCCESS for NOTIFY_REPORT with empty response', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.NOTIFY_REPORT,
+        {}
+      )
+
+      assert.strictEqual(status, ResponseStatus.SUCCESS)
+    })
+
+    await it('should return FAILURE for NOTIFY_REPORT with non-empty response', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.NOTIFY_REPORT,
+        { unexpected: 'field' }
+      )
+
+      assert.strictEqual(status, ResponseStatus.FAILURE)
+    })
+
+    await it('should return SUCCESS for SECURITY_EVENT_NOTIFICATION with empty response', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.SECURITY_EVENT_NOTIFICATION,
+        {}
+      )
+
+      assert.strictEqual(status, ResponseStatus.SUCCESS)
+    })
+
+    await it('should return FAILURE for SECURITY_EVENT_NOTIFICATION with non-empty response', () => {
+      const { station } = createMockChargingStation({
+        connectorsCount: 1,
+        heartbeatInterval: Constants.DEFAULT_HEARTBEAT_INTERVAL,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_201 },
+        websocketPingInterval: Constants.DEFAULT_WEBSOCKET_PING_INTERVAL,
+      })
+
+      instance = new ChargingStationWorkerBroadcastChannel(station)
+      const testable = createTestableWorkerBroadcastChannel(instance)
+
+      const status = testable.commandResponseToResponseStatus(
+        BroadcastChannelProcedureName.SECURITY_EVENT_NOTIFICATION,
+        { unexpected: 'field' }
       )
 
       assert.strictEqual(status, ResponseStatus.FAILURE)
@@ -471,7 +625,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
       const { station, testableRequestService } = createOCPP20RequestTestContext()
       const commandParams = {
         action: 'Install',
-        exiRequest: 'base64encodeddata',
+        exiRequest: 'base64EncodedData',
         iso15118SchemaVersion: 'urn:iso:15118:2:2013:MsgDef',
       }
 
@@ -508,7 +662,7 @@ await describe('ChargingStationWorkerBroadcastChannel', async () => {
     await it('should build SIGN_CERTIFICATE payload as passthrough', () => {
       const { station, testableRequestService } = createOCPP20RequestTestContext()
       const commandParams = {
-        csr: '-----BEGIN CERTIFICATE REQUEST-----\nMIIBkTCB+wIBADBSMQ...\n-----END CERTIFICATE REQUEST-----',
+        csr: '-----BEGIN CERTIFICATE REQUEST-----\nMIIBkTCB...\n-----END CERTIFICATE REQUEST-----',
       }
 
       const payload = testableRequestService.buildRequestPayload(


### PR DESCRIPTION
## Summary

Integrates all 8 missing OCPP 2.0.1 outgoing commands into the UIService → BroadcastChannel → ChargingStation pipeline end-to-end, fixes existing OCPP 1.6 bias bugs, and adds comprehensive tests.

## Changes

### New OCPP 2.0.1 commands accessible via UI protocol
- `transactionEvent`
- `logStatusNotification`
- `notifyReport`
- `securityEventNotification`
- `signCertificate`
- `get15118EVCertificate`
- `getCertificateStatus`
- `notifyCustomerInformation`

### Files modified

| File | Change |
|------|--------|
| `src/types/UIProtocol.ts` | +8 `ProcedureName` enum entries (33 total) |
| `src/types/WorkerBroadcastChannel.ts` | +8 `BroadcastChannelProcedureName` entries + 4 OCPP 2.0.1 payload fields (`eventType`, `evseId`, `idToken`, `transactionData`) |
| `src/charging-station/ui-server/ui-services/AbstractUIService.ts` | +8 mapping entries in `ProcedureNameToBroadCastChannelProcedureNameMapping` |
| `src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts` | +8 command handlers, +4 `commandResponseToResponseStatus` cases, updated `CommandResponse` type union, OCPP version-branched `METER_VALUES` handler |
| `src/charging-station/ocpp/2.0/OCPP20RequestService.ts` | +3 missing `buildRequestPayload` cases (SignCertificate, Get15118EVCertificate, GetCertificateStatus) |
| `tests/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.test.ts` | NEW — 45 tests across 6 groups |

### Bug fixes
- **METER_VALUES handler**: Added OCPP version branching — OCPP 2.0.1 stations now use native passthrough instead of OCPP 1.6 synthetic meter values
- **`buildRequestPayload`**: 3 certificate commands previously fell to `default` → throw; now properly handled
- **`CommandResponse` type**: Widened to include 4 OCPP 2.0.1 response types

### Response status logic
- Fire-and-forget commands (4): `logStatusNotification`, `notifyReport`, `securityEventNotification`, `notifyCustomerInformation` — no `commandResponseToResponseStatus` case needed (empty response → SUCCESS via `isEmpty` bailout)
- Commands needing response status (4): `transactionEvent`, `signCertificate`, `get15118EVCertificate`, `getCertificateStatus`

## Quality gates

- ✅ `pnpm lint` — passes
- ✅ `pnpm typecheck` — passes
- ✅ `pnpm build` — passes
- ✅ `pnpm test` — 1805 tests, 0 failures

## Backward compatibility

All existing OCPP 1.6 commands work unchanged. OCPP version checks added where needed (METER_VALUES handler).