### PR TITLE
feat: add connector cable retention lock/unlock simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,6 +958,40 @@ Set the WebSocket header _Sec-WebSocket-Protocol_ to `ui0.0.1`.
    `responsesFailed`: failed responses payload array (optional)  
   }
 
+###### Lock Connector
+
+- Request:  
+  `ProcedureName`: 'lockConnector'  
+  `PDU`: {  
+   `hashIds`: charging station unique identifier strings array (optional, default: all charging stations),  
+   `connectorId`: connector id integer  
+  }
+
+- Response:  
+  `PDU`: {  
+   `status`: 'success' | 'failure',  
+   `hashIdsSucceeded`: charging station unique identifier strings array,  
+   `hashIdsFailed`: charging station unique identifier strings array (optional),  
+   `responsesFailed`: failed responses payload array (optional)  
+  }
+
+###### Unlock Connector
+
+- Request:  
+  `ProcedureName`: 'unlockConnector'  
+  `PDU`: {  
+   `hashIds`: charging station unique identifier strings array (optional, default: all charging stations),  
+   `connectorId`: connector id integer  
+  }
+
+- Response:  
+  `PDU`: {  
+   `status`: 'success' | 'failure',  
+   `hashIdsSucceeded`: charging station unique identifier strings array,  
+   `hashIdsFailed`: charging station unique identifier strings array (optional),  
+   `responsesFailed`: failed responses payload array (optional)  
+  }
+
 ###### OCPP commands trigger
 
 - Request:  

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -857,7 +857,10 @@ export class ChargingStation extends EventEmitter {
     }
     if (connectorStatus.locked !== true) {
       connectorStatus.locked = true
-      this.emitChargingStationEvent(ChargingStationEvents.updated)
+      this.emitChargingStationEvent(ChargingStationEvents.connectorStatusChanged, {
+        connectorId,
+        ...connectorStatus,
+      })
     }
   }
 
@@ -1244,7 +1247,10 @@ export class ChargingStation extends EventEmitter {
     }
     if (connectorStatus.locked !== false) {
       connectorStatus.locked = false
-      this.emitChargingStationEvent(ChargingStationEvents.updated)
+      this.emitChargingStationEvent(ChargingStationEvents.connectorStatusChanged, {
+        connectorId,
+        ...connectorStatus,
+      })
     }
   }
 

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -837,6 +837,24 @@ export class ChargingStation extends EventEmitter {
     return this.wsConnection?.readyState === WebSocket.OPEN
   }
 
+  public lockConnector (connectorId: number): void {
+    if (connectorId === 0) {
+      logger.warn(`${this.logPrefix()} lockConnector: connector id 0 is not a physical connector`)
+      return
+    }
+    if (!this.hasConnector(connectorId)) {
+      logger.warn(
+        `${this.logPrefix()} lockConnector: connector id ${connectorId.toString()} does not exist`
+      )
+      return
+    }
+    const connectorStatus = this.getConnectorStatus(connectorId)
+    if (connectorStatus == null) {
+      return
+    }
+    connectorStatus.locked = true
+  }
+
   public logPrefix = (): string => {
     if (
       this instanceof ChargingStation &&
@@ -1198,6 +1216,24 @@ export class ChargingStation extends EventEmitter {
     }
     this.saveAutomaticTransactionGeneratorConfiguration()
     this.emitChargingStationEvent(ChargingStationEvents.updated)
+  }
+
+  public unlockConnector (connectorId: number): void {
+    if (connectorId === 0) {
+      logger.warn(`${this.logPrefix()} unlockConnector: connector id 0 is not a physical connector`)
+      return
+    }
+    if (!this.hasConnector(connectorId)) {
+      logger.warn(
+        `${this.logPrefix()} unlockConnector: connector id ${connectorId.toString()} does not exist`
+      )
+      return
+    }
+    const connectorStatus = this.getConnectorStatus(connectorId)
+    if (connectorStatus == null) {
+      return
+    }
+    connectorStatus.locked = false
   }
 
   private add (): void {

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -850,9 +850,15 @@ export class ChargingStation extends EventEmitter {
     }
     const connectorStatus = this.getConnectorStatus(connectorId)
     if (connectorStatus == null) {
+      logger.warn(
+        `${this.logPrefix()} lockConnector: connector id ${connectorId.toString()} status is null`
+      )
       return
     }
-    connectorStatus.locked = true
+    if (connectorStatus.locked !== true) {
+      connectorStatus.locked = true
+      this.emitChargingStationEvent(ChargingStationEvents.updated)
+    }
   }
 
   public logPrefix = (): string => {
@@ -1231,9 +1237,15 @@ export class ChargingStation extends EventEmitter {
     }
     const connectorStatus = this.getConnectorStatus(connectorId)
     if (connectorStatus == null) {
+      logger.warn(
+        `${this.logPrefix()} unlockConnector: connector id ${connectorId.toString()} status is null`
+      )
       return
     }
-    connectorStatus.locked = false
+    if (connectorStatus.locked !== false) {
+      connectorStatus.locked = false
+      this.emitChargingStationEvent(ChargingStationEvents.updated)
+    }
   }
 
   private add (): void {

--- a/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
+++ b/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
@@ -152,6 +152,17 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
       ],
       [BroadcastChannelProcedureName.HEARTBEAT, this.passthrough(RequestCommand.HEARTBEAT)],
       [
+        BroadcastChannelProcedureName.LOCK_CONNECTOR,
+        (requestPayload?: BroadcastChannelRequestPayload) => {
+          if (requestPayload?.connectorId == null) {
+            throw new BaseError(
+              `${this.chargingStation.logPrefix()} ${moduleName}.requestHandler: 'connectorId' field is required`
+            )
+          }
+          this.chargingStation.lockConnector(requestPayload.connectorId)
+        },
+      ],
+      [
         BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION,
         this.passthrough(RequestCommand.LOG_STATUS_NOTIFICATION),
       ],
@@ -223,6 +234,17 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
       [
         BroadcastChannelProcedureName.TRANSACTION_EVENT,
         this.passthrough(RequestCommand.TRANSACTION_EVENT),
+      ],
+      [
+        BroadcastChannelProcedureName.UNLOCK_CONNECTOR,
+        (requestPayload?: BroadcastChannelRequestPayload) => {
+          if (requestPayload?.connectorId == null) {
+            throw new BaseError(
+              `${this.chargingStation.logPrefix()} ${moduleName}.requestHandler: 'connectorId' field is required`
+            )
+          }
+          this.chargingStation.unlockConnector(requestPayload.connectorId)
+        },
       ],
     ])
     this.onmessage = this.requestHandler.bind(this) as (message: unknown) => void

--- a/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
@@ -1581,6 +1581,7 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService {
         OCPP16StopTransactionReason.UNLOCK_COMMAND
       )
       if (stopResponse.idTagInfo?.status === OCPP16AuthorizationStatus.ACCEPTED) {
+        chargingStation.unlockConnector(connectorId)
         return OCPP16Constants.OCPP_RESPONSE_UNLOCKED
       }
       return OCPP16Constants.OCPP_RESPONSE_UNLOCK_FAILED
@@ -1589,6 +1590,7 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService {
       connectorId,
       status: OCPP16ChargePointStatus.Available,
     } as OCPP16StatusNotificationRequest)
+    chargingStation.unlockConnector(connectorId)
     return OCPP16Constants.OCPP_RESPONSE_UNLOCKED
   }
 

--- a/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
@@ -1581,7 +1581,6 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService {
         OCPP16StopTransactionReason.UNLOCK_COMMAND
       )
       if (stopResponse.idTagInfo?.status === OCPP16AuthorizationStatus.ACCEPTED) {
-        chargingStation.unlockConnector(connectorId)
         return OCPP16Constants.OCPP_RESPONSE_UNLOCKED
       }
       return OCPP16Constants.OCPP_RESPONSE_UNLOCK_FAILED

--- a/src/charging-station/ocpp/1.6/OCPP16ResponseService.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16ResponseService.ts
@@ -521,8 +521,7 @@ export class OCPP16ResponseService extends OCPPResponseService {
     resetConnectorStatus(transactionConnectorStatus)
     if (
       transactionConnectorStatus != null &&
-      (payload.idTagInfo == null ||
-        payload.idTagInfo.status === OCPP16AuthorizationStatus.ACCEPTED)
+      (payload.idTagInfo == null || payload.idTagInfo.status === OCPP16AuthorizationStatus.ACCEPTED)
     ) {
       transactionConnectorStatus.locked = false
     }

--- a/src/charging-station/ocpp/1.6/OCPP16ResponseService.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16ResponseService.ts
@@ -519,7 +519,11 @@ export class OCPP16ResponseService extends OCPPResponseService {
     }
     const transactionConnectorStatus = chargingStation.getConnectorStatus(transactionConnectorId)
     resetConnectorStatus(transactionConnectorStatus)
-    if (transactionConnectorStatus != null) {
+    if (
+      transactionConnectorStatus != null &&
+      (payload.idTagInfo == null ||
+        payload.idTagInfo.status === OCPP16AuthorizationStatus.ACCEPTED)
+    ) {
       transactionConnectorStatus.locked = false
     }
     OCPP16ServiceUtils.stopPeriodicMeterValues(chargingStation, transactionConnectorId)

--- a/src/charging-station/ocpp/1.6/OCPP16ResponseService.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16ResponseService.ts
@@ -381,6 +381,7 @@ export class OCPP16ResponseService extends OCPPResponseService {
       connectorStatus.transactionId = payload.transactionId
       connectorStatus.transactionIdTag = requestPayload.idTag
       connectorStatus.transactionEnergyActiveImportRegisterValue = 0
+      connectorStatus.locked = true
       connectorStatus.transactionBeginMeterValue =
         OCPP16ServiceUtils.buildTransactionBeginMeterValue(
           chargingStation,
@@ -516,7 +517,11 @@ export class OCPP16ResponseService extends OCPPResponseService {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       chargingStation.powerDivider!--
     }
-    resetConnectorStatus(chargingStation.getConnectorStatus(transactionConnectorId))
+    const transactionConnectorStatus = chargingStation.getConnectorStatus(transactionConnectorId)
+    resetConnectorStatus(transactionConnectorStatus)
+    if (transactionConnectorStatus != null) {
+      transactionConnectorStatus.locked = false
+    }
     OCPP16ServiceUtils.stopPeriodicMeterValues(chargingStation, transactionConnectorId)
     const logMsg = `${chargingStation.logPrefix()} ${moduleName}.handleResponseStopTransaction: Transaction with id ${requestPayload.transactionId.toString()} STOPPED on ${
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions

--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -2708,6 +2708,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
         evseId,
       } as unknown as OCPP20StatusNotificationRequest)
 
+      chargingStation.unlockConnector(connectorId)
       return { status: UnlockStatusEnumType.Unlocked }
     } catch (error) {
       logger.error(

--- a/src/charging-station/ocpp/2.0/OCPP20ResponseService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20ResponseService.ts
@@ -386,10 +386,12 @@ export class OCPP20ResponseService extends OCPPResponseService {
           connectorStatus.transactionIdTag ??= requestPayload.idToken?.idToken
           connectorStatus.transactionStart ??= new Date()
           connectorStatus.transactionEnergyActiveImportRegisterValue ??= 0
-          connectorStatus.locked = true
           const isIdTokenAccepted =
             payload.idTokenInfo == null ||
             payload.idTokenInfo.status === OCPP20AuthorizationStatusEnumType.Accepted
+          if (isIdTokenAccepted) {
+            connectorStatus.locked = true
+          }
           if (connectorId != null && isIdTokenAccepted) {
             sendAndSetConnectorStatus(chargingStation, {
               connectorId,

--- a/src/charging-station/ocpp/2.0/OCPP20ResponseService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20ResponseService.ts
@@ -386,6 +386,7 @@ export class OCPP20ResponseService extends OCPPResponseService {
           connectorStatus.transactionIdTag ??= requestPayload.idToken?.idToken
           connectorStatus.transactionStart ??= new Date()
           connectorStatus.transactionEnergyActiveImportRegisterValue ??= 0
+          connectorStatus.locked = true
           const isIdTokenAccepted =
             payload.idTokenInfo == null ||
             payload.idTokenInfo.status === OCPP20AuthorizationStatusEnumType.Accepted

--- a/src/charging-station/ocpp/2.0/OCPP20ServiceUtils.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20ServiceUtils.ts
@@ -832,6 +832,7 @@ export class OCPP20ServiceUtils extends OCPPServiceUtils {
 
     OCPP20ServiceUtils.stopPeriodicMeterValues(chargingStation, connectorId)
     resetConnectorStatus(connectorStatus)
+    connectorStatus.locked = false
     await sendAndSetConnectorStatus(chargingStation, {
       connectorId,
       connectorStatus: ConnectorStatusEnum.Available,

--- a/src/charging-station/ui-server/mcp/MCPToolSchemas.ts
+++ b/src/charging-station/ui-server/mcp/MCPToolSchemas.ts
@@ -22,6 +22,11 @@ const broadcastInputSchema = z.object({
   hashIds,
 })
 
+const connectorInputSchema = z.object({
+  connectorId: z.number().int().positive().describe('Target connector ID'),
+  hashIds,
+})
+
 const emptyInputSchema = z.object({})
 
 const chargingStationOptionsSchema = z.object({
@@ -247,6 +252,13 @@ export const mcpToolSchemas = new Map<ProcedureName, MCPToolSchema>([
     },
   ],
   [
+    ProcedureName.LOCK_CONNECTOR,
+    {
+      description: 'Engage the cable retention lock on a connector',
+      inputSchema: connectorInputSchema,
+    },
+  ],
+  [
     ProcedureName.LOG_STATUS_NOTIFICATION,
     {
       description: ocppDescription(
@@ -409,6 +421,13 @@ export const mcpToolSchemas = new Map<ProcedureName, MCPToolSchema>([
     {
       description: ocppDescription('Send a TransactionEvent', ProcedureName.TRANSACTION_EVENT),
       inputSchema: ocppInputSchema(ProcedureName.TRANSACTION_EVENT),
+    },
+  ],
+  [
+    ProcedureName.UNLOCK_CONNECTOR,
+    {
+      description: 'Release the cable retention lock on a connector',
+      inputSchema: connectorInputSchema,
     },
   ],
 ])

--- a/src/charging-station/ui-server/ui-services/AbstractUIService.ts
+++ b/src/charging-station/ui-server/ui-services/AbstractUIService.ts
@@ -67,6 +67,7 @@ export abstract class AbstractUIService {
     ],
     [ProcedureName.GET_CERTIFICATE_STATUS, BroadcastChannelProcedureName.GET_CERTIFICATE_STATUS],
     [ProcedureName.HEARTBEAT, BroadcastChannelProcedureName.HEARTBEAT],
+    [ProcedureName.LOCK_CONNECTOR, BroadcastChannelProcedureName.LOCK_CONNECTOR],
     [ProcedureName.LOG_STATUS_NOTIFICATION, BroadcastChannelProcedureName.LOG_STATUS_NOTIFICATION],
     [ProcedureName.METER_VALUES, BroadcastChannelProcedureName.METER_VALUES],
     [
@@ -95,6 +96,7 @@ export abstract class AbstractUIService {
     [ProcedureName.STOP_CHARGING_STATION, BroadcastChannelProcedureName.STOP_CHARGING_STATION],
     [ProcedureName.STOP_TRANSACTION, BroadcastChannelProcedureName.STOP_TRANSACTION],
     [ProcedureName.TRANSACTION_EVENT, BroadcastChannelProcedureName.TRANSACTION_EVENT],
+    [ProcedureName.UNLOCK_CONNECTOR, BroadcastChannelProcedureName.UNLOCK_CONNECTOR],
   ])
 
   protected readonly requestHandlers: Map<ProcedureName, ProtocolRequestHandler>

--- a/src/types/ConnectorStatus.ts
+++ b/src/types/ConnectorStatus.ts
@@ -16,6 +16,7 @@ export interface ConnectorStatus {
   idTagAuthorized?: boolean
   idTagLocalAuthorized?: boolean
   localAuthorizeIdTag?: string
+  locked?: boolean
   MeterValues: SampledValueTemplate[]
   remoteStartId?: number
   reservation?: Reservation

--- a/src/types/UIProtocol.ts
+++ b/src/types/UIProtocol.ts
@@ -27,6 +27,7 @@ export enum ProcedureName {
   HEARTBEAT = 'heartbeat',
   LIST_CHARGING_STATIONS = 'listChargingStations',
   LIST_TEMPLATES = 'listTemplates',
+  LOCK_CONNECTOR = 'lockConnector',
   LOG_STATUS_NOTIFICATION = 'logStatusNotification',
   METER_VALUES = 'meterValues',
   NOTIFY_CUSTOMER_INFORMATION = 'notifyCustomerInformation',
@@ -47,6 +48,7 @@ export enum ProcedureName {
   STOP_SIMULATOR = 'stopSimulator',
   STOP_TRANSACTION = 'stopTransaction',
   TRANSACTION_EVENT = 'transactionEvent',
+  UNLOCK_CONNECTOR = 'unlockConnector',
 }
 
 export enum Protocol {

--- a/src/types/WorkerBroadcastChannel.ts
+++ b/src/types/WorkerBroadcastChannel.ts
@@ -12,6 +12,7 @@ export enum BroadcastChannelProcedureName {
   GET_15118_EV_CERTIFICATE = 'get15118EVCertificate',
   GET_CERTIFICATE_STATUS = 'getCertificateStatus',
   HEARTBEAT = 'heartbeat',
+  LOCK_CONNECTOR = 'lockConnector',
   LOG_STATUS_NOTIFICATION = 'logStatusNotification',
   METER_VALUES = 'meterValues',
   NOTIFY_CUSTOMER_INFORMATION = 'notifyCustomerInformation',
@@ -28,6 +29,7 @@ export enum BroadcastChannelProcedureName {
   STOP_CHARGING_STATION = 'stopChargingStation',
   STOP_TRANSACTION = 'stopTransaction',
   TRANSACTION_EVENT = 'transactionEvent',
+  UNLOCK_CONNECTOR = 'unlockConnector',
 }
 
 export type BroadcastChannelRequest = [

--- a/tests/charging-station/ChargingStation-Connectors.test.ts
+++ b/tests/charging-station/ChargingStation-Connectors.test.ts
@@ -651,4 +651,89 @@ await describe('ChargingStation Connector and EVSE State', async () => {
       assert.strictEqual(found2?.connectorId, 2)
     })
   })
+
+  await describe('Connector Lock/Unlock', async () => {
+    let station: ChargingStation | undefined
+
+    beforeEach(() => {
+      station = undefined
+    })
+
+    afterEach(() => {
+      standardCleanup()
+      if (station != null) {
+        cleanupChargingStation(station)
+      }
+    })
+
+    await it('should set locked=true on lockConnector() for valid connector', () => {
+      const result = createMockChargingStation({ connectorsCount: 2 })
+      station = result.station
+
+      station.lockConnector(1)
+
+      assert.strictEqual(station.getConnectorStatus(1)?.locked, true)
+    })
+
+    await it('should set locked=false on unlockConnector() for valid connector', () => {
+      const result = createMockChargingStation({ connectorsCount: 2 })
+      station = result.station
+
+      station.lockConnector(1)
+      assert.strictEqual(station.getConnectorStatus(1)?.locked, true)
+
+      station.unlockConnector(1)
+      assert.strictEqual(station.getConnectorStatus(1)?.locked, false)
+    })
+
+    await it('should reject connector id 0 for lockConnector()', () => {
+      const result = createMockChargingStation({ connectorsCount: 2 })
+      station = result.station
+
+      station.lockConnector(0)
+
+      assert.notStrictEqual(station.getConnectorStatus(0)?.locked, true)
+    })
+
+    await it('should reject connector id 0 for unlockConnector()', () => {
+      const result = createMockChargingStation({ connectorsCount: 2 })
+      station = result.station
+
+      station.unlockConnector(0)
+
+      assert.notStrictEqual(station.getConnectorStatus(0)?.locked, false)
+    })
+
+    await it('should reject non-existent connector for lockConnector()', () => {
+      const result = createMockChargingStation({ connectorsCount: 2 })
+      station = result.station
+
+      station.lockConnector(999)
+
+      assert.strictEqual(station.getConnectorStatus(999), undefined)
+    })
+
+    await it('should reject non-existent connector for unlockConnector()', () => {
+      const result = createMockChargingStation({ connectorsCount: 2 })
+      station = result.station
+
+      station.unlockConnector(999)
+
+      assert.strictEqual(station.getConnectorStatus(999), undefined)
+    })
+
+    await it('should not clear locked state on resetConnectorStatus', () => {
+      const result = createMockChargingStation({ connectorsCount: 2 })
+      station = result.station
+
+      station.lockConnector(1)
+      assert.strictEqual(station.getConnectorStatus(1)?.locked, true)
+
+      station.lockConnector(2)
+      station.unlockConnector(1)
+
+      assert.strictEqual(station.getConnectorStatus(1)?.locked, false)
+      assert.strictEqual(station.getConnectorStatus(2)?.locked, true)
+    })
+  })
 })

--- a/tests/charging-station/ChargingStation-Connectors.test.ts
+++ b/tests/charging-station/ChargingStation-Connectors.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, it } from 'node:test'
 import type { ChargingStation } from '../../src/charging-station/index.js'
 
 import { RegistrationStatusEnumType } from '../../src/types/index.js'
+import { resetConnectorStatus } from '../../src/charging-station/Helpers.js'
 import { standardCleanup } from '../helpers/TestLifecycleHelpers.js'
 import { TEST_ONE_HOUR_MS } from './ChargingStationTestConstants.js'
 import { cleanupChargingStation, createMockChargingStation } from './ChargingStationTestUtils.js'
@@ -729,11 +730,9 @@ await describe('ChargingStation Connector and EVSE State', async () => {
       station.lockConnector(1)
       assert.strictEqual(station.getConnectorStatus(1)?.locked, true)
 
-      station.lockConnector(2)
-      station.unlockConnector(1)
+      resetConnectorStatus(station.getConnectorStatus(1))
 
-      assert.strictEqual(station.getConnectorStatus(1)?.locked, false)
-      assert.strictEqual(station.getConnectorStatus(2)?.locked, true)
+      assert.strictEqual(station.getConnectorStatus(1)?.locked, true)
     })
   })
 })

--- a/tests/charging-station/ChargingStation-Connectors.test.ts
+++ b/tests/charging-station/ChargingStation-Connectors.test.ts
@@ -7,8 +7,8 @@ import { afterEach, beforeEach, describe, it } from 'node:test'
 
 import type { ChargingStation } from '../../src/charging-station/index.js'
 
-import { RegistrationStatusEnumType } from '../../src/types/index.js'
 import { resetConnectorStatus } from '../../src/charging-station/Helpers.js'
+import { RegistrationStatusEnumType } from '../../src/types/index.js'
 import { standardCleanup } from '../helpers/TestLifecycleHelpers.js'
 import { TEST_ONE_HOUR_MS } from './ChargingStationTestConstants.js'
 import { cleanupChargingStation, createMockChargingStation } from './ChargingStationTestUtils.js'

--- a/tests/charging-station/ChargingStation-Connectors.test.ts
+++ b/tests/charging-station/ChargingStation-Connectors.test.ts
@@ -687,6 +687,26 @@ await describe('ChargingStation Connector and EVSE State', async () => {
       assert.strictEqual(station.getConnectorStatus(1)?.locked, false)
     })
 
+    await it('should be idempotent on double lockConnector()', () => {
+      const result = createMockChargingStation({ connectorsCount: 2 })
+      station = result.station
+
+      station.lockConnector(1)
+      station.lockConnector(1)
+
+      assert.strictEqual(station.getConnectorStatus(1)?.locked, true)
+    })
+
+    await it('should be idempotent on double unlockConnector()', () => {
+      const result = createMockChargingStation({ connectorsCount: 2 })
+      station = result.station
+
+      station.unlockConnector(1)
+      station.unlockConnector(1)
+
+      assert.strictEqual(station.getConnectorStatus(1)?.locked, false)
+    })
+
     await it('should reject connector id 0 for lockConnector()', () => {
       const result = createMockChargingStation({ connectorsCount: 2 })
       station = result.station

--- a/tests/charging-station/helpers/StationHelpers.ts
+++ b/tests/charging-station/helpers/StationHelpers.ts
@@ -688,6 +688,20 @@ export function createMockChargingStation (
 
     listenerCount: () => 0,
 
+    lockConnector (connectorId: number): void {
+      if (connectorId === 0) {
+        return
+      }
+      if (!this.hasConnector(connectorId)) {
+        return
+      }
+      const connectorStatus = this.getConnectorStatus(connectorId)
+      if (connectorStatus == null) {
+        return
+      }
+      connectorStatus.locked = true
+    },
+
     logPrefix (): string {
       return `${this.stationInfo.chargingStationId} |`
     },
@@ -822,6 +836,21 @@ export function createMockChargingStation (
     stopping: false,
 
     templateFile,
+
+    unlockConnector (connectorId: number): void {
+      if (connectorId === 0) {
+        return
+      }
+      if (!this.hasConnector(connectorId)) {
+        return
+      }
+      const connectorStatus = this.getConnectorStatus(connectorId)
+      if (connectorStatus == null) {
+        return
+      }
+      connectorStatus.locked = false
+    },
+
     wsConnection: null as MockWebSocket | null,
     wsConnectionRetryCount: 0,
   }

--- a/ui/web/src/components/charging-stations/CSConnector.vue
+++ b/ui/web/src/components/charging-stations/CSConnector.vue
@@ -7,13 +7,13 @@
       {{ connector.status ?? 'Ø' }}
     </td>
     <td class="connectors-table__column">
+      {{ connector.locked === true ? 'Yes' : 'No' }}
+    </td>
+    <td class="connectors-table__column">
       {{ connector.transactionStarted === true ? `Yes (${connector.transactionId})` : 'No' }}
     </td>
     <td class="connectors-table__column">
       {{ atgStatus?.start === true ? 'Yes' : 'No' }}
-    </td>
-    <td class="connectors-table__column">
-      {{ connector.locked === true ? 'Yes' : 'No' }}
     </td>
     <td class="connectors-table__column">
       <ToggleButton

--- a/ui/web/src/components/charging-stations/CSConnector.vue
+++ b/ui/web/src/components/charging-stations/CSConnector.vue
@@ -13,6 +13,9 @@
       {{ atgStatus?.start === true ? 'Yes' : 'No' }}
     </td>
     <td class="connectors-table__column">
+      {{ connector.locked === true ? 'Yes' : 'No' }}
+    </td>
+    <td class="connectors-table__column">
       <ToggleButton
         :id="`${hashId}-${evseId ?? 0}-${connectorId}-start-transaction`"
         :off="
@@ -45,6 +48,18 @@
       </Button>
       <Button @click="stopAutomaticTransactionGenerator()">
         Stop ATG
+      </Button>
+      <Button
+        v-if="connector.locked !== true"
+        @click="lockConnector()"
+      >
+        Lock
+      </Button>
+      <Button
+        v-else
+        @click="unlockConnector()"
+      >
+        Unlock
       </Button>
     </td>
   </tr>
@@ -91,6 +106,28 @@ const stopTransaction = (): void => {
     .catch((error: Error) => {
       $toast.error('Error at stopping transaction')
       console.error('Error at stopping transaction:', error)
+    })
+}
+const lockConnector = (): void => {
+  uiClient
+    .lockConnector(props.hashId, props.connectorId)
+    .then(() => {
+      return $toast.success('Connector successfully locked')
+    })
+    .catch((error: Error) => {
+      $toast.error('Error at locking connector')
+      console.error('Error at locking connector:', error)
+    })
+}
+const unlockConnector = (): void => {
+  uiClient
+    .unlockConnector(props.hashId, props.connectorId)
+    .then(() => {
+      return $toast.success('Connector successfully unlocked')
+    })
+    .catch((error: Error) => {
+      $toast.error('Error at unlocking connector')
+      console.error('Error at unlocking connector:', error)
     })
 }
 const startAutomaticTransactionGenerator = (): void => {

--- a/ui/web/src/components/charging-stations/CSData.vue
+++ b/ui/web/src/components/charging-stations/CSData.vue
@@ -102,6 +102,12 @@
               class="connectors-table__column"
               scope="col"
             >
+              Locked
+            </th>
+            <th
+              class="connectors-table__column"
+              scope="col"
+            >
               Actions
             </th>
           </tr>

--- a/ui/web/src/components/charging-stations/CSData.vue
+++ b/ui/web/src/components/charging-stations/CSData.vue
@@ -90,6 +90,12 @@
               class="connectors-table__column"
               scope="col"
             >
+              Locked
+            </th>
+            <th
+              class="connectors-table__column"
+              scope="col"
+            >
               Transaction
             </th>
             <th
@@ -97,12 +103,6 @@
               scope="col"
             >
               ATG Started
-            </th>
-            <th
-              class="connectors-table__column"
-              scope="col"
-            >
-              Locked
             </th>
             <th
               class="connectors-table__column"

--- a/ui/web/src/composables/UIClient.ts
+++ b/ui/web/src/composables/UIClient.ts
@@ -90,6 +90,13 @@ export class UIClient {
     return this.sendRequest(ProcedureName.LIST_TEMPLATES, {})
   }
 
+  public async lockConnector (hashId: string, connectorId: number): Promise<ResponsePayload> {
+    return this.sendRequest(ProcedureName.LOCK_CONNECTOR, {
+      connectorId,
+      hashIds: [hashId],
+    })
+  }
+
   public async openConnection (hashId: string): Promise<ResponsePayload> {
     return this.sendRequest(ProcedureName.OPEN_CONNECTION, {
       hashIds: [hashId],
@@ -215,6 +222,13 @@ export class UIClient {
     return this.sendRequest(ProcedureName.STOP_TRANSACTION, {
       hashIds: [hashId],
       transactionId: options.transactionId,
+    })
+  }
+
+  public async unlockConnector (hashId: string, connectorId: number): Promise<ResponsePayload> {
+    return this.sendRequest(ProcedureName.UNLOCK_CONNECTOR, {
+      connectorId,
+      hashIds: [hashId],
     })
   }
 

--- a/ui/web/src/types/ChargingStationType.ts
+++ b/ui/web/src/types/ChargingStationType.ts
@@ -261,6 +261,7 @@ export interface ConnectorStatus extends JsonObject {
   idTagAuthorized?: boolean
   idTagLocalAuthorized?: boolean
   localAuthorizeIdTag?: string
+  locked?: boolean
   status?: ChargePointStatus
   transactionEnergyActiveImportRegisterValue?: number // In Wh
   /**

--- a/ui/web/src/types/UIProtocol.ts
+++ b/ui/web/src/types/UIProtocol.ts
@@ -19,6 +19,7 @@ export enum ProcedureName {
   GET_CERTIFICATE_STATUS = 'getCertificateStatus',
   LIST_CHARGING_STATIONS = 'listChargingStations',
   LIST_TEMPLATES = 'listTemplates',
+  LOCK_CONNECTOR = 'lockConnector',
   LOG_STATUS_NOTIFICATION = 'logStatusNotification',
   NOTIFY_CUSTOMER_INFORMATION = 'notifyCustomerInformation',
   NOTIFY_REPORT = 'notifyReport',
@@ -36,6 +37,7 @@ export enum ProcedureName {
   STOP_SIMULATOR = 'stopSimulator',
   STOP_TRANSACTION = 'stopTransaction',
   TRANSACTION_EVENT = 'transactionEvent',
+  UNLOCK_CONNECTOR = 'unlockConnector',
 }
 
 export enum Protocol {

--- a/ui/web/tests/unit/CSConnector.test.ts
+++ b/ui/web/tests/unit/CSConnector.test.ts
@@ -83,7 +83,7 @@ describe('CSConnector', () => {
     it('should display No when transaction not started', () => {
       const wrapper = mountCSConnector()
       const cells = wrapper.findAll('td')
-      expect(cells[2].text()).toBe('No')
+      expect(cells[3].text()).toBe('No')
     })
 
     it('should display Yes with transaction ID when transaction started', () => {
@@ -91,25 +91,25 @@ describe('CSConnector', () => {
         connector: createConnectorStatus({ transactionId: 12345, transactionStarted: true }),
       })
       const cells = wrapper.findAll('td')
-      expect(cells[2].text()).toBe('Yes (12345)')
+      expect(cells[3].text()).toBe('Yes (12345)')
     })
 
     it('should display ATG started as Yes when active', () => {
       const wrapper = mountCSConnector({ atgStatus: { start: true } })
       const cells = wrapper.findAll('td')
-      expect(cells[3].text()).toBe('Yes')
+      expect(cells[4].text()).toBe('Yes')
     })
 
     it('should display ATG started as No when not active', () => {
       const wrapper = mountCSConnector({ atgStatus: { start: false } })
       const cells = wrapper.findAll('td')
-      expect(cells[3].text()).toBe('No')
+      expect(cells[4].text()).toBe('No')
     })
 
     it('should display ATG started as No when atgStatus undefined', () => {
       const wrapper = mountCSConnector()
       const cells = wrapper.findAll('td')
-      expect(cells[3].text()).toBe('No')
+      expect(cells[4].text()).toBe('No')
     })
   })
 
@@ -206,7 +206,7 @@ describe('CSConnector', () => {
     it('should display Locked column as No when not locked', () => {
       const wrapper = mountCSConnector()
       const cells = wrapper.findAll('td')
-      expect(cells[4].text()).toBe('No')
+      expect(cells[2].text()).toBe('No')
     })
 
     it('should display Locked column as Yes when locked', () => {
@@ -214,7 +214,7 @@ describe('CSConnector', () => {
         connector: createConnectorStatus({ locked: true }),
       })
       const cells = wrapper.findAll('td')
-      expect(cells[4].text()).toBe('Yes')
+      expect(cells[2].text()).toBe('Yes')
     })
 
     it('should show Lock button when connector is not locked', () => {

--- a/ui/web/tests/unit/CSConnector.test.ts
+++ b/ui/web/tests/unit/CSConnector.test.ts
@@ -201,4 +201,100 @@ describe('CSConnector', () => {
       )
     })
   })
+
+  describe('lock/unlock actions', () => {
+    it('should display Locked column as No when not locked', () => {
+      const wrapper = mountCSConnector()
+      const cells = wrapper.findAll('td')
+      expect(cells[4].text()).toBe('No')
+    })
+
+    it('should display Locked column as Yes when locked', () => {
+      const wrapper = mountCSConnector({
+        connector: createConnectorStatus({ locked: true }),
+      })
+      const cells = wrapper.findAll('td')
+      expect(cells[4].text()).toBe('Yes')
+    })
+
+    it('should show Lock button when connector is not locked', () => {
+      const wrapper = mountCSConnector()
+      const buttons = wrapper.findAll('button')
+      const lockBtn = buttons.find(b => b.text() === 'Lock')
+      expect(lockBtn).toBeDefined()
+      expect(buttons.find(b => b.text() === 'Unlock')).toBeUndefined()
+    })
+
+    it('should show Unlock button when connector is locked', () => {
+      const wrapper = mountCSConnector({
+        connector: createConnectorStatus({ locked: true }),
+      })
+      const buttons = wrapper.findAll('button')
+      const unlockBtn = buttons.find(b => b.text() === 'Unlock')
+      expect(unlockBtn).toBeDefined()
+      expect(buttons.find(b => b.text() === 'Lock')).toBeUndefined()
+    })
+
+    it('should call lockConnector with correct params', async () => {
+      const wrapper = mountCSConnector()
+      const buttons = wrapper.findAll('button')
+      const lockBtn = buttons.find(b => b.text() === 'Lock')
+      await lockBtn?.trigger('click')
+      await flushPromises()
+      expect(mockClient.lockConnector).toHaveBeenCalledWith(TEST_HASH_ID, 1)
+    })
+
+    it('should call unlockConnector with correct params', async () => {
+      const wrapper = mountCSConnector({
+        connector: createConnectorStatus({ locked: true }),
+      })
+      const buttons = wrapper.findAll('button')
+      const unlockBtn = buttons.find(b => b.text() === 'Unlock')
+      await unlockBtn?.trigger('click')
+      await flushPromises()
+      expect(mockClient.unlockConnector).toHaveBeenCalledWith(TEST_HASH_ID, 1)
+    })
+
+    it('should show success toast after locking connector', async () => {
+      const wrapper = mountCSConnector()
+      const buttons = wrapper.findAll('button')
+      const lockBtn = buttons.find(b => b.text() === 'Lock')
+      await lockBtn?.trigger('click')
+      await flushPromises()
+      expect(toastMock.success).toHaveBeenCalledWith('Connector successfully locked')
+    })
+
+    it('should show error toast on lock failure', async () => {
+      mockClient.lockConnector.mockRejectedValueOnce(new Error('fail'))
+      const wrapper = mountCSConnector()
+      const buttons = wrapper.findAll('button')
+      const lockBtn = buttons.find(b => b.text() === 'Lock')
+      await lockBtn?.trigger('click')
+      await flushPromises()
+      expect(toastMock.error).toHaveBeenCalledWith('Error at locking connector')
+    })
+
+    it('should show success toast after unlocking connector', async () => {
+      const wrapper = mountCSConnector({
+        connector: createConnectorStatus({ locked: true }),
+      })
+      const buttons = wrapper.findAll('button')
+      const unlockBtn = buttons.find(b => b.text() === 'Unlock')
+      await unlockBtn?.trigger('click')
+      await flushPromises()
+      expect(toastMock.success).toHaveBeenCalledWith('Connector successfully unlocked')
+    })
+
+    it('should show error toast on unlock failure', async () => {
+      mockClient.unlockConnector.mockRejectedValueOnce(new Error('fail'))
+      const wrapper = mountCSConnector({
+        connector: createConnectorStatus({ locked: true }),
+      })
+      const buttons = wrapper.findAll('button')
+      const unlockBtn = buttons.find(b => b.text() === 'Unlock')
+      await unlockBtn?.trigger('click')
+      await flushPromises()
+      expect(toastMock.error).toHaveBeenCalledWith('Error at unlocking connector')
+    })
+  })
 })

--- a/ui/web/tests/unit/UIClient.test.ts
+++ b/ui/web/tests/unit/UIClient.test.ts
@@ -627,4 +627,33 @@ describe('UIClient', () => {
       })
     })
   })
+
+  describe('connector lock operations', () => {
+    let client: UIClient
+    let sendRequestSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      client = UIClient.getInstance(createUIServerConfig())
+      // @ts-expect-error — accessing private method for testing
+      sendRequestSpy = vi.spyOn(client, 'sendRequest').mockResolvedValue({
+        status: ResponseStatus.SUCCESS,
+      })
+    })
+
+    it('should send LOCK_CONNECTOR with hashIds and connectorId', async () => {
+      await client.lockConnector(TEST_HASH_ID, 1)
+      expect(sendRequestSpy).toHaveBeenCalledWith(ProcedureName.LOCK_CONNECTOR, {
+        connectorId: 1,
+        hashIds: [TEST_HASH_ID],
+      })
+    })
+
+    it('should send UNLOCK_CONNECTOR with hashIds and connectorId', async () => {
+      await client.unlockConnector(TEST_HASH_ID, 2)
+      expect(sendRequestSpy).toHaveBeenCalledWith(ProcedureName.UNLOCK_CONNECTOR, {
+        connectorId: 2,
+        hashIds: [TEST_HASH_ID],
+      })
+    })
+  })
 })

--- a/ui/web/tests/unit/helpers.ts
+++ b/ui/web/tests/unit/helpers.ts
@@ -19,6 +19,7 @@ export interface MockUIClient {
   deleteChargingStation: ReturnType<typeof vi.fn>
   listChargingStations: ReturnType<typeof vi.fn>
   listTemplates: ReturnType<typeof vi.fn>
+  lockConnector: ReturnType<typeof vi.fn>
   openConnection: ReturnType<typeof vi.fn>
   registerWSEventListener: ReturnType<typeof vi.fn>
   setConfiguration: ReturnType<typeof vi.fn>
@@ -32,6 +33,7 @@ export interface MockUIClient {
   stopChargingStation: ReturnType<typeof vi.fn>
   stopSimulator: ReturnType<typeof vi.fn>
   stopTransaction: ReturnType<typeof vi.fn>
+  unlockConnector: ReturnType<typeof vi.fn>
   unregisterWSEventListener: ReturnType<typeof vi.fn>
 }
 
@@ -116,6 +118,7 @@ export function createMockUIClient (): MockUIClient {
     deleteChargingStation: vi.fn().mockResolvedValue(successResponse),
     listChargingStations: vi.fn().mockResolvedValue({ ...successResponse, chargingStations: [] }),
     listTemplates: vi.fn().mockResolvedValue({ ...successResponse, templates: [] }),
+    lockConnector: vi.fn().mockResolvedValue(successResponse),
     openConnection: vi.fn().mockResolvedValue(successResponse),
     registerWSEventListener: vi.fn(),
     setConfiguration: vi.fn(),
@@ -131,6 +134,7 @@ export function createMockUIClient (): MockUIClient {
     stopChargingStation: vi.fn().mockResolvedValue(successResponse),
     stopSimulator: vi.fn().mockResolvedValue(successResponse),
     stopTransaction: vi.fn().mockResolvedValue(successResponse),
+    unlockConnector: vi.fn().mockResolvedValue(successResponse),
     unregisterWSEventListener: vi.fn(),
   }
 }


### PR DESCRIPTION
## PR Checklist

- [x] Please add a description of your changes.
- [x] Please ensure title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] We need your changes to come with unit tests in order to keep this project in quality and easy to maintain.
- [x] If your changes contain any new feature please be sure to document it.
- [x] Please add a link to the open issue or task that this pull request will resolve.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

---

## Description

Add cable retention lock state simulation (`locked: boolean`) to connectors, implementing the full lock lifecycle as defined by the OCPP specs.

Relates to #1227 (partial — adds the connector-level simulation infrastructure).

### Lock lifecycle (per OCPP spec)

The cable retention lock (ConnectorPlugRetentionLock in OCPP 2.0.1) prevents on-load disconnection and cable theft. Its lifecycle:

1. **Auto-lock on transaction start** — OCPP 1.6 §4.9 / OCPP 2.0.1 E07: the lock engages when a transaction is accepted
2. **Locked during charge** — the lock stays engaged throughout the transaction
3. **Auto-unlock on normal transaction end** — OCPP 1.6: *"SHALL unlock the cable (if not permanently attached)"* / OCPP 2.0.1 E07.FR.07: same
4. **Unlock via OCPP command** — `UnlockConnector` sets `locked = false` (both stacks)
5. **Manual lock/unlock via UI** — `lockConnector` / `unlockConnector` commands for operator control

### What this changes

- **New `locked` field on `ConnectorStatus`** — tracks the physical cable retention lock state
- **Auto-lock** — `locked = true` set when transaction starts (OCPP 1.6 `OCPP16ResponseService` + OCPP 2.0.1 `OCPP20ResponseService`)
- **Auto-unlock** — `locked = false` set on normal transaction termination (`OCPP16ResponseService` + `OCPP20ServiceUtils`)
- **OCPP UnlockConnector** — both 1.6 (`OCPP16IncomingRequestService`) and 2.0.1 (`OCPP20IncomingRequestService`) handlers set `locked = false`
- **UI commands** — `lockConnector(connectorId)` / `unlockConnector(connectorId)` with connector 0 and existence validation
- **Web UI** — Lock/Unlock toggle buttons + Locked column (before Transaction column) on connector cards
- **MCP / WebSocket** — two new procedures: `lockConnector`, `unlockConnector`

### Design decisions

- **No template tunable** — lock simulation always active, no configuration needed
- **Lock ≠ OCPP status** — locking/unlocking does not trigger StatusNotification; it tracks internal physical state
- **Identical behavior across stacks** — dictated by physics, not protocol

### Quality

- All quality gates pass with zero warnings
- 7 backend + 12 frontend new unit tests
- Coverage thresholds met