### PR TITLE
fix(cli): make high-level OCPP commands version-aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ temp/
 performanceRecords.json
 performanceRecords.json.lock
 *.db
+.hermes/

--- a/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
+++ b/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
@@ -441,7 +441,6 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
   private async handleStopTransaction (
     requestPayload?: BroadcastChannelRequestPayload
   ): Promise<StopTransactionResponse> {
-    // OCPP 1.6 only. For OCPP 2.0.x, the CLI dispatches via ProcedureName.TRANSACTION_EVENT.
     return await this.chargingStation.ocppRequestService.requestHandler<
       StopTransactionRequest,
       StopTransactionResponse

--- a/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
+++ b/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
@@ -441,7 +441,7 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
   private async handleStopTransaction (
     requestPayload?: BroadcastChannelRequestPayload
   ): Promise<StopTransactionResponse> {
-    // OCPP 1.6 only: the CLI routes OCPP 2.0.x stop requests through TRANSACTION_EVENT / passthrough.
+    // OCPP 1.6 only. For OCPP 2.0.x, the CLI dispatches via ProcedureName.TRANSACTION_EVENT.
     return await this.chargingStation.ocppRequestService.requestHandler<
       StopTransactionRequest,
       StopTransactionResponse

--- a/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
+++ b/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
@@ -441,6 +441,7 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
   private async handleStopTransaction (
     requestPayload?: BroadcastChannelRequestPayload
   ): Promise<StopTransactionResponse> {
+    // OCPP 1.6 only: the CLI routes OCPP 2.0.x stop requests through TRANSACTION_EVENT / passthrough.
     return await this.chargingStation.ocppRequestService.requestHandler<
       StopTransactionRequest,
       StopTransactionResponse

--- a/src/types/UIProtocol.ts
+++ b/src/types/UIProtocol.ts
@@ -41,12 +41,15 @@ export enum ProcedureName {
   START_AUTOMATIC_TRANSACTION_GENERATOR = 'startAutomaticTransactionGenerator',
   START_CHARGING_STATION = 'startChargingStation',
   START_SIMULATOR = 'startSimulator',
+  /** OCPP 1.6 only. Use TRANSACTION_EVENT for OCPP 2.0.x. */
   START_TRANSACTION = 'startTransaction',
   STATUS_NOTIFICATION = 'statusNotification',
   STOP_AUTOMATIC_TRANSACTION_GENERATOR = 'stopAutomaticTransactionGenerator',
   STOP_CHARGING_STATION = 'stopChargingStation',
   STOP_SIMULATOR = 'stopSimulator',
+  /** OCPP 1.6 only. Use TRANSACTION_EVENT for OCPP 2.0.x. */
   STOP_TRANSACTION = 'stopTransaction',
+  /** OCPP 2.0.x only. Use START_TRANSACTION / STOP_TRANSACTION for OCPP 1.6. */
   TRANSACTION_EVENT = 'transactionEvent',
   UNLOCK_CONNECTOR = 'unlockConnector',
 }

--- a/ui/cli/README.md
+++ b/ui/cli/README.md
@@ -195,26 +195,28 @@ evse-cli atg stop [hashId...]  [--connector-ids <ids...>]  # Stop ATG
 #### transaction
 
 ```shell
-evse-cli transaction start --connector-id <id> --id-tag <tag> [hashId...]
-evse-cli transaction stop --transaction-id <id> [hashId...]
+evse-cli transaction start --connector-id <id> --id-tag <tag> [--evse-id <id>] [hashId...]
+evse-cli transaction stop --transaction-id <id> [--connector-id <id>] [hashId...]
 ```
+
+Both commands auto-detect the station's OCPP version and adapt the procedure and payload (see [Version-aware commands](#version-aware-commands)). The `-p, --payload` option uses the OCPP 1.6 procedure; for 2.0.x raw payloads use `ocpp transaction-event -p`.
 
 #### ocpp
 
 Request charging station(s) to send OCPP messages to the CSMS:
 
 ```shell
-evse-cli ocpp heartbeat [hashId...]                                                               # Heartbeat
-evse-cli ocpp authorize --id-tag <tag> [hashId...]                                                # Authorize
-evse-cli ocpp boot-notification [hashId...]                                                       # BootNotification
-evse-cli ocpp status-notification --connector-id <id> --error-code <code> --status <status> [hashId...]  # StatusNotification
-evse-cli ocpp meter-values --connector-id <id> [hashId...]                                        # MeterValues
-evse-cli ocpp data-transfer --vendor-id <id> [--message-id <id>] [--data <json>] [hashId...]      # DataTransfer
+evse-cli ocpp heartbeat [hashId...]                                                                              # Heartbeat
+evse-cli ocpp authorize --id-tag <tag> [hashId...]                                                               # Authorize
+evse-cli ocpp boot-notification [hashId...]                                                                      # BootNotification
+evse-cli ocpp status-notification --connector-id <id> [--error-code <code>] --status <status> [--evse-id <id>] [hashId...]  # StatusNotification
+evse-cli ocpp meter-values --connector-id <id> [--evse-id <id>] [hashId...]                                      # MeterValues
+evse-cli ocpp data-transfer [--vendor-id <id>] [--message-id <id>] [--data <json>] [hashId...]                   # DataTransfer
 ```
 
 Other OCPP commands (no extra options): `diagnostics-status-notification`, `firmware-status-notification`, `get-15118-ev-certificate`, `get-certificate-status`, `log-status-notification`, `notify-customer-information`, `notify-report`, `security-event-notification`, `sign-certificate`, `transaction-event`.
 
-All OCPP commands accept `-p, --payload <json|@file|->` to pass a custom JSON payload:
+All OCPP and transaction commands accept `-p, --payload <json|@file|->` to pass a custom JSON payload:
 
 ```shell
 evse-cli ocpp boot-notification -p '{"reason":"PowerUp"}' [hashId...]        # Inline JSON
@@ -223,6 +225,20 @@ cat boot.json | jq '.reason = "RemoteReset"' | evse-cli ocpp boot-notification -
 ```
 
 The payload is merged with command-specific options (e.g., `--id-tag`, `--connector-id`). Command options take precedence over payload fields.
+
+#### Version-aware commands
+
+Commands with typed options (`authorize`, `meter-values`, `status-notification`, `transaction start`, `transaction stop`) auto-detect the target station's OCPP version and build the appropriate payload:
+
+| Option             | OCPP 1.6                           | OCPP 2.0.x                                  |
+| ------------------ | ---------------------------------- | ------------------------------------------- |
+| `--id-tag`         | Sent as `idTag`                    | Wrapped as `idToken` (type: ISO14443)       |
+| `--connector-id`   | Sent as `connectorId`              | Sent as `connectorId` (server derives EVSE) |
+| `--evse-id`        | N/A                                | Sent as `evseId`                            |
+| `--error-code`     | Required for `status-notification` | N/A                                         |
+| `--transaction-id` | Integer                            | UUID string                                 |
+
+When `-p` is provided, version detection is skipped and the raw payload is passed through as-is.
 
 #### supervision
 

--- a/ui/cli/README.md
+++ b/ui/cli/README.md
@@ -213,8 +213,10 @@ evse-cli ocpp authorize --id-tag <tag> [hashId...]                              
 evse-cli ocpp boot-notification [hashId...]                                                                      # BootNotification
 evse-cli ocpp status-notification --connector-id <id> [--error-code <code>] --status <status> [--evse-id <id>] [hashId...]  # StatusNotification
 evse-cli ocpp meter-values [--connector-id <id>] [--evse-id <id>] [hashId...]                                     # MeterValues
-evse-cli ocpp data-transfer [--vendor-id <id>] [--message-id <id>] [--data <json>] [hashId...]                   # DataTransfer
+evse-cli ocpp data-transfer [--vendor-id <id>] [--message-id <id>] [--data <data>] [hashId...]                    # DataTransfer
 ```
+
+`meter-values` requires at least one of `--connector-id` or `--evse-id` when `-p` is not provided.
 
 Other OCPP commands (no extra options): `diagnostics-status-notification`, `firmware-status-notification`, `get-15118-ev-certificate`, `get-certificate-status`, `log-status-notification`, `notify-customer-information`, `notify-report`, `security-event-notification`, `sign-certificate`, `transaction-event`.
 
@@ -226,19 +228,19 @@ evse-cli ocpp boot-notification -p @collections/boot.json [hashId...]        # F
 cat boot.json | jq '.reason = "RemoteReset"' | evse-cli ocpp boot-notification -p - [hashId...]  # From stdin
 ```
 
-The payload is merged with command-specific options (e.g., `--id-tag`, `--connector-id`). Command options take precedence over payload fields.
+For `data-transfer`, command options merge with `-p` payload (options take precedence). For all other typed-option commands, `-p` conflicts with typed options and they cannot be combined.
 
 #### Version-aware commands
 
 Commands with typed options (`authorize`, `meter-values`, `status-notification`, `transaction start`, `transaction stop`) auto-detect the target station's OCPP version and build the appropriate payload:
 
-| Option             | OCPP 1.6                           | OCPP 2.0.x                                  |
-| ------------------ | ---------------------------------- | ------------------------------------------- |
-| `--id-tag`         | Sent as `idTag`                    | Wrapped as `idToken` (type: ISO14443)       |
-| `--connector-id`   | Sent as `connectorId`              | Sent as `connectorId` (server derives EVSE) |
-| `--evse-id`        | N/A                                | Sent as `evseId`                            |
-| `--error-code`     | Required for `status-notification` | N/A                                         |
-| `--transaction-id` | Integer                            | UUID string                                 |
+| Option             | OCPP 1.6                           | OCPP 2.0.x                                             |
+| ------------------ | ---------------------------------- | ------------------------------------------------------ |
+| `--id-tag`         | Sent as `idTag`                    | Wrapped as `idToken` (type: ISO14443)                  |
+| `--connector-id`   | Sent as `connectorId`              | Sent as `connectorId`; required for `transaction stop` |
+| `--evse-id`        | N/A                                | Sent as `evseId`                                       |
+| `--error-code`     | Required for `status-notification` | N/A                                                    |
+| `--transaction-id` | Integer                            | UUID string                                            |
 
 When `-p` is provided, version detection is skipped and the raw payload is passed through as-is.
 

--- a/ui/cli/README.md
+++ b/ui/cli/README.md
@@ -143,7 +143,7 @@ evse-cli simulator stop    # Stop the simulator
 #### station
 
 ```shell
-evse-cli station list                          # List all charging stations
+evse-cli station list                          # List all stations
 evse-cli station start [hashId...]             # Start station(s)
 evse-cli station stop [hashId...]              # Stop station(s)
 evse-cli station add -t <template> -n <count>  # Add stations from template

--- a/ui/cli/README.md
+++ b/ui/cli/README.md
@@ -152,12 +152,14 @@ evse-cli station delete [hashId...]            # Delete station(s)
 
 **`station add` options:**
 
-| Option                    | Required | Description               |
-| ------------------------- | -------- | ------------------------- |
-| `-t, --template <name>`   | Yes      | Station template name     |
-| `-n, --count <n>`         | Yes      | Number of stations to add |
-| `--supervision-url <url>` | No       | Override supervision URL  |
-| `--auto-start`            | No       | Auto-start added stations |
+| Option                    | Required | Description                          |
+| ------------------------- | -------- | ------------------------------------ |
+| `-t, --template <name>`   | Yes      | Station template name                |
+| `-n, --count <n>`         | Yes      | Number of stations to add            |
+| `--supervision-url <url>` | No       | Override supervision URL             |
+| `--auto-start`            | No       | Auto-start added stations            |
+| `--persistent-config`     | No       | Enable persistent OCPP configuration |
+| `--ocpp-strict`           | No       | Enable OCPP strict compliance        |
 
 **`station delete` options:**
 
@@ -188,8 +190,8 @@ evse-cli connector unlock --connector-id <id> [hashId...]  # Unlock connector
 #### atg
 
 ```shell
-evse-cli atg start [hashId...] [--connector-ids <ids...>]  # Start ATG
-evse-cli atg stop [hashId...]  [--connector-ids <ids...>]  # Stop ATG
+evse-cli atg start [hashId...] [--connector-ids <id,...>]  # Start ATG
+evse-cli atg stop [hashId...]  [--connector-ids <id,...>]  # Stop ATG
 ```
 
 #### transaction
@@ -210,7 +212,7 @@ evse-cli ocpp heartbeat [hashId...]                                             
 evse-cli ocpp authorize --id-tag <tag> [hashId...]                                                               # Authorize
 evse-cli ocpp boot-notification [hashId...]                                                                      # BootNotification
 evse-cli ocpp status-notification --connector-id <id> [--error-code <code>] --status <status> [--evse-id <id>] [hashId...]  # StatusNotification
-evse-cli ocpp meter-values --connector-id <id> [--evse-id <id>] [hashId...]                                      # MeterValues
+evse-cli ocpp meter-values [--connector-id <id>] [--evse-id <id>] [hashId...]                                     # MeterValues
 evse-cli ocpp data-transfer [--vendor-id <id>] [--message-id <id>] [--data <json>] [hashId...]                   # DataTransfer
 ```
 

--- a/ui/cli/README.md
+++ b/ui/cli/README.md
@@ -212,11 +212,12 @@ evse-cli ocpp heartbeat [hashId...]                                             
 evse-cli ocpp authorize --id-tag <tag> [hashId...]                                                               # Authorize
 evse-cli ocpp boot-notification [hashId...]                                                                      # BootNotification
 evse-cli ocpp status-notification --connector-id <id> [--error-code <code>] --status <status> [--evse-id <id>] [hashId...]  # StatusNotification
-evse-cli ocpp meter-values [--connector-id <id>] [--evse-id <id>] [hashId...]                                     # MeterValues
+evse-cli ocpp meter-values --connector-id <id> [hashId...]                                                       # MeterValues (OCPP 1.6)
+evse-cli ocpp meter-values --evse-id <id> [hashId...]                                                            # MeterValues (OCPP 2.0.x)
 evse-cli ocpp data-transfer [--vendor-id <id>] [--message-id <id>] [--data <data>] [hashId...]                    # DataTransfer
 ```
 
-`meter-values` requires at least one of `--connector-id` or `--evse-id` when `-p` is not provided.
+`meter-values` requires `--connector-id` for OCPP 1.6 and `--evse-id` for OCPP 2.0.x.
 
 Other OCPP commands (no extra options): `diagnostics-status-notification`, `firmware-status-notification`, `get-15118-ev-certificate`, `get-certificate-status`, `log-status-notification`, `notify-customer-information`, `notify-report`, `security-event-notification`, `sign-certificate`, `transaction-event`.
 
@@ -234,13 +235,13 @@ For `data-transfer`, command options merge with `-p` payload (options take prece
 
 Commands with typed options (`authorize`, `meter-values`, `status-notification`, `transaction start`, `transaction stop`) auto-detect the target station's OCPP version and build the appropriate payload:
 
-| Option             | OCPP 1.6                           | OCPP 2.0.x                                             |
-| ------------------ | ---------------------------------- | ------------------------------------------------------ |
-| `--id-tag`         | Sent as `idTag`                    | Wrapped as `idToken` (type: ISO14443)                  |
-| `--connector-id`   | Sent as `connectorId`              | Sent as `connectorId`; required for `transaction stop` |
-| `--evse-id`        | N/A                                | Sent as `evseId`                                       |
-| `--error-code`     | Required for `status-notification` | N/A                                                    |
-| `--transaction-id` | Integer                            | UUID string                                            |
+| Option             | OCPP 1.6                           | OCPP 2.0.x                                                    |
+| ------------------ | ---------------------------------- | ------------------------------------------------------------- |
+| `--id-tag`         | Sent as `idTag`                    | Wrapped as `idToken` (type: ISO14443)                         |
+| `--connector-id`   | Sent as `connectorId`              | Required for `transaction stop`; not valid for `meter-values` |
+| `--evse-id`        | N/A                                | Sent as `evseId`; required for `meter-values`                 |
+| `--error-code`     | Required for `status-notification` | N/A                                                           |
+| `--transaction-id` | Integer                            | UUID string                                                   |
 
 When `-p` is provided, version detection is skipped and the raw payload is passed through as-is.
 

--- a/ui/cli/skills/evse-simulator/SKILL.md
+++ b/ui/cli/skills/evse-simulator/SKILL.md
@@ -116,11 +116,12 @@ evse-cli ocpp heartbeat [hashId...]
 evse-cli ocpp boot-notification [hashId...]
 evse-cli ocpp authorize --id-tag <tag> [hashId...]
 evse-cli ocpp status-notification --connector-id <id> [--error-code <code>] --status <status> [--evse-id <id>] [hashId...]
-evse-cli ocpp meter-values [--connector-id <id>] [--evse-id <id>] [hashId...]
+evse-cli ocpp meter-values --connector-id <id> [hashId...]                    # OCPP 1.6
+evse-cli ocpp meter-values --evse-id <id> [hashId...]                        # OCPP 2.0.x
 evse-cli ocpp data-transfer [--vendor-id <id>] [--message-id <id>] [--data <data>] [hashId...]
 ```
 
-`meter-values` requires at least one of `--connector-id` or `--evse-id` when `-p` is not provided.
+`meter-values` requires `--connector-id` for OCPP 1.6 and `--evse-id` for OCPP 2.0.x.
 
 Other OCPP commands (no extra options): `diagnostics-status-notification`, `firmware-status-notification`, `get-15118-ev-certificate`, `get-certificate-status`, `log-status-notification`, `notify-customer-information`, `notify-report`, `security-event-notification`, `sign-certificate`, `transaction-event`.
 
@@ -138,8 +139,8 @@ Commands with typed options (`authorize`, `meter-values`, `status-notification`,
 
 - `--id-tag`: sent as `idTag` (1.6) or wrapped as `idToken` (2.0.x)
 - `--error-code`: required for `status-notification` on 1.6 only
-- `--evse-id`: OCPP 2.0.x only; derived from connector ID if omitted
-- `--connector-id` on `transaction stop`: required for OCPP 2.0.x
+- `--evse-id`: OCPP 2.0.x only; required for `meter-values`
+- `--connector-id`: OCPP 1.6 for `meter-values`; required for `transaction stop` on 2.0.x
 - `--transaction-id`: integer (1.6) or UUID string (2.0.x)
 
 When `-p` is provided, version detection is skipped and the raw payload is passed through.

--- a/ui/cli/skills/evse-simulator/SKILL.md
+++ b/ui/cli/skills/evse-simulator/SKILL.md
@@ -117,8 +117,10 @@ evse-cli ocpp boot-notification [hashId...]
 evse-cli ocpp authorize --id-tag <tag> [hashId...]
 evse-cli ocpp status-notification --connector-id <id> [--error-code <code>] --status <status> [--evse-id <id>] [hashId...]
 evse-cli ocpp meter-values [--connector-id <id>] [--evse-id <id>] [hashId...]
-evse-cli ocpp data-transfer [--vendor-id <id>] [--message-id <id>] [--data <json>] [hashId...]
+evse-cli ocpp data-transfer [--vendor-id <id>] [--message-id <id>] [--data <data>] [hashId...]
 ```
+
+`meter-values` requires at least one of `--connector-id` or `--evse-id` when `-p` is not provided.
 
 Other OCPP commands (no extra options): `diagnostics-status-notification`, `firmware-status-notification`, `get-15118-ev-certificate`, `get-certificate-status`, `log-status-notification`, `notify-customer-information`, `notify-report`, `security-event-notification`, `sign-certificate`, `transaction-event`.
 

--- a/ui/cli/skills/evse-simulator/SKILL.md
+++ b/ui/cli/skills/evse-simulator/SKILL.md
@@ -99,9 +99,11 @@ evse-cli atg stop [hashId...]                          # Stop ATG
 ### Transactions
 
 ```shell
-evse-cli transaction start --connector-id <id> --id-tag <tag> [hashId...]
-evse-cli transaction stop --transaction-id <id> [hashId...]
+evse-cli transaction start --connector-id <id> --id-tag <tag> [--evse-id <id>] [hashId...]
+evse-cli transaction stop --transaction-id <id> [--connector-id <id>] [hashId...]
 ```
+
+Both commands auto-detect the station's OCPP version and adapt the procedure and payload. The `-p` option uses the OCPP 1.6 procedure; for 2.0.x raw payloads use `ocpp transaction-event -p`.
 
 ### OCPP Messages
 
@@ -111,20 +113,32 @@ Request station(s) to send OCPP messages to the CSMS:
 evse-cli ocpp heartbeat [hashId...]
 evse-cli ocpp boot-notification [hashId...]
 evse-cli ocpp authorize --id-tag <tag> [hashId...]
-evse-cli ocpp status-notification --connector-id <id> --error-code <code> --status <status> [hashId...]
-evse-cli ocpp meter-values --connector-id <id> [hashId...]
-evse-cli ocpp data-transfer --vendor-id <id> [--message-id <id>] [--data <json>] [hashId...]
+evse-cli ocpp status-notification --connector-id <id> [--error-code <code>] --status <status> [--evse-id <id>] [hashId...]
+evse-cli ocpp meter-values --connector-id <id> [--evse-id <id>] [hashId...]
+evse-cli ocpp data-transfer [--vendor-id <id>] [--message-id <id>] [--data <json>] [hashId...]
 ```
 
 Other OCPP commands (no extra options): `diagnostics-status-notification`, `firmware-status-notification`, `get-15118-ev-certificate`, `get-certificate-status`, `log-status-notification`, `notify-customer-information`, `notify-report`, `security-event-notification`, `sign-certificate`, `transaction-event`.
 
-All OCPP commands accept `-p, --payload <json|@file|->` for custom JSON payloads:
+All OCPP and transaction commands accept `-p, --payload <json|@file|->` for custom JSON payloads:
 
 ```shell
 evse-cli ocpp boot-notification -p '{"reason":"PowerUp"}' [hashId...]  # Inline
 evse-cli ocpp boot-notification -p @payload.json [hashId...]           # From file
 cat payload.json | evse-cli ocpp boot-notification -p - [hashId...]    # From stdin
 ```
+
+### Version-aware commands
+
+Commands with typed options (`authorize`, `meter-values`, `status-notification`, `transaction start`, `transaction stop`) auto-detect the target station's OCPP version and build the appropriate payload. Key differences:
+
+- `--id-tag`: sent as `idTag` (1.6) or wrapped as `idToken` (2.0.x)
+- `--error-code`: required for `status-notification` on 1.6 only
+- `--evse-id`: OCPP 2.0.x only; derived from connector ID if omitted
+- `--connector-id` on `transaction stop`: required for OCPP 2.0.x
+- `--transaction-id`: integer (1.6) or UUID string (2.0.x)
+
+When `-p` is provided, version detection is skipped and the raw payload is passed through.
 
 ### Supervision
 

--- a/ui/cli/skills/evse-simulator/SKILL.md
+++ b/ui/cli/skills/evse-simulator/SKILL.md
@@ -169,6 +169,7 @@ evse-cli performance stats   # Get performance statistics
 | `0`   | Success                          |
 | `1`   | Error (connection, server, auth) |
 | `130` | Interrupted (Ctrl+C)             |
+| `143` | Terminated (SIGTERM)             |
 
 ## hashId Convention
 

--- a/ui/cli/skills/evse-simulator/SKILL.md
+++ b/ui/cli/skills/evse-simulator/SKILL.md
@@ -66,6 +66,7 @@ evse-cli station add -t <template> -n <count>             # Add stations
 evse-cli station add -t <template> -n 2 --auto-start      # Add and auto-start
 evse-cli station add -t <template> -n 1 --supervision-url ws://csms:8180/path
 evse-cli station delete [hashId...]                       # Delete station(s)
+evse-cli station delete --delete-config [hashId...]       # Delete with config files
 ```
 
 ### Templates
@@ -93,7 +94,8 @@ evse-cli connector unlock --connector-id <id> [hashId...]  # Unlock connector
 ```shell
 evse-cli atg start [hashId...]                         # Start ATG on all connectors
 evse-cli atg start --connector-ids 1,2 [hashId...]     # Start on specific connectors
-evse-cli atg stop [hashId...]                          # Stop ATG
+evse-cli atg stop [hashId...]                          # Stop ATG on all connectors
+evse-cli atg stop --connector-ids 1,2 [hashId...]      # Stop on specific connectors
 ```
 
 ### Transactions
@@ -114,7 +116,7 @@ evse-cli ocpp heartbeat [hashId...]
 evse-cli ocpp boot-notification [hashId...]
 evse-cli ocpp authorize --id-tag <tag> [hashId...]
 evse-cli ocpp status-notification --connector-id <id> [--error-code <code>] --status <status> [--evse-id <id>] [hashId...]
-evse-cli ocpp meter-values --connector-id <id> [--evse-id <id>] [hashId...]
+evse-cli ocpp meter-values [--connector-id <id>] [--evse-id <id>] [hashId...]
 evse-cli ocpp data-transfer [--vendor-id <id>] [--message-id <id>] [--data <json>] [hashId...]
 ```
 
@@ -167,7 +169,7 @@ evse-cli performance stats   # Get performance statistics
 
 ## hashId Convention
 
-Omitting `[hashId...]` applies the command to ALL stations. Pass one or more hash IDs to target specific stations. Get hash IDs from `evse-cli station list` or `evse-cli --json station list`.
+Omitting `[hashId...]` applies the command to ALL stations. Pass one or more hash IDs to target specific stations. Hash IDs support prefix matching — a short unambiguous prefix works in place of the full ID. Get hash IDs from `evse-cli station list` or `evse-cli --json station list`.
 
 ## Common Workflows
 

--- a/ui/cli/src/commands/action.ts
+++ b/ui/cli/src/commands/action.ts
@@ -17,6 +17,10 @@ import { loadConfig } from '../config/loader.js'
 import { createFormatter } from '../output/formatter.js'
 import { resolvePayload } from './resolve-payload.js'
 
+export const MIXED_OCPP_VERSION_ERROR =
+  'Cannot determine a common OCPP version for the targeted stations. ' +
+  'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
+
 export const parseInteger = (value: string): number => {
   const n = Number.parseInt(value, 10)
   if (Number.isNaN(n)) {
@@ -99,9 +103,7 @@ export const resolveOcppVersionFromList = (
   const targeted =
     hashIds.length === 0
       ? chargingStations
-      : chargingStations.filter(cs =>
-        hashIds.some(id => cs.stationInfo.hashId === id || cs.stationInfo.hashId.startsWith(id))
-      )
+      : chargingStations.filter(cs => hashIds.some(id => cs.stationInfo.hashId.startsWith(id)))
 
   if (targeted.length === 0) return undefined
 
@@ -129,6 +131,43 @@ export const resolveOcppVersion = async (
 ): Promise<OCPPVersion | undefined> => {
   const listResponse = await fetchStationList(config)
   return resolveOcppVersionFromList(hashIds, listResponse.chargingStations)
+}
+
+/**
+ * Loads config from program options, resolves short hash-ID prefixes to full
+ * hashes in a single station-list fetch, and returns the common OCPP version
+ * together with the resolved hash IDs. Passing the returned resolvedHashIds
+ * into the payload before calling runAction prevents a second station-list fetch.
+ * @param program - Commander root program (provides config and server URL options)
+ * @param hashIds - station hash IDs or unique hash-ID prefixes to target
+ * @returns the common OCPPVersion (or undefined) and the fully-resolved hash IDs
+ */
+export const resolveOcppVersionFromProgram = async (
+  program: Command,
+  hashIds: string[]
+): Promise<{ ocppVersion: OCPPVersion | undefined; resolvedHashIds: string[] }> => {
+  const rootOpts = program.opts<GlobalOptions>()
+  const config = await loadConfig({ configPath: rootOpts.config, url: rootOpts.serverUrl })
+  const listResponse = await fetchStationList(config)
+  const resolvedHashIds =
+    hashIds.length === 0
+      ? hashIds
+      : (() => {
+          const allHashIds = listResponse.chargingStations.map(cs => cs.stationInfo.hashId)
+          return hashIds.map(input => {
+            if (input.length >= MIN_FULL_HASH_LENGTH) return input
+            const matches = allHashIds.filter(full => full.startsWith(input))
+            if (matches.length === 1) return matches[0]
+            if (matches.length === 0) {
+              throw new Error(`No station found matching hash prefix '${input}'`)
+            }
+            throw new Error(
+              `Ambiguous hash prefix '${input}' matches ${matches.length.toString()} stations`
+            )
+          })
+        })()
+  const ocppVersion = resolveOcppVersionFromList(hashIds, listResponse.chargingStations)
+  return { ocppVersion, resolvedHashIds }
 }
 
 export const runAction = async (

--- a/ui/cli/src/commands/action.ts
+++ b/ui/cli/src/commands/action.ts
@@ -17,14 +17,14 @@ import { loadConfig } from '../config/loader.js'
 import { createFormatter } from '../output/formatter.js'
 import { resolvePayload } from './resolve-payload.js'
 
-export const NO_STATIONS_ERROR =
+const NO_STATIONS_ERROR =
   'No charging stations available. Start stations before running this command.'
 
-export const MIXED_OCPP_VERSION_ERROR =
+const MIXED_OCPP_VERSION_ERROR =
   'Cannot determine a common OCPP version for the targeted stations. ' +
   'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
 
-export const UNKNOWN_OCPP_VERSION_ERROR =
+const UNKNOWN_OCPP_VERSION_ERROR =
   'The targeted station(s) have not reported their OCPP version yet. ' +
   'Ensure stations are connected and registered, or use -p to pass the payload directly.'
 
@@ -186,6 +186,17 @@ export const resolveOcppVersionFromProgram = async (
   return { config, ocppVersion, resolvedHashIds }
 }
 
+const formatError = (program: Command, error: unknown): void => {
+  const rootOpts = program.opts<GlobalOptions>()
+  const formatter = createFormatter(rootOpts.json)
+  if (error instanceof ServerFailureError) {
+    formatter.output(error.payload)
+  } else {
+    formatter.error(error)
+  }
+  process.exitCode = 1
+}
+
 export const handleActionErrors = async (
   program: Command,
   fn: () => Promise<void>
@@ -193,14 +204,7 @@ export const handleActionErrors = async (
   try {
     await fn()
   } catch (error: unknown) {
-    const rootOpts = program.opts<GlobalOptions>()
-    const formatter = createFormatter(rootOpts.json)
-    if (error instanceof ServerFailureError) {
-      formatter.output(error.payload)
-    } else {
-      formatter.error(error)
-    }
-    process.exitCode = 1
+    formatError(program, error)
   }
 }
 
@@ -235,11 +239,6 @@ export const runAction = async (
     await executeCommand({ config, formatter, payload: resolvedPayload, procedureName })
     process.exitCode = 0
   } catch (error: unknown) {
-    if (error instanceof ServerFailureError) {
-      formatter.output(error.payload)
-    } else {
-      formatter.error(error)
-    }
-    process.exitCode = 1
+    formatError(program, error)
   }
 }

--- a/ui/cli/src/commands/action.ts
+++ b/ui/cli/src/commands/action.ts
@@ -2,6 +2,7 @@ import type { Command } from 'commander'
 
 import process from 'node:process'
 import {
+  type OCPPVersion,
   ProcedureName,
   type RequestPayload,
   ResponseStatus,
@@ -27,15 +28,9 @@ export const parseInteger = (value: string): number => {
 // SHA-384 hex hashes are 96 chars. Treat anything >= half-length as a full hash (skip resolution).
 const MIN_FULL_HASH_LENGTH = 48
 
-const resolveShortHashIds = async (
-  hashIds: string[],
+const fetchStationList = async (
   config: UIServerConfigurationSection
-): Promise<string[]> => {
-  if (hashIds.length === 0) return []
-
-  const allFull = hashIds.every(id => id.length >= MIN_FULL_HASH_LENGTH)
-  if (allFull) return hashIds
-
+): Promise<StationListPayload> => {
   let response
   try {
     response = await executeCommand({
@@ -46,16 +41,26 @@ const resolveShortHashIds = async (
     })
   } catch (error: unknown) {
     const msg = error instanceof Error ? error.message : String(error)
-    throw new Error(`Failed to resolve hash ID prefixes: ${msg}`)
+    throw new Error(`Failed to fetch charging station list: ${msg}`)
   }
 
   if (response.status !== ResponseStatus.SUCCESS || !Array.isArray(response.chargingStations)) {
-    throw new Error(
-      `Failed to list charging stations for hash ID resolution (status: ${response.status})`
-    )
+    throw new Error(`Failed to list charging stations (status: ${response.status})`)
   }
 
-  const listResponse = response as StationListPayload
+  return response as StationListPayload
+}
+
+const resolveShortHashIds = async (
+  hashIds: string[],
+  config: UIServerConfigurationSection
+): Promise<string[]> => {
+  if (hashIds.length === 0) return []
+
+  const allFull = hashIds.every(id => id.length >= MIN_FULL_HASH_LENGTH)
+  if (allFull) return hashIds
+
+  const listResponse = await fetchStationList(config)
   const allHashIds = listResponse.chargingStations.map(cs => cs.stationInfo.hashId)
 
   return hashIds.map(input => {
@@ -70,6 +75,47 @@ const resolveShortHashIds = async (
       `Ambiguous hash prefix '${input}' matches ${matches.length.toString()} stations`
     )
   })
+}
+
+/**
+ * Pure helper: resolves the common OCPP version from a pre-fetched station list.
+ * Exported for unit testing; callers should use resolveOcppVersion instead.
+ * @param hashIds - station hash IDs (full or prefix) to target; empty means all stations
+ * @param chargingStations - station list to filter and inspect
+ * @returns the common OCPPVersion, or undefined if no match or heterogeneous versions
+ */
+export const resolveOcppVersionFromList = (
+  hashIds: string[],
+  chargingStations: { stationInfo: { hashId: string; ocppVersion?: OCPPVersion } }[]
+): OCPPVersion | undefined => {
+  const targeted =
+    hashIds.length === 0
+      ? chargingStations
+      : chargingStations.filter(cs =>
+        hashIds.some(id => cs.stationInfo.hashId === id || cs.stationInfo.hashId.startsWith(id))
+      )
+
+  if (targeted.length === 0) return undefined
+
+  const versions = new Set(targeted.map(cs => cs.stationInfo.ocppVersion))
+  if (versions.size !== 1) return undefined
+
+  return [...versions][0]
+}
+
+/**
+ * Returns the OCPP version shared by all targeted stations, or undefined when
+ * no stations match or the targeted stations run different versions.
+ * @param hashIds - station hash IDs (full or prefix) to target; empty means all stations
+ * @param config - UI server configuration
+ * @returns the common OCPPVersion, or undefined if unavailable / heterogeneous
+ */
+export const resolveOcppVersion = async (
+  hashIds: string[],
+  config: UIServerConfigurationSection
+): Promise<OCPPVersion | undefined> => {
+  const listResponse = await fetchStationList(config)
+  return resolveOcppVersionFromList(hashIds, listResponse.chargingStations)
 }
 
 export const runAction = async (

--- a/ui/cli/src/commands/action.ts
+++ b/ui/cli/src/commands/action.ts
@@ -44,7 +44,8 @@ export const parseInteger = (value: string, nameOrPrevious?: number | string): n
   return n
 }
 
-// SHA-384 hex hashes are 96 chars. Treat anything >= half-length as a full hash (skip resolution).
+// SHA-384 hex hashes are 96 chars. Inputs >= half-length skip prefix resolution
+// but are still validated against the station list (unknown IDs are rejected).
 const MIN_FULL_HASH_LENGTH = 48
 
 const fetchStationList = async (
@@ -148,8 +149,10 @@ export const resolveOcppVersionFromList = (
  * station-list fetch and config load.
  * @param program - Commander root program (provides config and server URL options)
  * @param hashIds - station hash IDs or unique hash-ID prefixes to target
- * @returns the common OCPPVersion (or undefined), the fully-resolved hash IDs,
+ * @returns the common OCPPVersion, the fully-resolved hash IDs,
  *   and the loaded UI server config
+ * @throws {Error} if no stations are available, hash IDs don't match, or the
+ *   targeted stations do not share a single known OCPP version
  */
 export const resolveOcppVersionFromProgram = async (
   program: Command,

--- a/ui/cli/src/commands/action.ts
+++ b/ui/cli/src/commands/action.ts
@@ -24,10 +24,22 @@ export const MIXED_OCPP_VERSION_ERROR =
   'Cannot determine a common OCPP version for the targeted stations. ' +
   'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
 
-export const parseInteger = (value: string): number => {
+export const UNKNOWN_OCPP_VERSION_ERROR =
+  'The targeted station(s) have not reported their OCPP version yet. ' +
+  'Ensure stations are connected and registered, or use -p to pass the payload directly.'
+
+export const UNSUPPORTED_OCPP_VERSION_ERROR =
+  'Unsupported OCPP version for this command. Use -p to pass the payload directly.'
+
+export const parseInteger = (value: string, nameOrPrevious?: number | string): number => {
   const n = Number.parseInt(value, 10)
   if (Number.isNaN(n)) {
-    throw new Error(`Expected integer, got '${value}'`)
+    const label = typeof nameOrPrevious === 'string' ? nameOrPrevious : undefined
+    throw new Error(
+      label != null
+        ? `${label}: expected integer, got '${value}'`
+        : `Expected integer, got '${value}'`
+    )
   }
   return n
 }
@@ -68,7 +80,10 @@ const fetchStationList = async (
  */
 const resolveShortHashIdsFromList = (hashIds: string[], allHashIds: string[]): string[] =>
   hashIds.map(input => {
-    if (input.length >= MIN_FULL_HASH_LENGTH) return input
+    if (input.length >= MIN_FULL_HASH_LENGTH) {
+      if (allHashIds.includes(input)) return input
+      throw new Error(`No station found matching hash ID '${input}'`)
+    }
 
     const matches = allHashIds.filter(full => full.startsWith(input))
     if (matches.length === 1) return matches[0]
@@ -99,16 +114,14 @@ const resolveShortHashIds = async (
  * Pure helper: resolves the common OCPP version from a pre-fetched station list.
  * Exported for unit testing; callers should use resolveOcppVersionFromProgram.
  *
- * Unlike resolveShortHashIdsFromList, this function never throws on ambiguous or
- * non-matching prefixes — it returns undefined instead.
+ * Unlike resolveShortHashIdsFromList, this function never throws.
  * @param hashIds - station hash IDs or unique hash-ID prefixes to target;
- *   each entry is matched if the station's hashId equals it or starts with it.
- *   An ambiguous prefix (matching multiple stations) or a non-matching prefix
- *   does not throw — both cases cause undefined to be returned.
+ *   each entry is matched via startsWith against station hashIds.
+ *   Non-matching prefixes are silently excluded from targeting (no throw).
  *   Pass an empty array to target all stations.
  * @param chargingStations - station list to filter and inspect
- * @returns the common OCPPVersion, or undefined if no station matches, the
- *   prefix is ambiguous, or the targeted stations run heterogeneous versions
+ * @returns the common OCPPVersion, or undefined if the targeted set is empty
+ *   or the targeted stations run heterogeneous versions
  */
 export const resolveOcppVersionFromList = (
   hashIds: string[],
@@ -143,7 +156,7 @@ export const resolveOcppVersionFromProgram = async (
   hashIds: string[]
 ): Promise<{
   config: UIServerConfigurationSection
-  ocppVersion: OCPPVersion | undefined
+  ocppVersion: OCPPVersion
   resolvedHashIds: string[]
 }> => {
   const rootOpts = program.opts<GlobalOptions>()
@@ -158,6 +171,16 @@ export const resolveOcppVersionFromProgram = async (
   const resolvedHashIds =
     hashIds.length === 0 ? hashIds : resolveShortHashIdsFromList(hashIds, allHashIds)
   const ocppVersion = resolveOcppVersionFromList(resolvedHashIds, listResponse.chargingStations)
+  if (ocppVersion == null) {
+    const targeted =
+      resolvedHashIds.length === 0
+        ? listResponse.chargingStations
+        : listResponse.chargingStations.filter(cs =>
+          resolvedHashIds.some(id => cs.stationInfo.hashId.startsWith(id))
+        )
+    const hasUnknown = targeted.some(cs => cs.stationInfo.ocppVersion == null)
+    throw new Error(hasUnknown ? UNKNOWN_OCPP_VERSION_ERROR : MIXED_OCPP_VERSION_ERROR)
+  }
   return { config, ocppVersion, resolvedHashIds }
 }
 

--- a/ui/cli/src/commands/action.ts
+++ b/ui/cli/src/commands/action.ts
@@ -17,8 +17,7 @@ import { loadConfig } from '../config/loader.js'
 import { createFormatter } from '../output/formatter.js'
 import { resolvePayload } from './resolve-payload.js'
 
-const NO_STATIONS_ERROR =
-  'No charging stations available. Start stations before running this command.'
+const NO_STATIONS_ERROR = 'No stations available. Start stations before running this command.'
 
 const MIXED_OCPP_VERSION_ERROR =
   'Cannot determine a common OCPP version for the targeted stations. ' +

--- a/ui/cli/src/commands/action.ts
+++ b/ui/cli/src/commands/action.ts
@@ -119,8 +119,8 @@ const resolveShortHashIds = async (
  *   Non-matching prefixes are silently excluded from targeting (no throw).
  *   Pass an empty array to target all stations.
  * @param chargingStations - station list to filter and inspect
- * @returns the common OCPPVersion, or undefined if the targeted set is empty
- *   or the targeted stations run heterogeneous versions
+ * @returns the common OCPPVersion, or undefined if the targeted set is empty,
+ *   the targeted stations run heterogeneous versions, or all versions are unknown
  */
 export const resolveOcppVersionFromList = (
   hashIds: string[],

--- a/ui/cli/src/commands/action.ts
+++ b/ui/cli/src/commands/action.ts
@@ -17,6 +17,9 @@ import { loadConfig } from '../config/loader.js'
 import { createFormatter } from '../output/formatter.js'
 import { resolvePayload } from './resolve-payload.js'
 
+export const NO_STATIONS_ERROR =
+  'No charging stations available. Start stations before running this command.'
+
 export const MIXED_OCPP_VERSION_ERROR =
   'Cannot determine a common OCPP version for the targeted stations. ' +
   'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
@@ -61,7 +64,7 @@ const fetchStationList = async (
  * @param hashIds - station hash IDs or unique hash-ID prefixes to resolve
  * @param allHashIds - full hash IDs of all known stations
  * @returns fully-resolved hash IDs in the same order as the input
- * @throws if any prefix matches zero stations or more than one station
+ * @throws {Error} if any prefix matches zero stations or more than one station
  */
 const resolveShortHashIdsFromList = (hashIds: string[], allHashIds: string[]): string[] =>
   hashIds.map(input => {
@@ -146,6 +149,11 @@ export const resolveOcppVersionFromProgram = async (
   const rootOpts = program.opts<GlobalOptions>()
   const config = await loadConfig({ configPath: rootOpts.config, url: rootOpts.serverUrl })
   const listResponse = await fetchStationList(config)
+
+  if (listResponse.chargingStations.length === 0) {
+    throw new Error(NO_STATIONS_ERROR)
+  }
+
   const allHashIds = listResponse.chargingStations.map(cs => cs.stationInfo.hashId)
   const resolvedHashIds =
     hashIds.length === 0 ? hashIds : resolveShortHashIdsFromList(hashIds, allHashIds)

--- a/ui/cli/src/commands/action.ts
+++ b/ui/cli/src/commands/action.ts
@@ -44,8 +44,7 @@ export const parseInteger = (value: string, nameOrPrevious?: number | string): n
   return n
 }
 
-// SHA-384 hex hashes are 96 chars. Inputs >= half-length skip prefix resolution
-// but are still validated against the station list (unknown IDs are rejected).
+// SHA-384 hex hashes are 96 chars; >= half-length is treated as a full or near-full hash.
 const MIN_FULL_HASH_LENGTH = 48
 
 const fetchStationList = async (
@@ -185,6 +184,24 @@ export const resolveOcppVersionFromProgram = async (
     throw new Error(hasUnknown ? UNKNOWN_OCPP_VERSION_ERROR : MIXED_OCPP_VERSION_ERROR)
   }
   return { config, ocppVersion, resolvedHashIds }
+}
+
+export const handleActionErrors = async (
+  program: Command,
+  fn: () => Promise<void>
+): Promise<void> => {
+  try {
+    await fn()
+  } catch (error: unknown) {
+    const rootOpts = program.opts<GlobalOptions>()
+    const formatter = createFormatter(rootOpts.json)
+    if (error instanceof ServerFailureError) {
+      formatter.output(error.payload)
+    } else {
+      formatter.error(error)
+    }
+    process.exitCode = 1
+  }
 }
 
 export const runAction = async (

--- a/ui/cli/src/commands/action.ts
+++ b/ui/cli/src/commands/action.ts
@@ -55,6 +55,28 @@ const fetchStationList = async (
   return response as StationListPayload
 }
 
+/**
+ * Pure helper: resolves short hash-ID prefixes to full hashes against a
+ * pre-fetched list of all station hash IDs.
+ * @param hashIds - station hash IDs or unique hash-ID prefixes to resolve
+ * @param allHashIds - full hash IDs of all known stations
+ * @returns fully-resolved hash IDs in the same order as the input
+ * @throws if any prefix matches zero stations or more than one station
+ */
+const resolveShortHashIdsFromList = (hashIds: string[], allHashIds: string[]): string[] =>
+  hashIds.map(input => {
+    if (input.length >= MIN_FULL_HASH_LENGTH) return input
+
+    const matches = allHashIds.filter(full => full.startsWith(input))
+    if (matches.length === 1) return matches[0]
+    if (matches.length === 0) {
+      throw new Error(`No station found matching hash prefix '${input}'`)
+    }
+    throw new Error(
+      `Ambiguous hash prefix '${input}' matches ${matches.length.toString()} stations`
+    )
+  })
+
 const resolveShortHashIds = async (
   hashIds: string[],
   config: UIServerConfigurationSection
@@ -67,25 +89,14 @@ const resolveShortHashIds = async (
   const listResponse = await fetchStationList(config)
   const allHashIds = listResponse.chargingStations.map(cs => cs.stationInfo.hashId)
 
-  return hashIds.map(input => {
-    if (input.length >= MIN_FULL_HASH_LENGTH) return input
-
-    const matches = allHashIds.filter(full => full.startsWith(input))
-    if (matches.length === 1) return matches[0]
-    if (matches.length === 0) {
-      throw new Error(`No station found matching hash prefix '${input}'`)
-    }
-    throw new Error(
-      `Ambiguous hash prefix '${input}' matches ${matches.length.toString()} stations`
-    )
-  })
+  return resolveShortHashIdsFromList(hashIds, allHashIds)
 }
 
 /**
  * Pure helper: resolves the common OCPP version from a pre-fetched station list.
- * Exported for unit testing; callers should use resolveOcppVersion instead.
+ * Exported for unit testing; callers should use resolveOcppVersionFromProgram.
  *
- * Unlike resolveShortHashIds, this function never throws on ambiguous or
+ * Unlike resolveShortHashIdsFromList, this function never throws on ambiguous or
  * non-matching prefixes — it returns undefined instead.
  * @param hashIds - station hash IDs or unique hash-ID prefixes to target;
  *   each entry is matched if the station's hashId equals it or starts with it.
@@ -114,67 +125,40 @@ export const resolveOcppVersionFromList = (
 }
 
 /**
- * Returns the OCPP version shared by all targeted stations, or undefined when
- * no stations match or the targeted stations run different versions.
- * @param hashIds - station hash IDs or unique hash-ID prefixes to target;
- *   each entry is matched if the station's hashId equals it or starts with it.
- *   Ambiguous or non-matching prefixes do not throw — they cause undefined to
- *   be returned (contrast with resolveShortHashIds, which throws in those cases).
- *   Pass an empty array to target all stations.
- * @param config - UI server configuration
- * @returns the common OCPPVersion, or undefined if no station matches, a prefix
- *   is ambiguous, or the targeted stations run heterogeneous versions
- */
-export const resolveOcppVersion = async (
-  hashIds: string[],
-  config: UIServerConfigurationSection
-): Promise<OCPPVersion | undefined> => {
-  const listResponse = await fetchStationList(config)
-  return resolveOcppVersionFromList(hashIds, listResponse.chargingStations)
-}
-
-/**
  * Loads config from program options, resolves short hash-ID prefixes to full
  * hashes in a single station-list fetch, and returns the common OCPP version
- * together with the resolved hash IDs. Passing the returned resolvedHashIds
- * into the payload before calling runAction prevents a second station-list fetch.
+ * together with the resolved hash IDs and the loaded config. Pass the returned
+ * resolvedHashIds into the payload and config into runAction to avoid a second
+ * station-list fetch and config load.
  * @param program - Commander root program (provides config and server URL options)
  * @param hashIds - station hash IDs or unique hash-ID prefixes to target
- * @returns the common OCPPVersion (or undefined) and the fully-resolved hash IDs
+ * @returns the common OCPPVersion (or undefined), the fully-resolved hash IDs,
+ *   and the loaded UI server config
  */
 export const resolveOcppVersionFromProgram = async (
   program: Command,
   hashIds: string[]
-): Promise<{ ocppVersion: OCPPVersion | undefined; resolvedHashIds: string[] }> => {
+): Promise<{
+  config: UIServerConfigurationSection
+  ocppVersion: OCPPVersion | undefined
+  resolvedHashIds: string[]
+}> => {
   const rootOpts = program.opts<GlobalOptions>()
   const config = await loadConfig({ configPath: rootOpts.config, url: rootOpts.serverUrl })
   const listResponse = await fetchStationList(config)
+  const allHashIds = listResponse.chargingStations.map(cs => cs.stationInfo.hashId)
   const resolvedHashIds =
-    hashIds.length === 0
-      ? hashIds
-      : (() => {
-          const allHashIds = listResponse.chargingStations.map(cs => cs.stationInfo.hashId)
-          return hashIds.map(input => {
-            if (input.length >= MIN_FULL_HASH_LENGTH) return input
-            const matches = allHashIds.filter(full => full.startsWith(input))
-            if (matches.length === 1) return matches[0]
-            if (matches.length === 0) {
-              throw new Error(`No station found matching hash prefix '${input}'`)
-            }
-            throw new Error(
-              `Ambiguous hash prefix '${input}' matches ${matches.length.toString()} stations`
-            )
-          })
-        })()
-  const ocppVersion = resolveOcppVersionFromList(hashIds, listResponse.chargingStations)
-  return { ocppVersion, resolvedHashIds }
+    hashIds.length === 0 ? hashIds : resolveShortHashIdsFromList(hashIds, allHashIds)
+  const ocppVersion = resolveOcppVersionFromList(resolvedHashIds, listResponse.chargingStations)
+  return { config, ocppVersion, resolvedHashIds }
 }
 
 export const runAction = async (
   program: Command,
   procedureName: ProcedureName,
   payload: RequestPayload,
-  rawPayload?: string
+  rawPayload?: string,
+  preloadedConfig?: UIServerConfigurationSection
 ): Promise<void> => {
   const rootOpts = program.opts<GlobalOptions>()
   const formatter = createFormatter(rootOpts.json)
@@ -185,7 +169,9 @@ export const runAction = async (
       mergedPayload = { ...extra, ...payload }
     }
 
-    const config = await loadConfig({ configPath: rootOpts.config, url: rootOpts.serverUrl })
+    const config =
+      preloadedConfig ??
+      (await loadConfig({ configPath: rootOpts.config, url: rootOpts.serverUrl }))
 
     let resolvedPayload = mergedPayload
     if (Array.isArray(mergedPayload.hashIds) && mergedPayload.hashIds.length > 0) {

--- a/ui/cli/src/commands/action.ts
+++ b/ui/cli/src/commands/action.ts
@@ -80,9 +80,17 @@ const resolveShortHashIds = async (
 /**
  * Pure helper: resolves the common OCPP version from a pre-fetched station list.
  * Exported for unit testing; callers should use resolveOcppVersion instead.
- * @param hashIds - station hash IDs (full or prefix) to target; empty means all stations
+ *
+ * Unlike resolveShortHashIds, this function never throws on ambiguous or
+ * non-matching prefixes — it returns undefined instead.
+ * @param hashIds - station hash IDs or unique hash-ID prefixes to target;
+ *   each entry is matched if the station's hashId equals it or starts with it.
+ *   An ambiguous prefix (matching multiple stations) or a non-matching prefix
+ *   does not throw — both cases cause undefined to be returned.
+ *   Pass an empty array to target all stations.
  * @param chargingStations - station list to filter and inspect
- * @returns the common OCPPVersion, or undefined if no match or heterogeneous versions
+ * @returns the common OCPPVersion, or undefined if no station matches, the
+ *   prefix is ambiguous, or the targeted stations run heterogeneous versions
  */
 export const resolveOcppVersionFromList = (
   hashIds: string[],
@@ -106,9 +114,14 @@ export const resolveOcppVersionFromList = (
 /**
  * Returns the OCPP version shared by all targeted stations, or undefined when
  * no stations match or the targeted stations run different versions.
- * @param hashIds - station hash IDs (full or prefix) to target; empty means all stations
+ * @param hashIds - station hash IDs or unique hash-ID prefixes to target;
+ *   each entry is matched if the station's hashId equals it or starts with it.
+ *   Ambiguous or non-matching prefixes do not throw — they cause undefined to
+ *   be returned (contrast with resolveShortHashIds, which throws in those cases).
+ *   Pass an empty array to target all stations.
  * @param config - UI server configuration
- * @returns the common OCPPVersion, or undefined if unavailable / heterogeneous
+ * @returns the common OCPPVersion, or undefined if no station matches, a prefix
+ *   is ambiguous, or the targeted stations run heterogeneous versions
  */
 export const resolveOcppVersion = async (
   hashIds: string[],

--- a/ui/cli/src/commands/ocpp.ts
+++ b/ui/cli/src/commands/ocpp.ts
@@ -1,7 +1,10 @@
 import { Command } from 'commander'
-import { ProcedureName, type RequestPayload } from 'ui-common'
+import { OCPP20IdTokenEnumType, OCPPVersion, ProcedureName, type RequestPayload } from 'ui-common'
 
-import { parseInteger, runAction } from './action.js'
+import type { GlobalOptions } from '../types.js'
+
+import { loadConfig } from '../config/loader.js'
+import { parseInteger, resolveOcppVersion, runAction } from './action.js'
 import { buildHashIdsPayload, PAYLOAD_DESC, PAYLOAD_OPTION, pickDefined } from './payload.js'
 
 export const createOcppCommands = (program: Command): Command => {
@@ -10,12 +13,39 @@ export const createOcppCommands = (program: Command): Command => {
   cmd
     .command('authorize [hashIds...]')
     .description('Request station(s) to send OCPP Authorize')
-    .requiredOption('--id-tag <tag>', 'RFID tag for authorization')
+    .option('--id-tag <tag>', 'RFID tag for authorization')
     .option(PAYLOAD_OPTION, PAYLOAD_DESC)
-    .action(async (hashIds: string[], options: { idTag: string; payload?: string }) => {
-      const payload: RequestPayload = {
-        idTag: options.idTag,
-        ...buildHashIdsPayload(hashIds),
+    .action(async (hashIds: string[], options: { idTag?: string; payload?: string }) => {
+      if (options.payload == null && options.idTag == null) {
+        throw new Error('Either --id-tag or -p/--payload must be provided')
+      }
+      let payload: RequestPayload
+      if (options.payload == null) {
+        const idTag = options.idTag ?? ''
+        // High-level: detect OCPP version and build correct payload
+        const rootOpts = program.opts<GlobalOptions>()
+        const config = await loadConfig({ configPath: rootOpts.config, url: rootOpts.serverUrl })
+        const ocppVersion = await resolveOcppVersion(hashIds, config)
+        if (ocppVersion == null) {
+          throw new Error(
+            'Cannot determine a common OCPP version for the targeted stations. ' +
+              'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
+          )
+        }
+        if (ocppVersion === OCPPVersion.VERSION_20 || ocppVersion === OCPPVersion.VERSION_201) {
+          payload = {
+            idToken: { idToken: idTag, type: OCPP20IdTokenEnumType.ISO14443 },
+            ...buildHashIdsPayload(hashIds),
+          }
+        } else {
+          payload = {
+            idTag,
+            ...buildHashIdsPayload(hashIds),
+          }
+        }
+      } else {
+        // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
+        payload = buildHashIdsPayload(hashIds)
       }
       await runAction(program, ProcedureName.AUTHORIZE, payload, options.payload)
     })

--- a/ui/cli/src/commands/ocpp.ts
+++ b/ui/cli/src/commands/ocpp.ts
@@ -83,48 +83,101 @@ export const createOcppCommands = (program: Command): Command => {
   cmd
     .command('meter-values [hashIds...]')
     .description('Request station(s) to send OCPP MeterValues')
-    .requiredOption('--connector-id <id>', 'connector ID (OCPP 1.6)', parseInteger)
-    .option('--evse-id <id>', 'EVSE ID (OCPP 2.0.x)', parseInteger)
-    .option(PAYLOAD_OPTION, PAYLOAD_DESC)
+    .addOption(
+      new Option('--connector-id <id>', 'connector ID').argParser(parseInteger).conflicts('payload')
+    )
+    .addOption(
+      new Option('--evse-id <id>', 'EVSE ID (OCPP 2.0.x)')
+        .argParser(parseInteger)
+        .conflicts('payload')
+    )
+    .addOption(new Option(PAYLOAD_OPTION, PAYLOAD_DESC).conflicts(['connectorId', 'evseId']))
     .action(
       async (
         hashIds: string[],
-        options: { connectorId: number; evseId?: number; payload?: string }
+        options: { connectorId?: number; evseId?: number; payload?: string }
       ) => {
-        const payload: RequestPayload = {
-          connectorId: options.connectorId,
-          ...(options.evseId != null && { evseId: options.evseId }),
-          ...buildHashIdsPayload(hashIds),
+        let payload: RequestPayload
+        if (options.payload == null) {
+          if (options.connectorId == null && options.evseId == null) {
+            throw new Error(
+              '--connector-id or --evse-id is required when -p/--payload is not provided'
+            )
+          }
+          // High-level: detect OCPP version and build correct payload
+          const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
+            program,
+            hashIds
+          )
+          switch (ocppVersion) {
+            case OCPPVersion.VERSION_16:
+              if (options.connectorId == null) {
+                throw new Error('--connector-id is required for OCPP 1.6 stations')
+              }
+              payload = {
+                connectorId: options.connectorId,
+                ...buildHashIdsPayload(resolvedHashIds),
+              }
+              break
+            case OCPPVersion.VERSION_20:
+            case OCPPVersion.VERSION_201:
+              payload = {
+                evseId: options.evseId ?? options.connectorId,
+                ...buildHashIdsPayload(resolvedHashIds),
+              }
+              break
+            default:
+              throw new Error(MIXED_OCPP_VERSION_ERROR)
+          }
+          await runAction(program, ProcedureName.METER_VALUES, payload, undefined, config)
+        } else {
+          // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
+          payload = buildHashIdsPayload(hashIds)
+          await runAction(program, ProcedureName.METER_VALUES, payload, options.payload)
         }
-        await runAction(program, ProcedureName.METER_VALUES, payload, options.payload)
       }
     )
 
   cmd
     .command('status-notification [hashIds...]')
     .description('Request station(s) to send OCPP StatusNotification')
-    .requiredOption('--connector-id <id>', 'connector ID', parseInteger)
-    .option('--error-code <code>', 'connector error code (OCPP 1.6 only; required for 1.6)')
+    .addOption(
+      new Option('--connector-id <id>', 'connector ID').argParser(parseInteger).conflicts('payload')
+    )
+    .addOption(
+      new Option(
+        '--error-code <code>',
+        'connector error code (OCPP 1.6 only; required for 1.6)'
+      ).conflicts('payload')
+    )
     .option(
       '--evse-id <id>',
       'EVSE ID (OCPP 2.0.x only; resolved automatically if omitted)',
       parseInteger
     )
-    .requiredOption('--status <status>', 'connector status')
-    .option(PAYLOAD_OPTION, PAYLOAD_DESC)
+    .addOption(new Option('--status <status>', 'connector status').conflicts('payload'))
+    .addOption(
+      new Option(PAYLOAD_OPTION, PAYLOAD_DESC).conflicts(['connectorId', 'errorCode', 'status'])
+    )
     .action(
       async (
         hashIds: string[],
         options: {
-          connectorId: number
+          connectorId?: number
           errorCode?: string
           evseId?: number
           payload?: string
-          status: string
+          status?: string
         }
       ) => {
         let payload: RequestPayload
         if (options.payload == null) {
+          if (options.connectorId == null) {
+            throw new Error('--connector-id is required when -p/--payload is not provided')
+          }
+          if (options.status == null) {
+            throw new Error('--status is required when -p/--payload is not provided')
+          }
           // High-level: detect OCPP version and build correct payload
           const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
             program,

--- a/ui/cli/src/commands/ocpp.ts
+++ b/ui/cli/src/commands/ocpp.ts
@@ -26,22 +26,25 @@ export const createOcppCommands = (program: Command): Command => {
         const rootOpts = program.opts<GlobalOptions>()
         const config = await loadConfig({ configPath: rootOpts.config, url: rootOpts.serverUrl })
         const ocppVersion = await resolveOcppVersion(hashIds, config)
-        if (ocppVersion == null) {
-          throw new Error(
-            'Cannot determine a common OCPP version for the targeted stations. ' +
-              'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
-          )
-        }
-        if (ocppVersion === OCPPVersion.VERSION_20 || ocppVersion === OCPPVersion.VERSION_201) {
-          payload = {
-            idToken: { idToken: idTag, type: OCPP20IdTokenEnumType.ISO14443 },
-            ...buildHashIdsPayload(hashIds),
-          }
-        } else {
-          payload = {
-            idTag,
-            ...buildHashIdsPayload(hashIds),
-          }
+        switch (ocppVersion) {
+          case OCPPVersion.VERSION_16:
+            payload = {
+              idTag,
+              ...buildHashIdsPayload(hashIds),
+            }
+            break
+          case OCPPVersion.VERSION_20:
+          case OCPPVersion.VERSION_201:
+            payload = {
+              idToken: { idToken: idTag, type: OCPP20IdTokenEnumType.ISO14443 },
+              ...buildHashIdsPayload(hashIds),
+            }
+            break
+          default:
+            throw new Error(
+              'Cannot determine a common OCPP version for the targeted stations. ' +
+                'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
+            )
         }
       } else {
         // Low-level passthrough: -p provided, use only routing fields; raw payload has full control

--- a/ui/cli/src/commands/ocpp.ts
+++ b/ui/cli/src/commands/ocpp.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander'
+import { Command, Option } from 'commander'
 import { OCPP20IdTokenEnumType, OCPPVersion, ProcedureName, type RequestPayload } from 'ui-common'
 
 import {
@@ -15,8 +15,8 @@ export const createOcppCommands = (program: Command): Command => {
   cmd
     .command('authorize [hashIds...]')
     .description('Request station(s) to send OCPP Authorize')
-    .option('--id-tag <tag>', 'RFID tag for authorization')
-    .option(PAYLOAD_OPTION, PAYLOAD_DESC)
+    .addOption(new Option('--id-tag <tag>', 'RFID tag for authorization').conflicts('payload'))
+    .addOption(new Option(PAYLOAD_OPTION, PAYLOAD_DESC).conflicts('idTag'))
     .action(async (hashIds: string[], options: { idTag?: string; payload?: string }) => {
       if (options.payload == null && options.idTag == null) {
         throw new Error('Either --id-tag or -p/--payload must be provided')

--- a/ui/cli/src/commands/ocpp.ts
+++ b/ui/cli/src/commands/ocpp.ts
@@ -23,7 +23,7 @@ export const createOcppCommands = (program: Command): Command => {
         let payload: RequestPayload
         if (options.payload == null) {
           if (options.idTag == null) {
-            throw new Error('Either --id-tag or -p/--payload must be provided')
+            throw new Error('--id-tag is required when -p/--payload is not provided')
           }
           // High-level: detect OCPP version and build correct payload
           const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(

--- a/ui/cli/src/commands/ocpp.ts
+++ b/ui/cli/src/commands/ocpp.ts
@@ -2,6 +2,7 @@ import { Command, Option } from 'commander'
 import { OCPP20IdTokenEnumType, OCPPVersion, ProcedureName, type RequestPayload } from 'ui-common'
 
 import {
+  handleActionErrors,
   parseInteger,
   resolveOcppVersionFromProgram,
   runAction,
@@ -18,39 +19,41 @@ export const createOcppCommands = (program: Command): Command => {
     .addOption(new Option('--id-tag <tag>', 'RFID tag for authorization').conflicts('payload'))
     .addOption(new Option(PAYLOAD_OPTION, PAYLOAD_DESC).conflicts('idTag'))
     .action(async (hashIds: string[], options: { idTag?: string; payload?: string }) => {
-      let payload: RequestPayload
-      if (options.payload == null) {
-        if (options.idTag == null) {
-          throw new Error('Either --id-tag or -p/--payload must be provided')
+      await handleActionErrors(program, async () => {
+        let payload: RequestPayload
+        if (options.payload == null) {
+          if (options.idTag == null) {
+            throw new Error('Either --id-tag or -p/--payload must be provided')
+          }
+          // High-level: detect OCPP version and build correct payload
+          const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
+            program,
+            hashIds
+          )
+          switch (ocppVersion) {
+            case OCPPVersion.VERSION_16:
+              payload = {
+                idTag: options.idTag,
+                ...buildHashIdsPayload(resolvedHashIds),
+              }
+              break
+            case OCPPVersion.VERSION_20:
+            case OCPPVersion.VERSION_201:
+              payload = {
+                idToken: { idToken: options.idTag, type: OCPP20IdTokenEnumType.ISO14443 },
+                ...buildHashIdsPayload(resolvedHashIds),
+              }
+              break
+            default:
+              throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
+          }
+          await runAction(program, ProcedureName.AUTHORIZE, payload, undefined, config)
+        } else {
+          // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
+          payload = buildHashIdsPayload(hashIds)
+          await runAction(program, ProcedureName.AUTHORIZE, payload, options.payload)
         }
-        // High-level: detect OCPP version and build correct payload
-        const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
-          program,
-          hashIds
-        )
-        switch (ocppVersion) {
-          case OCPPVersion.VERSION_16:
-            payload = {
-              idTag: options.idTag,
-              ...buildHashIdsPayload(resolvedHashIds),
-            }
-            break
-          case OCPPVersion.VERSION_20:
-          case OCPPVersion.VERSION_201:
-            payload = {
-              idToken: { idToken: options.idTag, type: OCPP20IdTokenEnumType.ISO14443 },
-              ...buildHashIdsPayload(resolvedHashIds),
-            }
-            break
-          default:
-            throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
-        }
-        await runAction(program, ProcedureName.AUTHORIZE, payload, undefined, config)
-      } else {
-        // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
-        payload = buildHashIdsPayload(hashIds)
-        await runAction(program, ProcedureName.AUTHORIZE, payload, options.payload)
-      }
+      })
     })
 
   cmd
@@ -94,45 +97,47 @@ export const createOcppCommands = (program: Command): Command => {
         hashIds: string[],
         options: { connectorId?: number; evseId?: number; payload?: string }
       ) => {
-        let payload: RequestPayload
-        if (options.payload == null) {
-          if (options.connectorId == null && options.evseId == null) {
-            throw new Error(
-              '--connector-id or --evse-id is required when -p/--payload is not provided'
+        await handleActionErrors(program, async () => {
+          let payload: RequestPayload
+          if (options.payload == null) {
+            if (options.connectorId == null && options.evseId == null) {
+              throw new Error(
+                '--connector-id or --evse-id is required when -p/--payload is not provided'
+              )
+            }
+            // High-level: detect OCPP version and build correct payload
+            const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
+              program,
+              hashIds
             )
+            switch (ocppVersion) {
+              case OCPPVersion.VERSION_16:
+                if (options.connectorId == null) {
+                  throw new Error('--connector-id is required for OCPP 1.6 stations')
+                }
+                payload = {
+                  connectorId: options.connectorId,
+                  ...buildHashIdsPayload(resolvedHashIds),
+                }
+                break
+              case OCPPVersion.VERSION_20:
+              case OCPPVersion.VERSION_201:
+                payload = {
+                  ...(options.connectorId != null && { connectorId: options.connectorId }),
+                  ...(options.evseId != null && { evseId: options.evseId }),
+                  ...buildHashIdsPayload(resolvedHashIds),
+                }
+                break
+              default:
+                throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
+            }
+            await runAction(program, ProcedureName.METER_VALUES, payload, undefined, config)
+          } else {
+            // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
+            payload = buildHashIdsPayload(hashIds)
+            await runAction(program, ProcedureName.METER_VALUES, payload, options.payload)
           }
-          // High-level: detect OCPP version and build correct payload
-          const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
-            program,
-            hashIds
-          )
-          switch (ocppVersion) {
-            case OCPPVersion.VERSION_16:
-              if (options.connectorId == null) {
-                throw new Error('--connector-id is required for OCPP 1.6 stations')
-              }
-              payload = {
-                connectorId: options.connectorId,
-                ...buildHashIdsPayload(resolvedHashIds),
-              }
-              break
-            case OCPPVersion.VERSION_20:
-            case OCPPVersion.VERSION_201:
-              payload = {
-                ...(options.connectorId != null && { connectorId: options.connectorId }),
-                ...(options.evseId != null && { evseId: options.evseId }),
-                ...buildHashIdsPayload(resolvedHashIds),
-              }
-              break
-            default:
-              throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
-          }
-          await runAction(program, ProcedureName.METER_VALUES, payload, undefined, config)
-        } else {
-          // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
-          payload = buildHashIdsPayload(hashIds)
-          await runAction(program, ProcedureName.METER_VALUES, payload, options.payload)
-        }
+        })
       }
     )
 
@@ -176,49 +181,51 @@ export const createOcppCommands = (program: Command): Command => {
           status?: string
         }
       ) => {
-        let payload: RequestPayload
-        if (options.payload == null) {
-          if (options.connectorId == null) {
-            throw new Error('--connector-id is required when -p/--payload is not provided')
+        await handleActionErrors(program, async () => {
+          let payload: RequestPayload
+          if (options.payload == null) {
+            if (options.connectorId == null) {
+              throw new Error('--connector-id is required when -p/--payload is not provided')
+            }
+            if (options.status == null) {
+              throw new Error('--status is required when -p/--payload is not provided')
+            }
+            // High-level: detect OCPP version and build correct payload
+            const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
+              program,
+              hashIds
+            )
+            switch (ocppVersion) {
+              case OCPPVersion.VERSION_16:
+                if (options.errorCode == null) {
+                  throw new Error('--error-code is required for OCPP 1.6 stations')
+                }
+                payload = {
+                  connectorId: options.connectorId,
+                  errorCode: options.errorCode,
+                  status: options.status,
+                  ...buildHashIdsPayload(resolvedHashIds),
+                }
+                break
+              case OCPPVersion.VERSION_20:
+              case OCPPVersion.VERSION_201:
+                payload = {
+                  connectorId: options.connectorId,
+                  connectorStatus: options.status,
+                  ...(options.evseId != null && { evseId: options.evseId }),
+                  ...buildHashIdsPayload(resolvedHashIds),
+                }
+                break
+              default:
+                throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
+            }
+            await runAction(program, ProcedureName.STATUS_NOTIFICATION, payload, undefined, config)
+          } else {
+            // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
+            payload = buildHashIdsPayload(hashIds)
+            await runAction(program, ProcedureName.STATUS_NOTIFICATION, payload, options.payload)
           }
-          if (options.status == null) {
-            throw new Error('--status is required when -p/--payload is not provided')
-          }
-          // High-level: detect OCPP version and build correct payload
-          const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
-            program,
-            hashIds
-          )
-          switch (ocppVersion) {
-            case OCPPVersion.VERSION_16:
-              if (options.errorCode == null) {
-                throw new Error('--error-code is required for OCPP 1.6 stations')
-              }
-              payload = {
-                connectorId: options.connectorId,
-                errorCode: options.errorCode,
-                status: options.status,
-                ...buildHashIdsPayload(resolvedHashIds),
-              }
-              break
-            case OCPPVersion.VERSION_20:
-            case OCPPVersion.VERSION_201:
-              payload = {
-                connectorId: options.connectorId,
-                connectorStatus: options.status,
-                ...(options.evseId != null && { evseId: options.evseId }),
-                ...buildHashIdsPayload(resolvedHashIds),
-              }
-              break
-            default:
-              throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
-          }
-          await runAction(program, ProcedureName.STATUS_NOTIFICATION, payload, undefined, config)
-        } else {
-          // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
-          payload = buildHashIdsPayload(hashIds)
-          await runAction(program, ProcedureName.STATUS_NOTIFICATION, payload, options.payload)
-        }
+        })
       }
     )
 

--- a/ui/cli/src/commands/ocpp.ts
+++ b/ui/cli/src/commands/ocpp.ts
@@ -84,10 +84,12 @@ export const createOcppCommands = (program: Command): Command => {
     .command('meter-values [hashIds...]')
     .description('Request station(s) to send OCPP MeterValues')
     .addOption(
-      new Option('--connector-id <id>', 'connector ID').argParser(parseInteger).conflicts('payload')
+      new Option('--connector-id <id>', 'connector ID (OCPP 1.6 only)')
+        .argParser(parseInteger)
+        .conflicts('payload')
     )
     .addOption(
-      new Option('--evse-id <id>', 'EVSE ID (OCPP 2.0.x; derived from connector ID if omitted)')
+      new Option('--evse-id <id>', 'EVSE ID (required for OCPP 2.0.x)')
         .argParser(parseInteger)
         .conflicts('payload')
     )
@@ -122,9 +124,13 @@ export const createOcppCommands = (program: Command): Command => {
                 break
               case OCPPVersion.VERSION_20:
               case OCPPVersion.VERSION_201:
+                if (options.evseId == null) {
+                  throw new Error(
+                    '--evse-id is required for OCPP 2.0.x stations (connectorId is not a valid MeterValues field in OCPP 2.0.x)'
+                  )
+                }
                 payload = {
-                  ...(options.connectorId != null && { connectorId: options.connectorId }),
-                  ...(options.evseId != null && { evseId: options.evseId }),
+                  evseId: options.evseId,
                   ...buildHashIdsPayload(resolvedHashIds),
                 }
                 break

--- a/ui/cli/src/commands/ocpp.ts
+++ b/ui/cli/src/commands/ocpp.ts
@@ -2,10 +2,10 @@ import { Command, Option } from 'commander'
 import { OCPP20IdTokenEnumType, OCPPVersion, ProcedureName, type RequestPayload } from 'ui-common'
 
 import {
-  MIXED_OCPP_VERSION_ERROR,
   parseInteger,
   resolveOcppVersionFromProgram,
   runAction,
+  UNSUPPORTED_OCPP_VERSION_ERROR,
 } from './action.js'
 import { buildHashIdsPayload, PAYLOAD_DESC, PAYLOAD_OPTION, pickDefined } from './payload.js'
 
@@ -18,13 +18,10 @@ export const createOcppCommands = (program: Command): Command => {
     .addOption(new Option('--id-tag <tag>', 'RFID tag for authorization').conflicts('payload'))
     .addOption(new Option(PAYLOAD_OPTION, PAYLOAD_DESC).conflicts('idTag'))
     .action(async (hashIds: string[], options: { idTag?: string; payload?: string }) => {
-      if (options.payload == null && options.idTag == null) {
-        throw new Error('Either --id-tag or -p/--payload must be provided')
-      }
       let payload: RequestPayload
       if (options.payload == null) {
         if (options.idTag == null) {
-          throw new Error('--id-tag is required when -p/--payload is not provided')
+          throw new Error('Either --id-tag or -p/--payload must be provided')
         }
         // High-level: detect OCPP version and build correct payload
         const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
@@ -46,7 +43,7 @@ export const createOcppCommands = (program: Command): Command => {
             }
             break
           default:
-            throw new Error(MIXED_OCPP_VERSION_ERROR)
+            throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
         }
         await runAction(program, ProcedureName.AUTHORIZE, payload, undefined, config)
       } else {
@@ -122,12 +119,13 @@ export const createOcppCommands = (program: Command): Command => {
             case OCPPVersion.VERSION_20:
             case OCPPVersion.VERSION_201:
               payload = {
-                evseId: options.evseId ?? options.connectorId,
+                ...(options.connectorId != null && { connectorId: options.connectorId }),
+                ...(options.evseId != null && { evseId: options.evseId }),
                 ...buildHashIdsPayload(resolvedHashIds),
               }
               break
             default:
-              throw new Error(MIXED_OCPP_VERSION_ERROR)
+              throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
           }
           await runAction(program, ProcedureName.METER_VALUES, payload, undefined, config)
         } else {
@@ -150,14 +148,22 @@ export const createOcppCommands = (program: Command): Command => {
         'connector error code (OCPP 1.6 only; required for 1.6)'
       ).conflicts('payload')
     )
-    .option(
-      '--evse-id <id>',
-      'EVSE ID (OCPP 2.0.x only; resolved automatically if omitted)',
-      parseInteger
+    .addOption(
+      new Option(
+        '--evse-id <id>',
+        'EVSE ID (OCPP 2.0.x only; derived from connector ID if omitted)'
+      )
+        .argParser(parseInteger)
+        .conflicts('payload')
     )
     .addOption(new Option('--status <status>', 'connector status').conflicts('payload'))
     .addOption(
-      new Option(PAYLOAD_OPTION, PAYLOAD_DESC).conflicts(['connectorId', 'errorCode', 'status'])
+      new Option(PAYLOAD_OPTION, PAYLOAD_DESC).conflicts([
+        'connectorId',
+        'errorCode',
+        'evseId',
+        'status',
+      ])
     )
     .action(
       async (
@@ -205,7 +211,7 @@ export const createOcppCommands = (program: Command): Command => {
               }
               break
             default:
-              throw new Error(MIXED_OCPP_VERSION_ERROR)
+              throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
           }
           await runAction(program, ProcedureName.STATUS_NOTIFICATION, payload, undefined, config)
         } else {

--- a/ui/cli/src/commands/ocpp.ts
+++ b/ui/cli/src/commands/ocpp.ts
@@ -61,7 +61,7 @@ export const createOcppCommands = (program: Command): Command => {
     .description('Request station(s) to send OCPP DataTransfer')
     .option('--vendor-id <id>', 'vendor identifier')
     .option('--message-id <id>', 'message identifier')
-    .option('--data <json>', 'data payload (JSON string)')
+    .option('--data <data>', 'data payload (free-form string)')
     .option(PAYLOAD_OPTION, PAYLOAD_DESC)
     .action(
       async (

--- a/ui/cli/src/commands/ocpp.ts
+++ b/ui/cli/src/commands/ocpp.ts
@@ -80,33 +80,86 @@ export const createOcppCommands = (program: Command): Command => {
   cmd
     .command('meter-values [hashIds...]')
     .description('Request station(s) to send OCPP MeterValues')
-    .requiredOption('--connector-id <id>', 'connector ID', parseInteger)
+    .requiredOption('--connector-id <id>', 'connector ID (OCPP 1.6)', parseInteger)
+    .option(
+      '--evse-id <id>',
+      'EVSE ID (OCPP 2.0.x); takes precedence over --connector-id for EVSE resolution',
+      parseInteger
+    )
     .option(PAYLOAD_OPTION, PAYLOAD_DESC)
-    .action(async (hashIds: string[], options: { connectorId: number; payload?: string }) => {
-      const payload: RequestPayload = {
-        connectorId: options.connectorId,
-        ...buildHashIdsPayload(hashIds),
+    .action(
+      async (
+        hashIds: string[],
+        options: { connectorId: number; evseId?: number; payload?: string }
+      ) => {
+        const payload: RequestPayload = {
+          connectorId: options.connectorId,
+          ...(options.evseId != null && { evseId: options.evseId }),
+          ...buildHashIdsPayload(hashIds),
+        }
+        await runAction(program, ProcedureName.METER_VALUES, payload, options.payload)
       }
-      await runAction(program, ProcedureName.METER_VALUES, payload, options.payload)
-    })
+    )
 
   cmd
     .command('status-notification [hashIds...]')
     .description('Request station(s) to send OCPP StatusNotification')
     .requiredOption('--connector-id <id>', 'connector ID', parseInteger)
-    .requiredOption('--error-code <code>', 'connector error code')
+    .option('--error-code <code>', 'connector error code (OCPP 1.6 only; required for 1.6)')
+    .option(
+      '--evse-id <id>',
+      'EVSE ID (OCPP 2.0.x only; resolved automatically if omitted)',
+      parseInteger
+    )
     .requiredOption('--status <status>', 'connector status')
     .option(PAYLOAD_OPTION, PAYLOAD_DESC)
     .action(
       async (
         hashIds: string[],
-        options: { connectorId: number; errorCode: string; payload?: string; status: string }
+        options: {
+          connectorId: number
+          errorCode?: string
+          evseId?: number
+          payload?: string
+          status: string
+        }
       ) => {
-        const payload: RequestPayload = {
-          connectorId: options.connectorId,
-          errorCode: options.errorCode,
-          status: options.status,
-          ...buildHashIdsPayload(hashIds),
+        let payload: RequestPayload
+        if (options.payload == null) {
+          // High-level: detect OCPP version and build correct payload
+          const rootOpts = program.opts<GlobalOptions>()
+          const config = await loadConfig({ configPath: rootOpts.config, url: rootOpts.serverUrl })
+          const ocppVersion = await resolveOcppVersion(hashIds, config)
+          switch (ocppVersion) {
+            case OCPPVersion.VERSION_16:
+              if (options.errorCode == null) {
+                throw new Error('--error-code is required for OCPP 1.6 stations')
+              }
+              payload = {
+                connectorId: options.connectorId,
+                errorCode: options.errorCode,
+                status: options.status,
+                ...buildHashIdsPayload(hashIds),
+              }
+              break
+            case OCPPVersion.VERSION_20:
+            case OCPPVersion.VERSION_201:
+              payload = {
+                connectorId: options.connectorId,
+                connectorStatus: options.status,
+                ...(options.evseId != null && { evseId: options.evseId }),
+                ...buildHashIdsPayload(hashIds),
+              }
+              break
+            default:
+              throw new Error(
+                'Cannot determine a common OCPP version for the targeted stations. ' +
+                  'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
+              )
+          }
+        } else {
+          // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
+          payload = buildHashIdsPayload(hashIds)
         }
         await runAction(program, ProcedureName.STATUS_NOTIFICATION, payload, options.payload)
       }

--- a/ui/cli/src/commands/ocpp.ts
+++ b/ui/cli/src/commands/ocpp.ts
@@ -1,10 +1,12 @@
 import { Command } from 'commander'
 import { OCPP20IdTokenEnumType, OCPPVersion, ProcedureName, type RequestPayload } from 'ui-common'
 
-import type { GlobalOptions } from '../types.js'
-
-import { loadConfig } from '../config/loader.js'
-import { parseInteger, resolveOcppVersion, runAction } from './action.js'
+import {
+  MIXED_OCPP_VERSION_ERROR,
+  parseInteger,
+  resolveOcppVersionFromProgram,
+  runAction,
+} from './action.js'
 import { buildHashIdsPayload, PAYLOAD_DESC, PAYLOAD_OPTION, pickDefined } from './payload.js'
 
 export const createOcppCommands = (program: Command): Command => {
@@ -21,30 +23,30 @@ export const createOcppCommands = (program: Command): Command => {
       }
       let payload: RequestPayload
       if (options.payload == null) {
-        const idTag = options.idTag ?? ''
+        if (options.idTag == null) {
+          throw new Error('--id-tag is required when -p/--payload is not provided')
+        }
         // High-level: detect OCPP version and build correct payload
-        const rootOpts = program.opts<GlobalOptions>()
-        const config = await loadConfig({ configPath: rootOpts.config, url: rootOpts.serverUrl })
-        const ocppVersion = await resolveOcppVersion(hashIds, config)
+        const { ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
+          program,
+          hashIds
+        )
         switch (ocppVersion) {
           case OCPPVersion.VERSION_16:
             payload = {
-              idTag,
-              ...buildHashIdsPayload(hashIds),
+              idTag: options.idTag,
+              ...buildHashIdsPayload(resolvedHashIds),
             }
             break
           case OCPPVersion.VERSION_20:
           case OCPPVersion.VERSION_201:
             payload = {
-              idToken: { idToken: idTag, type: OCPP20IdTokenEnumType.ISO14443 },
-              ...buildHashIdsPayload(hashIds),
+              idToken: { idToken: options.idTag, type: OCPP20IdTokenEnumType.ISO14443 },
+              ...buildHashIdsPayload(resolvedHashIds),
             }
             break
           default:
-            throw new Error(
-              'Cannot determine a common OCPP version for the targeted stations. ' +
-                'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
-            )
+            throw new Error(MIXED_OCPP_VERSION_ERROR)
         }
       } else {
         // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
@@ -127,9 +129,10 @@ export const createOcppCommands = (program: Command): Command => {
         let payload: RequestPayload
         if (options.payload == null) {
           // High-level: detect OCPP version and build correct payload
-          const rootOpts = program.opts<GlobalOptions>()
-          const config = await loadConfig({ configPath: rootOpts.config, url: rootOpts.serverUrl })
-          const ocppVersion = await resolveOcppVersion(hashIds, config)
+          const { ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
+            program,
+            hashIds
+          )
           switch (ocppVersion) {
             case OCPPVersion.VERSION_16:
               if (options.errorCode == null) {
@@ -139,7 +142,7 @@ export const createOcppCommands = (program: Command): Command => {
                 connectorId: options.connectorId,
                 errorCode: options.errorCode,
                 status: options.status,
-                ...buildHashIdsPayload(hashIds),
+                ...buildHashIdsPayload(resolvedHashIds),
               }
               break
             case OCPPVersion.VERSION_20:
@@ -148,14 +151,11 @@ export const createOcppCommands = (program: Command): Command => {
                 connectorId: options.connectorId,
                 connectorStatus: options.status,
                 ...(options.evseId != null && { evseId: options.evseId }),
-                ...buildHashIdsPayload(hashIds),
+                ...buildHashIdsPayload(resolvedHashIds),
               }
               break
             default:
-              throw new Error(
-                'Cannot determine a common OCPP version for the targeted stations. ' +
-                  'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
-              )
+              throw new Error(MIXED_OCPP_VERSION_ERROR)
           }
         } else {
           // Low-level passthrough: -p provided, use only routing fields; raw payload has full control

--- a/ui/cli/src/commands/ocpp.ts
+++ b/ui/cli/src/commands/ocpp.ts
@@ -84,12 +84,12 @@ export const createOcppCommands = (program: Command): Command => {
     .command('meter-values [hashIds...]')
     .description('Request station(s) to send OCPP MeterValues')
     .addOption(
-      new Option('--connector-id <id>', 'connector ID (OCPP 1.6 only)')
+      new Option('--connector-id <id>', 'connector ID (OCPP 1.6)')
         .argParser(parseInteger)
         .conflicts('payload')
     )
     .addOption(
-      new Option('--evse-id <id>', 'EVSE ID (required for OCPP 2.0.x)')
+      new Option('--evse-id <id>', 'EVSE ID (OCPP 2.0.x)')
         .argParser(parseInteger)
         .conflicts('payload')
     )
@@ -125,9 +125,7 @@ export const createOcppCommands = (program: Command): Command => {
               case OCPPVersion.VERSION_20:
               case OCPPVersion.VERSION_201:
                 if (options.evseId == null) {
-                  throw new Error(
-                    '--evse-id is required for OCPP 2.0.x stations (connectorId is not a valid MeterValues field in OCPP 2.0.x)'
-                  )
+                  throw new Error('--evse-id is required for OCPP 2.0.x stations')
                 }
                 payload = {
                   evseId: options.evseId,

--- a/ui/cli/src/commands/ocpp.ts
+++ b/ui/cli/src/commands/ocpp.ts
@@ -84,11 +84,7 @@ export const createOcppCommands = (program: Command): Command => {
     .command('meter-values [hashIds...]')
     .description('Request station(s) to send OCPP MeterValues')
     .requiredOption('--connector-id <id>', 'connector ID (OCPP 1.6)', parseInteger)
-    .option(
-      '--evse-id <id>',
-      'EVSE ID (OCPP 2.0.x); takes precedence over --connector-id for EVSE resolution',
-      parseInteger
-    )
+    .option('--evse-id <id>', 'EVSE ID (OCPP 2.0.x)', parseInteger)
     .option(PAYLOAD_OPTION, PAYLOAD_DESC)
     .action(
       async (

--- a/ui/cli/src/commands/ocpp.ts
+++ b/ui/cli/src/commands/ocpp.ts
@@ -87,7 +87,7 @@ export const createOcppCommands = (program: Command): Command => {
       new Option('--connector-id <id>', 'connector ID').argParser(parseInteger).conflicts('payload')
     )
     .addOption(
-      new Option('--evse-id <id>', 'EVSE ID (OCPP 2.0.x)')
+      new Option('--evse-id <id>', 'EVSE ID (OCPP 2.0.x; derived from connector ID if omitted)')
         .argParser(parseInteger)
         .conflicts('payload')
     )
@@ -148,16 +148,10 @@ export const createOcppCommands = (program: Command): Command => {
       new Option('--connector-id <id>', 'connector ID').argParser(parseInteger).conflicts('payload')
     )
     .addOption(
-      new Option(
-        '--error-code <code>',
-        'connector error code (OCPP 1.6 only; required for 1.6)'
-      ).conflicts('payload')
+      new Option('--error-code <code>', 'connector error code (OCPP 1.6)').conflicts('payload')
     )
     .addOption(
-      new Option(
-        '--evse-id <id>',
-        'EVSE ID (OCPP 2.0.x only; derived from connector ID if omitted)'
-      )
+      new Option('--evse-id <id>', 'EVSE ID (OCPP 2.0.x; derived from connector ID if omitted)')
         .argParser(parseInteger)
         .conflicts('payload')
     )

--- a/ui/cli/src/commands/ocpp.ts
+++ b/ui/cli/src/commands/ocpp.ts
@@ -27,7 +27,7 @@ export const createOcppCommands = (program: Command): Command => {
           throw new Error('--id-tag is required when -p/--payload is not provided')
         }
         // High-level: detect OCPP version and build correct payload
-        const { ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
+        const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
           program,
           hashIds
         )
@@ -48,11 +48,12 @@ export const createOcppCommands = (program: Command): Command => {
           default:
             throw new Error(MIXED_OCPP_VERSION_ERROR)
         }
+        await runAction(program, ProcedureName.AUTHORIZE, payload, undefined, config)
       } else {
         // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
         payload = buildHashIdsPayload(hashIds)
+        await runAction(program, ProcedureName.AUTHORIZE, payload, options.payload)
       }
-      await runAction(program, ProcedureName.AUTHORIZE, payload, options.payload)
     })
 
   cmd
@@ -129,7 +130,7 @@ export const createOcppCommands = (program: Command): Command => {
         let payload: RequestPayload
         if (options.payload == null) {
           // High-level: detect OCPP version and build correct payload
-          const { ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
+          const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
             program,
             hashIds
           )
@@ -157,11 +158,12 @@ export const createOcppCommands = (program: Command): Command => {
             default:
               throw new Error(MIXED_OCPP_VERSION_ERROR)
           }
+          await runAction(program, ProcedureName.STATUS_NOTIFICATION, payload, undefined, config)
         } else {
           // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
           payload = buildHashIdsPayload(hashIds)
+          await runAction(program, ProcedureName.STATUS_NOTIFICATION, payload, options.payload)
         }
-        await runAction(program, ProcedureName.STATUS_NOTIFICATION, payload, options.payload)
       }
     )
 

--- a/ui/cli/src/commands/station.ts
+++ b/ui/cli/src/commands/station.ts
@@ -9,14 +9,14 @@ export const createStationCommands = (program: Command): Command => {
 
   cmd
     .command('list')
-    .description('List all charging stations')
+    .description('List all stations')
     .action(async () => {
       await runAction(program, ProcedureName.LIST_CHARGING_STATIONS, {})
     })
 
   cmd
     .command('start [hashIds...]')
-    .description('Start charging station(s)')
+    .description('Start station(s)')
     .action(async (hashIds: string[]) => {
       const payload: RequestPayload = buildHashIdsPayload(hashIds)
       await runAction(program, ProcedureName.START_CHARGING_STATION, payload)
@@ -24,7 +24,7 @@ export const createStationCommands = (program: Command): Command => {
 
   cmd
     .command('stop [hashIds...]')
-    .description('Stop charging station(s)')
+    .description('Stop station(s)')
     .action(async (hashIds: string[]) => {
       const payload: RequestPayload = buildHashIdsPayload(hashIds)
       await runAction(program, ProcedureName.STOP_CHARGING_STATION, payload)
@@ -32,7 +32,7 @@ export const createStationCommands = (program: Command): Command => {
 
   cmd
     .command('add')
-    .description('Add charging stations from template')
+    .description('Add stations from template')
     .requiredOption('-t, --template <name>', 'station template name')
     .requiredOption('-n, --count <n>', 'number of stations to add', parseInteger)
     .option('--supervision-url <url>', 'supervision URL for new stations')
@@ -64,7 +64,7 @@ export const createStationCommands = (program: Command): Command => {
 
   cmd
     .command('delete [hashIds...]')
-    .description('Delete charging station(s)')
+    .description('Delete station(s)')
     .option('--delete-config', 'delete station configuration files')
     .action(async (hashIds: string[], options: { deleteConfig?: true }) => {
       const payload: RequestPayload = {

--- a/ui/cli/src/commands/transaction.ts
+++ b/ui/cli/src/commands/transaction.ts
@@ -36,31 +36,34 @@ export const createTransactionCommands = (program: Command): Command => {
           const rootOpts = program.opts<GlobalOptions>()
           const config = await loadConfig({ configPath: rootOpts.config, url: rootOpts.serverUrl })
           const ocppVersion = await resolveOcppVersion(hashIds, config)
-          if (ocppVersion == null) {
-            throw new Error(
-              'Cannot determine a common OCPP version for the targeted stations. ' +
-                'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
-            )
-          }
-          if (ocppVersion === OCPPVersion.VERSION_20 || ocppVersion === OCPPVersion.VERSION_201) {
-            procedureName = ProcedureName.TRANSACTION_EVENT
-            payload = {
-              eventType: OCPP20TransactionEventEnumType.STARTED,
-              evse: { connectorId: options.connectorId, id: options.connectorId },
-              idToken: { idToken: options.idTag, type: OCPP20IdTokenEnumType.ISO14443 },
-              seqNo: 0,
-              timestamp: new Date().toISOString(),
-              transactionInfo: { transactionId: randomUUID() },
-              triggerReason: OCPP20TriggerReasonEnumType.AUTHORIZED,
-              ...buildHashIdsPayload(hashIds),
-            }
-          } else {
-            procedureName = ProcedureName.START_TRANSACTION
-            payload = {
-              connectorId: options.connectorId,
-              idTag: options.idTag,
-              ...buildHashIdsPayload(hashIds),
-            }
+          switch (ocppVersion) {
+            case OCPPVersion.VERSION_16:
+              procedureName = ProcedureName.START_TRANSACTION
+              payload = {
+                connectorId: options.connectorId,
+                idTag: options.idTag,
+                ...buildHashIdsPayload(hashIds),
+              }
+              break
+            case OCPPVersion.VERSION_20:
+            case OCPPVersion.VERSION_201:
+              procedureName = ProcedureName.TRANSACTION_EVENT
+              payload = {
+                eventType: OCPP20TransactionEventEnumType.STARTED,
+                evse: { connectorId: options.connectorId, id: options.connectorId },
+                idToken: { idToken: options.idTag, type: OCPP20IdTokenEnumType.ISO14443 },
+                seqNo: 0,
+                timestamp: new Date().toISOString(),
+                transactionInfo: { transactionId: randomUUID() },
+                triggerReason: OCPP20TriggerReasonEnumType.AUTHORIZED,
+                ...buildHashIdsPayload(hashIds),
+              }
+              break
+            default:
+              throw new Error(
+                'Cannot determine a common OCPP version for the targeted stations. ' +
+                  'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
+              )
           }
         } else {
           // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
@@ -74,10 +77,7 @@ export const createTransactionCommands = (program: Command): Command => {
   cmd
     .command('stop [hashIds...]')
     .description('Stop a transaction on station(s)')
-    .requiredOption(
-      '--transaction-id <id>',
-      'transaction ID (integer for OCPP 1.6, UUID for OCPP 2.0.x)'
-    )
+    .requiredOption('--transaction-id <id>', 'transaction ID')
     .option(PAYLOAD_OPTION, PAYLOAD_DESC)
     .action(async (hashIds: string[], options: { payload?: string; transactionId: string }) => {
       let procedureName: ProcedureName
@@ -87,28 +87,31 @@ export const createTransactionCommands = (program: Command): Command => {
         const rootOpts = program.opts<GlobalOptions>()
         const config = await loadConfig({ configPath: rootOpts.config, url: rootOpts.serverUrl })
         const ocppVersion = await resolveOcppVersion(hashIds, config)
-        if (ocppVersion == null) {
-          throw new Error(
-            'Cannot determine a common OCPP version for the targeted stations. ' +
-              'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
-          )
-        }
-        if (ocppVersion === OCPPVersion.VERSION_20 || ocppVersion === OCPPVersion.VERSION_201) {
-          procedureName = ProcedureName.TRANSACTION_EVENT
-          payload = {
-            eventType: OCPP20TransactionEventEnumType.ENDED,
-            seqNo: 0,
-            timestamp: new Date().toISOString(),
-            transactionInfo: { transactionId: options.transactionId },
-            triggerReason: OCPP20TriggerReasonEnumType.REMOTE_STOP,
-            ...buildHashIdsPayload(hashIds),
-          }
-        } else {
-          procedureName = ProcedureName.STOP_TRANSACTION
-          payload = {
-            transactionId: parseInteger(options.transactionId),
-            ...buildHashIdsPayload(hashIds),
-          }
+        switch (ocppVersion) {
+          case OCPPVersion.VERSION_16:
+            procedureName = ProcedureName.STOP_TRANSACTION
+            payload = {
+              transactionId: parseInteger(options.transactionId),
+              ...buildHashIdsPayload(hashIds),
+            }
+            break
+          case OCPPVersion.VERSION_20:
+          case OCPPVersion.VERSION_201:
+            procedureName = ProcedureName.TRANSACTION_EVENT
+            payload = {
+              eventType: OCPP20TransactionEventEnumType.ENDED,
+              seqNo: 0,
+              timestamp: new Date().toISOString(),
+              transactionInfo: { transactionId: options.transactionId },
+              triggerReason: OCPP20TriggerReasonEnumType.REMOTE_STOP,
+              ...buildHashIdsPayload(hashIds),
+            }
+            break
+          default:
+            throw new Error(
+              'Cannot determine a common OCPP version for the targeted stations. ' +
+                'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
+            )
         }
       } else {
         // Low-level passthrough: -p provided, use only routing fields; raw payload has full control

--- a/ui/cli/src/commands/transaction.ts
+++ b/ui/cli/src/commands/transaction.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander'
+import { Command, Option } from 'commander'
 import {
   OCPP20IdTokenEnumType,
   OCPP20TransactionEventEnumType,
@@ -21,21 +21,36 @@ export const createTransactionCommands = (program: Command): Command => {
   cmd
     .command('start [hashIds...]')
     .description('Start a transaction on station(s)')
-    .requiredOption('--connector-id <id>', 'connector ID', parseInteger)
-    .requiredOption('--id-tag <tag>', 'RFID tag for authorization')
-    .option('--evse-id <id>', 'EVSE ID (OCPP 2.0.x; defaults to 1)', parseInteger)
+    .addOption(
+      new Option('--connector-id <id>', 'connector ID').argParser(parseInteger).conflicts('payload')
+    )
+    .addOption(new Option('--id-tag <tag>', 'RFID tag for authorization').conflicts('payload'))
     .option(
-      PAYLOAD_OPTION,
-      PAYLOAD_DESC + ' (uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event)'
+      '--evse-id <id>',
+      'EVSE ID (OCPP 2.0.x; resolved from connector ID when omitted)',
+      parseInteger
+    )
+    .addOption(
+      new Option(
+        PAYLOAD_OPTION,
+        PAYLOAD_DESC +
+          ' (uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event)'
+      ).conflicts(['connectorId', 'idTag'])
     )
     .action(
       async (
         hashIds: string[],
-        options: { connectorId: number; evseId?: number; idTag: string; payload?: string }
+        options: { connectorId?: number; evseId?: number; idTag?: string; payload?: string }
       ) => {
         let procedureName: ProcedureName
         let payload: RequestPayload
         if (options.payload == null) {
+          if (options.connectorId == null) {
+            throw new Error('--connector-id is required when -p/--payload is not provided')
+          }
+          if (options.idTag == null) {
+            throw new Error('--id-tag is required when -p/--payload is not provided')
+          }
           // High-level: detect OCPP version and build correct payload
           const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
             program,
@@ -77,15 +92,21 @@ export const createTransactionCommands = (program: Command): Command => {
   cmd
     .command('stop [hashIds...]')
     .description('Stop a transaction on station(s)')
-    .requiredOption('--transaction-id <id>', 'transaction ID')
-    .option(
-      PAYLOAD_OPTION,
-      PAYLOAD_DESC + ' (uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event)'
+    .addOption(new Option('--transaction-id <id>', 'transaction ID').conflicts('payload'))
+    .addOption(
+      new Option(
+        PAYLOAD_OPTION,
+        PAYLOAD_DESC +
+          ' (uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event)'
+      ).conflicts('transactionId')
     )
-    .action(async (hashIds: string[], options: { payload?: string; transactionId: string }) => {
+    .action(async (hashIds: string[], options: { payload?: string; transactionId?: string }) => {
       let procedureName: ProcedureName
       let payload: RequestPayload
       if (options.payload == null) {
+        if (options.transactionId == null) {
+          throw new Error('--transaction-id is required when -p/--payload is not provided')
+        }
         // High-level: detect OCPP version and build correct payload
         const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
           program,

--- a/ui/cli/src/commands/transaction.ts
+++ b/ui/cli/src/commands/transaction.ts
@@ -8,10 +8,10 @@ import {
 } from 'ui-common'
 
 import {
-  MIXED_OCPP_VERSION_ERROR,
   parseInteger,
   resolveOcppVersionFromProgram,
   runAction,
+  UNSUPPORTED_OCPP_VERSION_ERROR,
 } from './action.js'
 import { buildHashIdsPayload, PAYLOAD_DESC, PAYLOAD_OPTION } from './payload.js'
 
@@ -25,17 +25,17 @@ export const createTransactionCommands = (program: Command): Command => {
       new Option('--connector-id <id>', 'connector ID').argParser(parseInteger).conflicts('payload')
     )
     .addOption(new Option('--id-tag <tag>', 'RFID tag for authorization').conflicts('payload'))
-    .option(
-      '--evse-id <id>',
-      'EVSE ID (OCPP 2.0.x; resolved from connector ID when omitted)',
-      parseInteger
+    .addOption(
+      new Option('--evse-id <id>', 'EVSE ID (OCPP 2.0.x; resolved from connector ID when omitted)')
+        .argParser(parseInteger)
+        .conflicts('payload')
     )
     .addOption(
       new Option(
         PAYLOAD_OPTION,
         PAYLOAD_DESC +
           ' (uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event)'
-      ).conflicts(['connectorId', 'idTag'])
+      ).conflicts(['connectorId', 'evseId', 'idTag'])
     )
     .action(
       async (
@@ -77,7 +77,7 @@ export const createTransactionCommands = (program: Command): Command => {
               }
               break
             default:
-              throw new Error(MIXED_OCPP_VERSION_ERROR)
+              throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
           }
           await runAction(program, procedureName, payload, undefined, config)
         } else {
@@ -94,52 +94,69 @@ export const createTransactionCommands = (program: Command): Command => {
     .description('Stop a transaction on station(s)')
     .addOption(new Option('--transaction-id <id>', 'transaction ID').conflicts('payload'))
     .addOption(
+      new Option('--connector-id <id>', 'connector ID (required for OCPP 2.0.x)')
+        .argParser(parseInteger)
+        .conflicts('payload')
+    )
+    .addOption(
       new Option(
         PAYLOAD_OPTION,
         PAYLOAD_DESC +
           ' (uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event)'
-      ).conflicts('transactionId')
+      ).conflicts(['transactionId', 'connectorId'])
     )
-    .action(async (hashIds: string[], options: { payload?: string; transactionId?: string }) => {
-      let procedureName: ProcedureName
-      let payload: RequestPayload
-      if (options.payload == null) {
-        if (options.transactionId == null) {
-          throw new Error('--transaction-id is required when -p/--payload is not provided')
+    .action(
+      async (
+        hashIds: string[],
+        options: { connectorId?: number; payload?: string; transactionId?: string }
+      ) => {
+        let procedureName: ProcedureName
+        let payload: RequestPayload
+        if (options.payload == null) {
+          if (options.transactionId == null) {
+            throw new Error('--transaction-id is required when -p/--payload is not provided')
+          }
+          // High-level: detect OCPP version and build correct payload
+          const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
+            program,
+            hashIds
+          )
+          switch (ocppVersion) {
+            case OCPPVersion.VERSION_16:
+              procedureName = ProcedureName.STOP_TRANSACTION
+              payload = {
+                transactionId: parseInteger(
+                  options.transactionId,
+                  '--transaction-id (OCPP 1.6 requires integer)'
+                ),
+                ...buildHashIdsPayload(resolvedHashIds),
+              }
+              break
+            case OCPPVersion.VERSION_20:
+            case OCPPVersion.VERSION_201:
+              if (options.connectorId == null) {
+                throw new Error('--connector-id is required for OCPP 2.0.x stations')
+              }
+              procedureName = ProcedureName.TRANSACTION_EVENT
+              payload = {
+                connectorId: options.connectorId,
+                eventType: OCPP20TransactionEventEnumType.ENDED,
+                transactionId: options.transactionId,
+                ...buildHashIdsPayload(resolvedHashIds),
+              }
+              break
+            default:
+              throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
+          }
+          await runAction(program, procedureName, payload, undefined, config)
+        } else {
+          // Low-level passthrough: -p provided, uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event
+          procedureName = ProcedureName.STOP_TRANSACTION
+          payload = buildHashIdsPayload(hashIds)
+          await runAction(program, procedureName, payload, options.payload)
         }
-        // High-level: detect OCPP version and build correct payload
-        const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
-          program,
-          hashIds
-        )
-        switch (ocppVersion) {
-          case OCPPVersion.VERSION_16:
-            procedureName = ProcedureName.STOP_TRANSACTION
-            payload = {
-              transactionId: parseInteger(options.transactionId),
-              ...buildHashIdsPayload(resolvedHashIds),
-            }
-            break
-          case OCPPVersion.VERSION_20:
-          case OCPPVersion.VERSION_201:
-            procedureName = ProcedureName.TRANSACTION_EVENT
-            payload = {
-              eventType: OCPP20TransactionEventEnumType.ENDED,
-              transactionId: options.transactionId,
-              ...buildHashIdsPayload(resolvedHashIds),
-            }
-            break
-          default:
-            throw new Error(MIXED_OCPP_VERSION_ERROR)
-        }
-        await runAction(program, procedureName, payload, undefined, config)
-      } else {
-        // Low-level passthrough: -p provided, uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event
-        procedureName = ProcedureName.STOP_TRANSACTION
-        payload = buildHashIdsPayload(hashIds)
-        await runAction(program, procedureName, payload, options.payload)
       }
-    })
+    )
 
   return cmd
 }

--- a/ui/cli/src/commands/transaction.ts
+++ b/ui/cli/src/commands/transaction.ts
@@ -17,7 +17,7 @@ import { buildHashIdsPayload, PAYLOAD_DESC, PAYLOAD_OPTION } from './payload.js'
 
 export const createTransactionCommands = (program: Command): Command => {
   const cmd = new Command('transaction').description('Transaction management')
-  const unsupportedVersionError =
+  const UNSUPPORTED_VERSION_ERROR =
     'Unsupported OCPP version for this command. ' +
     'Use ocpp transaction-event -p to pass the payload directly.'
 
@@ -81,7 +81,7 @@ export const createTransactionCommands = (program: Command): Command => {
                 }
                 break
               default:
-                throw new Error(unsupportedVersionError)
+                throw new Error(UNSUPPORTED_VERSION_ERROR)
             }
             await runAction(program, procedureName, payload, undefined, config)
           } else {
@@ -152,7 +152,7 @@ export const createTransactionCommands = (program: Command): Command => {
                 }
                 break
               default:
-                throw new Error(unsupportedVersionError)
+                throw new Error(UNSUPPORTED_VERSION_ERROR)
             }
             await runAction(program, procedureName, payload, undefined, config)
           } else {

--- a/ui/cli/src/commands/transaction.ts
+++ b/ui/cli/src/commands/transaction.ts
@@ -1,7 +1,18 @@
 import { Command } from 'commander'
-import { ProcedureName, type RequestPayload } from 'ui-common'
+import {
+  OCPP20IdTokenEnumType,
+  OCPP20TransactionEventEnumType,
+  OCPP20TriggerReasonEnumType,
+  OCPPVersion,
+  ProcedureName,
+  randomUUID,
+  type RequestPayload,
+} from 'ui-common'
 
-import { parseInteger, runAction } from './action.js'
+import type { GlobalOptions } from '../types.js'
+
+import { loadConfig } from '../config/loader.js'
+import { parseInteger, resolveOcppVersion, runAction } from './action.js'
 import { buildHashIdsPayload, PAYLOAD_DESC, PAYLOAD_OPTION } from './payload.js'
 
 export const createTransactionCommands = (program: Command): Command => {
@@ -18,26 +29,93 @@ export const createTransactionCommands = (program: Command): Command => {
         hashIds: string[],
         options: { connectorId: number; idTag: string; payload?: string }
       ) => {
-        const payload: RequestPayload = {
-          connectorId: options.connectorId,
-          idTag: options.idTag,
-          ...buildHashIdsPayload(hashIds),
+        let procedureName: ProcedureName
+        let payload: RequestPayload
+        if (options.payload == null) {
+          // High-level: detect OCPP version and build correct payload
+          const rootOpts = program.opts<GlobalOptions>()
+          const config = await loadConfig({ configPath: rootOpts.config, url: rootOpts.serverUrl })
+          const ocppVersion = await resolveOcppVersion(hashIds, config)
+          if (ocppVersion == null) {
+            throw new Error(
+              'Cannot determine a common OCPP version for the targeted stations. ' +
+                'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
+            )
+          }
+          if (ocppVersion === OCPPVersion.VERSION_20 || ocppVersion === OCPPVersion.VERSION_201) {
+            procedureName = ProcedureName.TRANSACTION_EVENT
+            payload = {
+              eventType: OCPP20TransactionEventEnumType.STARTED,
+              evse: { connectorId: options.connectorId, id: options.connectorId },
+              idToken: { idToken: options.idTag, type: OCPP20IdTokenEnumType.ISO14443 },
+              seqNo: 0,
+              timestamp: new Date().toISOString(),
+              transactionInfo: { transactionId: randomUUID() },
+              triggerReason: OCPP20TriggerReasonEnumType.AUTHORIZED,
+              ...buildHashIdsPayload(hashIds),
+            }
+          } else {
+            procedureName = ProcedureName.START_TRANSACTION
+            payload = {
+              connectorId: options.connectorId,
+              idTag: options.idTag,
+              ...buildHashIdsPayload(hashIds),
+            }
+          }
+        } else {
+          // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
+          procedureName = ProcedureName.START_TRANSACTION
+          payload = buildHashIdsPayload(hashIds)
         }
-        await runAction(program, ProcedureName.START_TRANSACTION, payload, options.payload)
+        await runAction(program, procedureName, payload, options.payload)
       }
     )
 
   cmd
     .command('stop [hashIds...]')
     .description('Stop a transaction on station(s)')
-    .requiredOption('--transaction-id <id>', 'transaction ID', parseInteger)
+    .requiredOption(
+      '--transaction-id <id>',
+      'transaction ID (integer for OCPP 1.6, UUID for OCPP 2.0.x)'
+    )
     .option(PAYLOAD_OPTION, PAYLOAD_DESC)
-    .action(async (hashIds: string[], options: { payload?: string; transactionId: number }) => {
-      const payload: RequestPayload = {
-        transactionId: options.transactionId,
-        ...buildHashIdsPayload(hashIds),
+    .action(async (hashIds: string[], options: { payload?: string; transactionId: string }) => {
+      let procedureName: ProcedureName
+      let payload: RequestPayload
+      if (options.payload == null) {
+        // High-level: detect OCPP version and build correct payload
+        const rootOpts = program.opts<GlobalOptions>()
+        const config = await loadConfig({ configPath: rootOpts.config, url: rootOpts.serverUrl })
+        const ocppVersion = await resolveOcppVersion(hashIds, config)
+        if (ocppVersion == null) {
+          throw new Error(
+            'Cannot determine a common OCPP version for the targeted stations. ' +
+              'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
+          )
+        }
+        if (ocppVersion === OCPPVersion.VERSION_20 || ocppVersion === OCPPVersion.VERSION_201) {
+          procedureName = ProcedureName.TRANSACTION_EVENT
+          payload = {
+            eventType: OCPP20TransactionEventEnumType.ENDED,
+            seqNo: 0,
+            timestamp: new Date().toISOString(),
+            transactionInfo: { transactionId: options.transactionId },
+            triggerReason: OCPP20TriggerReasonEnumType.REMOTE_STOP,
+            ...buildHashIdsPayload(hashIds),
+          }
+        } else {
+          procedureName = ProcedureName.STOP_TRANSACTION
+          payload = {
+            transactionId: parseInteger(options.transactionId),
+            ...buildHashIdsPayload(hashIds),
+          }
+        }
+      } else {
+        // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
+        procedureName = ProcedureName.STOP_TRANSACTION
+        payload = buildHashIdsPayload(hashIds)
       }
-      await runAction(program, ProcedureName.STOP_TRANSACTION, payload, options.payload)
+      await runAction(program, procedureName, payload, options.payload)
     })
 
   return cmd

--- a/ui/cli/src/commands/transaction.ts
+++ b/ui/cli/src/commands/transaction.ts
@@ -17,6 +17,9 @@ import { buildHashIdsPayload, PAYLOAD_DESC, PAYLOAD_OPTION } from './payload.js'
 
 export const createTransactionCommands = (program: Command): Command => {
   const cmd = new Command('transaction').description('Transaction management')
+  const unsupportedVersionError =
+    'Unsupported OCPP version for this command. ' +
+    'Use ocpp transaction-event -p to pass the payload directly.'
 
   cmd
     .command('start [hashIds...]')
@@ -78,9 +81,7 @@ export const createTransactionCommands = (program: Command): Command => {
                 }
                 break
               default:
-                throw new Error(
-                  'Unsupported OCPP version for this command. Use ocpp transaction-event -p to pass the payload directly.'
-                )
+                throw new Error(unsupportedVersionError)
             }
             await runAction(program, procedureName, payload, undefined, config)
           } else {
@@ -151,9 +152,7 @@ export const createTransactionCommands = (program: Command): Command => {
                 }
                 break
               default:
-                throw new Error(
-                  'Unsupported OCPP version for this command. Use ocpp transaction-event -p to pass the payload directly.'
-                )
+                throw new Error(unsupportedVersionError)
             }
             await runAction(program, procedureName, payload, undefined, config)
           } else {

--- a/ui/cli/src/commands/transaction.ts
+++ b/ui/cli/src/commands/transaction.ts
@@ -2,10 +2,8 @@ import { Command } from 'commander'
 import {
   OCPP20IdTokenEnumType,
   OCPP20TransactionEventEnumType,
-  OCPP20TriggerReasonEnumType,
   OCPPVersion,
   ProcedureName,
-  randomUUID,
   type RequestPayload,
 } from 'ui-common'
 
@@ -56,13 +54,10 @@ export const createTransactionCommands = (program: Command): Command => {
             case OCPPVersion.VERSION_201:
               procedureName = ProcedureName.TRANSACTION_EVENT
               payload = {
+                connectorId: options.connectorId,
                 eventType: OCPP20TransactionEventEnumType.STARTED,
-                evse: { connectorId: options.connectorId, id: options.evseId ?? 1 },
+                ...(options.evseId != null && { evseId: options.evseId }),
                 idToken: { idToken: options.idTag, type: OCPP20IdTokenEnumType.ISO14443 },
-                seqNo: 0,
-                timestamp: new Date().toISOString(),
-                transactionInfo: { transactionId: randomUUID() },
-                triggerReason: OCPP20TriggerReasonEnumType.AUTHORIZED,
                 ...buildHashIdsPayload(resolvedHashIds),
               }
               break
@@ -109,11 +104,7 @@ export const createTransactionCommands = (program: Command): Command => {
             procedureName = ProcedureName.TRANSACTION_EVENT
             payload = {
               eventType: OCPP20TransactionEventEnumType.ENDED,
-              // seqNo 1: start uses 0; stop is the next event in sequence (simplified)
-              seqNo: 1,
-              timestamp: new Date().toISOString(),
-              transactionInfo: { transactionId: options.transactionId },
-              triggerReason: OCPP20TriggerReasonEnumType.REMOTE_STOP,
+              transactionId: options.transactionId,
               ...buildHashIdsPayload(resolvedHashIds),
             }
             break

--- a/ui/cli/src/commands/transaction.ts
+++ b/ui/cli/src/commands/transaction.ts
@@ -12,7 +12,6 @@ import {
   parseInteger,
   resolveOcppVersionFromProgram,
   runAction,
-  UNSUPPORTED_OCPP_VERSION_ERROR,
 } from './action.js'
 import { buildHashIdsPayload, PAYLOAD_DESC, PAYLOAD_OPTION } from './payload.js'
 
@@ -79,7 +78,9 @@ export const createTransactionCommands = (program: Command): Command => {
                 }
                 break
               default:
-                throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
+                throw new Error(
+                  'Unsupported OCPP version for this command. Use ocpp transaction-event -p to pass the payload directly.'
+                )
             }
             await runAction(program, procedureName, payload, undefined, config)
           } else {
@@ -150,7 +151,9 @@ export const createTransactionCommands = (program: Command): Command => {
                 }
                 break
               default:
-                throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
+                throw new Error(
+                  'Unsupported OCPP version for this command. Use ocpp transaction-event -p to pass the payload directly.'
+                )
             }
             await runAction(program, procedureName, payload, undefined, config)
           } else {

--- a/ui/cli/src/commands/transaction.ts
+++ b/ui/cli/src/commands/transaction.ts
@@ -9,10 +9,12 @@ import {
   type RequestPayload,
 } from 'ui-common'
 
-import type { GlobalOptions } from '../types.js'
-
-import { loadConfig } from '../config/loader.js'
-import { parseInteger, resolveOcppVersion, runAction } from './action.js'
+import {
+  MIXED_OCPP_VERSION_ERROR,
+  parseInteger,
+  resolveOcppVersionFromProgram,
+  runAction,
+} from './action.js'
 import { buildHashIdsPayload, PAYLOAD_DESC, PAYLOAD_OPTION } from './payload.js'
 
 export const createTransactionCommands = (program: Command): Command => {
@@ -23,26 +25,31 @@ export const createTransactionCommands = (program: Command): Command => {
     .description('Start a transaction on station(s)')
     .requiredOption('--connector-id <id>', 'connector ID', parseInteger)
     .requiredOption('--id-tag <tag>', 'RFID tag for authorization')
-    .option(PAYLOAD_OPTION, PAYLOAD_DESC)
+    .option('--evse-id <id>', 'EVSE ID (OCPP 2.0.x; defaults to 1)', parseInteger)
+    .option(
+      PAYLOAD_OPTION,
+      PAYLOAD_DESC + ' (uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event)'
+    )
     .action(
       async (
         hashIds: string[],
-        options: { connectorId: number; idTag: string; payload?: string }
+        options: { connectorId: number; evseId?: number; idTag: string; payload?: string }
       ) => {
         let procedureName: ProcedureName
         let payload: RequestPayload
         if (options.payload == null) {
           // High-level: detect OCPP version and build correct payload
-          const rootOpts = program.opts<GlobalOptions>()
-          const config = await loadConfig({ configPath: rootOpts.config, url: rootOpts.serverUrl })
-          const ocppVersion = await resolveOcppVersion(hashIds, config)
+          const { ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
+            program,
+            hashIds
+          )
           switch (ocppVersion) {
             case OCPPVersion.VERSION_16:
               procedureName = ProcedureName.START_TRANSACTION
               payload = {
                 connectorId: options.connectorId,
                 idTag: options.idTag,
-                ...buildHashIdsPayload(hashIds),
+                ...buildHashIdsPayload(resolvedHashIds),
               }
               break
             case OCPPVersion.VERSION_20:
@@ -50,23 +57,20 @@ export const createTransactionCommands = (program: Command): Command => {
               procedureName = ProcedureName.TRANSACTION_EVENT
               payload = {
                 eventType: OCPP20TransactionEventEnumType.STARTED,
-                evse: { connectorId: options.connectorId, id: options.connectorId },
+                evse: { connectorId: options.connectorId, id: options.evseId ?? 1 },
                 idToken: { idToken: options.idTag, type: OCPP20IdTokenEnumType.ISO14443 },
                 seqNo: 0,
                 timestamp: new Date().toISOString(),
                 transactionInfo: { transactionId: randomUUID() },
                 triggerReason: OCPP20TriggerReasonEnumType.AUTHORIZED,
-                ...buildHashIdsPayload(hashIds),
+                ...buildHashIdsPayload(resolvedHashIds),
               }
               break
             default:
-              throw new Error(
-                'Cannot determine a common OCPP version for the targeted stations. ' +
-                  'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
-              )
+              throw new Error(MIXED_OCPP_VERSION_ERROR)
           }
         } else {
-          // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
+          // Low-level passthrough: -p provided, uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event
           procedureName = ProcedureName.START_TRANSACTION
           payload = buildHashIdsPayload(hashIds)
         }
@@ -78,21 +82,25 @@ export const createTransactionCommands = (program: Command): Command => {
     .command('stop [hashIds...]')
     .description('Stop a transaction on station(s)')
     .requiredOption('--transaction-id <id>', 'transaction ID')
-    .option(PAYLOAD_OPTION, PAYLOAD_DESC)
+    .option(
+      PAYLOAD_OPTION,
+      PAYLOAD_DESC + ' (uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event)'
+    )
     .action(async (hashIds: string[], options: { payload?: string; transactionId: string }) => {
       let procedureName: ProcedureName
       let payload: RequestPayload
       if (options.payload == null) {
         // High-level: detect OCPP version and build correct payload
-        const rootOpts = program.opts<GlobalOptions>()
-        const config = await loadConfig({ configPath: rootOpts.config, url: rootOpts.serverUrl })
-        const ocppVersion = await resolveOcppVersion(hashIds, config)
+        const { ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
+          program,
+          hashIds
+        )
         switch (ocppVersion) {
           case OCPPVersion.VERSION_16:
             procedureName = ProcedureName.STOP_TRANSACTION
             payload = {
               transactionId: parseInteger(options.transactionId),
-              ...buildHashIdsPayload(hashIds),
+              ...buildHashIdsPayload(resolvedHashIds),
             }
             break
           case OCPPVersion.VERSION_20:
@@ -104,17 +112,14 @@ export const createTransactionCommands = (program: Command): Command => {
               timestamp: new Date().toISOString(),
               transactionInfo: { transactionId: options.transactionId },
               triggerReason: OCPP20TriggerReasonEnumType.REMOTE_STOP,
-              ...buildHashIdsPayload(hashIds),
+              ...buildHashIdsPayload(resolvedHashIds),
             }
             break
           default:
-            throw new Error(
-              'Cannot determine a common OCPP version for the targeted stations. ' +
-                'Target homogeneous stations (same OCPP version) or use -p to pass the payload directly.'
-            )
+            throw new Error(MIXED_OCPP_VERSION_ERROR)
         }
       } else {
-        // Low-level passthrough: -p provided, use only routing fields; raw payload has full control
+        // Low-level passthrough: -p provided, uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event
         procedureName = ProcedureName.STOP_TRANSACTION
         payload = buildHashIdsPayload(hashIds)
       }

--- a/ui/cli/src/commands/transaction.ts
+++ b/ui/cli/src/commands/transaction.ts
@@ -8,6 +8,7 @@ import {
 } from 'ui-common'
 
 import {
+  handleActionErrors,
   parseInteger,
   resolveOcppVersionFromProgram,
   runAction,
@@ -42,50 +43,52 @@ export const createTransactionCommands = (program: Command): Command => {
         hashIds: string[],
         options: { connectorId?: number; evseId?: number; idTag?: string; payload?: string }
       ) => {
-        let procedureName: ProcedureName
-        let payload: RequestPayload
-        if (options.payload == null) {
-          if (options.connectorId == null) {
-            throw new Error('--connector-id is required when -p/--payload is not provided')
+        await handleActionErrors(program, async () => {
+          let procedureName: ProcedureName
+          let payload: RequestPayload
+          if (options.payload == null) {
+            if (options.connectorId == null) {
+              throw new Error('--connector-id is required when -p/--payload is not provided')
+            }
+            if (options.idTag == null) {
+              throw new Error('--id-tag is required when -p/--payload is not provided')
+            }
+            // High-level: detect OCPP version and build correct payload
+            const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
+              program,
+              hashIds
+            )
+            switch (ocppVersion) {
+              case OCPPVersion.VERSION_16:
+                procedureName = ProcedureName.START_TRANSACTION
+                payload = {
+                  connectorId: options.connectorId,
+                  idTag: options.idTag,
+                  ...buildHashIdsPayload(resolvedHashIds),
+                }
+                break
+              case OCPPVersion.VERSION_20:
+              case OCPPVersion.VERSION_201:
+                procedureName = ProcedureName.TRANSACTION_EVENT
+                payload = {
+                  connectorId: options.connectorId,
+                  eventType: OCPP20TransactionEventEnumType.STARTED,
+                  ...(options.evseId != null && { evseId: options.evseId }),
+                  idToken: { idToken: options.idTag, type: OCPP20IdTokenEnumType.ISO14443 },
+                  ...buildHashIdsPayload(resolvedHashIds),
+                }
+                break
+              default:
+                throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
+            }
+            await runAction(program, procedureName, payload, undefined, config)
+          } else {
+            // Low-level passthrough: -p provided, uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event
+            procedureName = ProcedureName.START_TRANSACTION
+            payload = buildHashIdsPayload(hashIds)
+            await runAction(program, procedureName, payload, options.payload)
           }
-          if (options.idTag == null) {
-            throw new Error('--id-tag is required when -p/--payload is not provided')
-          }
-          // High-level: detect OCPP version and build correct payload
-          const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
-            program,
-            hashIds
-          )
-          switch (ocppVersion) {
-            case OCPPVersion.VERSION_16:
-              procedureName = ProcedureName.START_TRANSACTION
-              payload = {
-                connectorId: options.connectorId,
-                idTag: options.idTag,
-                ...buildHashIdsPayload(resolvedHashIds),
-              }
-              break
-            case OCPPVersion.VERSION_20:
-            case OCPPVersion.VERSION_201:
-              procedureName = ProcedureName.TRANSACTION_EVENT
-              payload = {
-                connectorId: options.connectorId,
-                eventType: OCPP20TransactionEventEnumType.STARTED,
-                ...(options.evseId != null && { evseId: options.evseId }),
-                idToken: { idToken: options.idTag, type: OCPP20IdTokenEnumType.ISO14443 },
-                ...buildHashIdsPayload(resolvedHashIds),
-              }
-              break
-            default:
-              throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
-          }
-          await runAction(program, procedureName, payload, undefined, config)
-        } else {
-          // Low-level passthrough: -p provided, uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event
-          procedureName = ProcedureName.START_TRANSACTION
-          payload = buildHashIdsPayload(hashIds)
-          await runAction(program, procedureName, payload, options.payload)
-        }
+        })
       }
     )
 
@@ -110,51 +113,53 @@ export const createTransactionCommands = (program: Command): Command => {
         hashIds: string[],
         options: { connectorId?: number; payload?: string; transactionId?: string }
       ) => {
-        let procedureName: ProcedureName
-        let payload: RequestPayload
-        if (options.payload == null) {
-          if (options.transactionId == null) {
-            throw new Error('--transaction-id is required when -p/--payload is not provided')
+        await handleActionErrors(program, async () => {
+          let procedureName: ProcedureName
+          let payload: RequestPayload
+          if (options.payload == null) {
+            if (options.transactionId == null) {
+              throw new Error('--transaction-id is required when -p/--payload is not provided')
+            }
+            // High-level: detect OCPP version and build correct payload
+            const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
+              program,
+              hashIds
+            )
+            switch (ocppVersion) {
+              case OCPPVersion.VERSION_16:
+                procedureName = ProcedureName.STOP_TRANSACTION
+                payload = {
+                  transactionId: parseInteger(
+                    options.transactionId,
+                    '--transaction-id (OCPP 1.6 requires integer)'
+                  ),
+                  ...buildHashIdsPayload(resolvedHashIds),
+                }
+                break
+              case OCPPVersion.VERSION_20:
+              case OCPPVersion.VERSION_201:
+                if (options.connectorId == null) {
+                  throw new Error('--connector-id is required for OCPP 2.0.x stations')
+                }
+                procedureName = ProcedureName.TRANSACTION_EVENT
+                payload = {
+                  connectorId: options.connectorId,
+                  eventType: OCPP20TransactionEventEnumType.ENDED,
+                  transactionId: options.transactionId,
+                  ...buildHashIdsPayload(resolvedHashIds),
+                }
+                break
+              default:
+                throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
+            }
+            await runAction(program, procedureName, payload, undefined, config)
+          } else {
+            // Low-level passthrough: -p provided, uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event
+            procedureName = ProcedureName.STOP_TRANSACTION
+            payload = buildHashIdsPayload(hashIds)
+            await runAction(program, procedureName, payload, options.payload)
           }
-          // High-level: detect OCPP version and build correct payload
-          const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
-            program,
-            hashIds
-          )
-          switch (ocppVersion) {
-            case OCPPVersion.VERSION_16:
-              procedureName = ProcedureName.STOP_TRANSACTION
-              payload = {
-                transactionId: parseInteger(
-                  options.transactionId,
-                  '--transaction-id (OCPP 1.6 requires integer)'
-                ),
-                ...buildHashIdsPayload(resolvedHashIds),
-              }
-              break
-            case OCPPVersion.VERSION_20:
-            case OCPPVersion.VERSION_201:
-              if (options.connectorId == null) {
-                throw new Error('--connector-id is required for OCPP 2.0.x stations')
-              }
-              procedureName = ProcedureName.TRANSACTION_EVENT
-              payload = {
-                connectorId: options.connectorId,
-                eventType: OCPP20TransactionEventEnumType.ENDED,
-                transactionId: options.transactionId,
-                ...buildHashIdsPayload(resolvedHashIds),
-              }
-              break
-            default:
-              throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
-          }
-          await runAction(program, procedureName, payload, undefined, config)
-        } else {
-          // Low-level passthrough: -p provided, uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event
-          procedureName = ProcedureName.STOP_TRANSACTION
-          payload = buildHashIdsPayload(hashIds)
-          await runAction(program, procedureName, payload, options.payload)
-        }
+        })
       }
     )
 

--- a/ui/cli/src/commands/transaction.ts
+++ b/ui/cli/src/commands/transaction.ts
@@ -17,7 +17,7 @@ import { buildHashIdsPayload, PAYLOAD_DESC, PAYLOAD_OPTION } from './payload.js'
 
 export const createTransactionCommands = (program: Command): Command => {
   const cmd = new Command('transaction').description('Transaction management')
-  const UNSUPPORTED_VERSION_ERROR =
+  const UNSUPPORTED_OCPP_VERSION_ERROR =
     'Unsupported OCPP version for this command. ' +
     'Use ocpp transaction-event -p to pass the payload directly.'
 
@@ -81,7 +81,7 @@ export const createTransactionCommands = (program: Command): Command => {
                 }
                 break
               default:
-                throw new Error(UNSUPPORTED_VERSION_ERROR)
+                throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
             }
             await runAction(program, procedureName, payload, undefined, config)
           } else {
@@ -152,7 +152,7 @@ export const createTransactionCommands = (program: Command): Command => {
                 }
                 break
               default:
-                throw new Error(UNSUPPORTED_VERSION_ERROR)
+                throw new Error(UNSUPPORTED_OCPP_VERSION_ERROR)
             }
             await runAction(program, procedureName, payload, undefined, config)
           } else {

--- a/ui/cli/src/commands/transaction.ts
+++ b/ui/cli/src/commands/transaction.ts
@@ -27,7 +27,7 @@ export const createTransactionCommands = (program: Command): Command => {
     )
     .addOption(new Option('--id-tag <tag>', 'RFID tag for authorization').conflicts('payload'))
     .addOption(
-      new Option('--evse-id <id>', 'EVSE ID (OCPP 2.0.x; resolved from connector ID when omitted)')
+      new Option('--evse-id <id>', 'EVSE ID (OCPP 2.0.x; derived from connector ID if omitted)')
         .argParser(parseInteger)
         .conflicts('payload')
     )

--- a/ui/cli/src/commands/transaction.ts
+++ b/ui/cli/src/commands/transaction.ts
@@ -39,7 +39,7 @@ export const createTransactionCommands = (program: Command): Command => {
         let payload: RequestPayload
         if (options.payload == null) {
           // High-level: detect OCPP version and build correct payload
-          const { ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
+          const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
             program,
             hashIds
           )
@@ -69,12 +69,13 @@ export const createTransactionCommands = (program: Command): Command => {
             default:
               throw new Error(MIXED_OCPP_VERSION_ERROR)
           }
+          await runAction(program, procedureName, payload, undefined, config)
         } else {
           // Low-level passthrough: -p provided, uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event
           procedureName = ProcedureName.START_TRANSACTION
           payload = buildHashIdsPayload(hashIds)
+          await runAction(program, procedureName, payload, options.payload)
         }
-        await runAction(program, procedureName, payload, options.payload)
       }
     )
 
@@ -91,7 +92,7 @@ export const createTransactionCommands = (program: Command): Command => {
       let payload: RequestPayload
       if (options.payload == null) {
         // High-level: detect OCPP version and build correct payload
-        const { ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
+        const { config, ocppVersion, resolvedHashIds } = await resolveOcppVersionFromProgram(
           program,
           hashIds
         )
@@ -108,7 +109,8 @@ export const createTransactionCommands = (program: Command): Command => {
             procedureName = ProcedureName.TRANSACTION_EVENT
             payload = {
               eventType: OCPP20TransactionEventEnumType.ENDED,
-              seqNo: 0,
+              // seqNo 1: start uses 0; stop is the next event in sequence (simplified)
+              seqNo: 1,
               timestamp: new Date().toISOString(),
               transactionInfo: { transactionId: options.transactionId },
               triggerReason: OCPP20TriggerReasonEnumType.REMOTE_STOP,
@@ -118,12 +120,13 @@ export const createTransactionCommands = (program: Command): Command => {
           default:
             throw new Error(MIXED_OCPP_VERSION_ERROR)
         }
+        await runAction(program, procedureName, payload, undefined, config)
       } else {
         // Low-level passthrough: -p provided, uses OCPP 1.6 procedure; for 2.0.x raw payloads use ocpp transaction-event
         procedureName = ProcedureName.STOP_TRANSACTION
         payload = buildHashIdsPayload(hashIds)
+        await runAction(program, procedureName, payload, options.payload)
       }
-      await runAction(program, procedureName, payload, options.payload)
     })
 
   return cmd

--- a/ui/cli/tests/action.test.ts
+++ b/ui/cli/tests/action.test.ts
@@ -92,6 +92,18 @@ await describe('resolveOcppVersionFromList', async () => {
       assert.strictEqual(resolveOcppVersionFromList(['aaa'], stations), undefined)
     })
 
+    await it("returns version when some hashIds match and others don't", () => {
+      const stations = [
+        station('aaa111', OCPPVersion.VERSION_201),
+        station('bbb222', OCPPVersion.VERSION_16),
+      ]
+      // 'aaa' matches aaa111, 'zzz' matches nothing — only aaa111 targeted
+      assert.strictEqual(
+        resolveOcppVersionFromList(['aaa', 'zzz'], stations),
+        OCPPVersion.VERSION_201
+      )
+    })
+
     await it('returns common version when multiple hashIds all resolve to same version', () => {
       const stations = [
         station('aaa111', OCPPVersion.VERSION_201),

--- a/ui/cli/tests/action.test.ts
+++ b/ui/cli/tests/action.test.ts
@@ -70,6 +70,15 @@ await describe('resolveOcppVersionFromList', async () => {
       assert.strictEqual(resolveOcppVersionFromList(['aaa'], stations), OCPPVersion.VERSION_201)
     })
 
+    await it('returns the common version when an ambiguous prefix matches multiple stations with homogeneous versions', () => {
+      const stations = [
+        station('aaa111', OCPPVersion.VERSION_201),
+        station('aaa222', OCPPVersion.VERSION_201),
+        station('bbb333', OCPPVersion.VERSION_16),
+      ]
+      assert.strictEqual(resolveOcppVersionFromList(['aaa'], stations), OCPPVersion.VERSION_201)
+    })
+
     await it('returns undefined when prefix matches no station', () => {
       const stations = [station('aaa111', OCPPVersion.VERSION_16)]
       assert.strictEqual(resolveOcppVersionFromList(['zzz'], stations), undefined)

--- a/ui/cli/tests/action.test.ts
+++ b/ui/cli/tests/action.test.ts
@@ -1,0 +1,126 @@
+/** @file Unit tests for resolveOcppVersionFromList */
+
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { OCPPVersion } from 'ui-common'
+
+import { resolveOcppVersionFromList } from '../src/commands/action.js'
+
+interface StationEntry {
+  stationInfo: { hashId: string; ocppVersion?: OCPPVersion }
+}
+
+const station = (hashId: string, ocppVersion?: OCPPVersion): StationEntry => ({
+  stationInfo: { hashId, ocppVersion },
+})
+
+await describe('resolveOcppVersionFromList', async () => {
+  await describe('empty station list', async () => {
+    await it('returns undefined when list is empty and no hashIds given', () => {
+      assert.strictEqual(resolveOcppVersionFromList([], []), undefined)
+    })
+
+    await it('returns undefined when list is empty and hashIds are given', () => {
+      assert.strictEqual(resolveOcppVersionFromList(['abc'], []), undefined)
+    })
+  })
+
+  await describe('no hashIds (all stations)', async () => {
+    await it('returns the common version when all stations share one version', () => {
+      const stations = [
+        station('aaa111', OCPPVersion.VERSION_201),
+        station('bbb222', OCPPVersion.VERSION_201),
+      ]
+      assert.strictEqual(resolveOcppVersionFromList([], stations), OCPPVersion.VERSION_201)
+    })
+
+    await it('returns undefined when stations have heterogeneous versions', () => {
+      const stations = [
+        station('aaa111', OCPPVersion.VERSION_16),
+        station('bbb222', OCPPVersion.VERSION_201),
+      ]
+      assert.strictEqual(resolveOcppVersionFromList([], stations), undefined)
+    })
+
+    await it('returns undefined when ocppVersion is missing on any station', () => {
+      const stations = [station('aaa111', OCPPVersion.VERSION_16), station('bbb222', undefined)]
+      assert.strictEqual(resolveOcppVersionFromList([], stations), undefined)
+    })
+
+    await it('returns undefined when ocppVersion is missing on all stations', () => {
+      const stations = [station('aaa111', undefined), station('bbb222', undefined)]
+      assert.strictEqual(resolveOcppVersionFromList([], stations), undefined)
+    })
+  })
+
+  await describe('hashId filtering', async () => {
+    await it('returns version when exact hashId matches', () => {
+      const stations = [
+        station('aaa111', OCPPVersion.VERSION_16),
+        station('bbb222', OCPPVersion.VERSION_201),
+      ]
+      assert.strictEqual(resolveOcppVersionFromList(['aaa111'], stations), OCPPVersion.VERSION_16)
+    })
+
+    await it('matches by prefix', () => {
+      const stations = [
+        station('aaa111bbbccc', OCPPVersion.VERSION_201),
+        station('xxx999', OCPPVersion.VERSION_16),
+      ]
+      assert.strictEqual(resolveOcppVersionFromList(['aaa'], stations), OCPPVersion.VERSION_201)
+    })
+
+    await it('returns undefined when prefix matches no station', () => {
+      const stations = [station('aaa111', OCPPVersion.VERSION_16)]
+      assert.strictEqual(resolveOcppVersionFromList(['zzz'], stations), undefined)
+    })
+
+    await it('returns undefined when matched stations have heterogeneous versions', () => {
+      const stations = [
+        station('aaa111', OCPPVersion.VERSION_16),
+        station('aaa222', OCPPVersion.VERSION_201),
+      ]
+      assert.strictEqual(resolveOcppVersionFromList(['aaa'], stations), undefined)
+    })
+
+    await it('returns common version when multiple hashIds all resolve to same version', () => {
+      const stations = [
+        station('aaa111', OCPPVersion.VERSION_201),
+        station('bbb222', OCPPVersion.VERSION_201),
+        station('ccc333', OCPPVersion.VERSION_16),
+      ]
+      assert.strictEqual(
+        resolveOcppVersionFromList(['aaa111', 'bbb222'], stations),
+        OCPPVersion.VERSION_201
+      )
+    })
+
+    await it('returns undefined when matched stations have unknown/missing ocppVersion', () => {
+      const stations = [station('aaa111', undefined), station('bbb222', OCPPVersion.VERSION_201)]
+      assert.strictEqual(resolveOcppVersionFromList(['aaa111'], stations), undefined)
+    })
+  })
+
+  await describe('OCPP version values', async () => {
+    await it('returns VERSION_16 correctly', () => {
+      assert.strictEqual(
+        resolveOcppVersionFromList([], [station('a', OCPPVersion.VERSION_16)]),
+        OCPPVersion.VERSION_16
+      )
+    })
+
+    await it('returns VERSION_20 correctly', () => {
+      assert.strictEqual(
+        resolveOcppVersionFromList([], [station('a', OCPPVersion.VERSION_20)]),
+        OCPPVersion.VERSION_20
+      )
+    })
+
+    await it('returns VERSION_201 correctly', () => {
+      assert.strictEqual(
+        resolveOcppVersionFromList([], [station('a', OCPPVersion.VERSION_201)]),
+        OCPPVersion.VERSION_201
+      )
+    })
+  })
+})

--- a/ui/common/src/types/ChargingStationType.ts
+++ b/ui/common/src/types/ChargingStationType.ts
@@ -104,8 +104,6 @@ export enum OCPP20TransactionEventEnumType {
   UPDATED = 'Updated',
 }
 
-// NOTE: OCPP20TriggerReasonEnumType also exists in src/types/ocpp/2.0/Transaction.ts with PascalCase
-// member names. ui-common cannot import from src/, so this copy is kept in sync manually.
 export enum OCPP20TriggerReasonEnumType {
   ABNORMAL_CONDITION = 'AbnormalCondition',
   AUTHORIZED = 'Authorized',

--- a/ui/common/src/types/ChargingStationType.ts
+++ b/ui/common/src/types/ChargingStationType.ts
@@ -104,6 +104,8 @@ export enum OCPP20TransactionEventEnumType {
   UPDATED = 'Updated',
 }
 
+// NOTE: OCPP20TriggerReasonEnumType also exists in src/types/ocpp/2.0/Transaction.ts with PascalCase
+// member names. ui-common cannot import from src/, so this copy is kept in sync manually.
 export enum OCPP20TriggerReasonEnumType {
   ABNORMAL_CONDITION = 'AbnormalCondition',
   AUTHORIZED = 'Authorized',

--- a/ui/common/src/types/ChargingStationType.ts
+++ b/ui/common/src/types/ChargingStationType.ts
@@ -104,6 +104,30 @@ export enum OCPP20TransactionEventEnumType {
   UPDATED = 'Updated',
 }
 
+export enum OCPP20TriggerReasonEnumType {
+  ABNORMAL_CONDITION = 'AbnormalCondition',
+  AUTHORIZED = 'Authorized',
+  CABLE_PLUGGED_IN = 'CablePluggedIn',
+  CHARGING_RATE_CHANGED = 'ChargingRateChanged',
+  CHARGING_STATE_CHANGED = 'ChargingStateChanged',
+  DEAUTHORIZED = 'Deauthorized',
+  ENERGY_LIMIT_REACHED = 'EnergyLimitReached',
+  EV_COMMUNICATION_LOST = 'EVCommunicationLost',
+  EV_CONNECT_TIMEOUT = 'EVConnectTimeout',
+  EV_DEPARTED = 'EVDeparted',
+  EV_DETECTED = 'EVDetected',
+  METER_VALUE_CLOCK = 'MeterValueClock',
+  METER_VALUE_PERIODIC = 'MeterValuePeriodic',
+  REMOTE_START = 'RemoteStart',
+  REMOTE_STOP = 'RemoteStop',
+  RESET_COMMAND = 'ResetCommand',
+  SIGNED_DATA_RECEIVED = 'SignedDataReceived',
+  STOP_AUTHORIZED = 'StopAuthorized',
+  TIME_LIMIT_REACHED = 'TimeLimitReached',
+  TRIGGER = 'Trigger',
+  UNLOCK_COMMAND = 'UnlockCommand',
+}
+
 export enum OCPPProtocol {
   JSON = 'json',
 }


### PR DESCRIPTION
## Summary

CLI high-level commands now detect the target station's OCPP version and construct the appropriate payload for OCPP 1.6 vs 2.0.x. Low-level passthrough (`-p`) remains unchanged — full control for debugging.

### Version-aware commands

| Command | OCPP 1.6 | OCPP 2.0.x |
|---|---|---|
| `transaction start` | `START_TRANSACTION` + `{connectorId, idTag}` | `TRANSACTION_EVENT` + `{eventType: Started, connectorId, idToken}` |
| `transaction stop` | `STOP_TRANSACTION` + integer `transactionId` | `TRANSACTION_EVENT` + `{eventType: Ended, connectorId, transactionId}` |
| `ocpp authorize` | `{idTag}` | `{idToken: {idToken, type: ISO14443}}` |
| `ocpp meter-values` | `{connectorId}` | `{evseId}` |
| `ocpp status-notification` | `{connectorId, errorCode, status}` | `{connectorId, connectorStatus[, evseId]}` |

### Changes

**`ui/cli/src/commands/action.ts`**
- Extract `fetchStationList()` helper; share station-list fetch between hash-ID resolution and version detection
- Export `resolveOcppVersionFromProgram()` — single fetch for config, hash resolution, and OCPP version
- Export `resolveOcppVersionFromList()` — pure helper for unit testing
- Validate full-length hash IDs against station list (previously skipped)
- Differentiated error messages: `NO_STATIONS_ERROR`, `UNKNOWN_OCPP_VERSION_ERROR`, `MIXED_OCPP_VERSION_ERROR`, `UNSUPPORTED_OCPP_VERSION_ERROR`
- `parseInteger` accepts optional label via dual-purpose `nameOrPrevious` param (Commander-compatible)
- `handleActionErrors` wrapper routes pre-`runAction` errors through formatter for `--json` mode
- `formatError` extracted from duplicated catch blocks in `handleActionErrors` and `runAction`

**`ui/cli/src/commands/transaction.ts`**
- `transaction start`: version-aware payload with `.conflicts()` pattern
- `transaction stop`: version-aware; `--connector-id` required for OCPP 2.0.x; `--transaction-id` deferred integer validation (1.6 = integer, 2.0.x = UUID string)
- All semantic options conflict with `-p`; passthrough uses OCPP 1.6 procedure

**`ui/cli/src/commands/ocpp.ts`**
- `authorize`: `.conflicts()` pattern between `--id-tag` and `-p`
- `meter-values`: version-aware; OCPP 1.6 requires `--connector-id`, OCPP 2.0.x requires `--evse-id`
- `status-notification`: version-aware; `--error-code` required for OCPP 1.6 only
- All semantic options conflict with `-p`

**`ui/cli/tests/action.test.ts`**
- Thorough unit tests for `resolveOcppVersionFromList` (empty lists, heterogeneous versions, prefix matching, missing ocppVersion)

**`ui/common/src/types/ChargingStationType.ts`**
- Add `OCPP20TriggerReasonEnumType` enum

### Design

- **High-level commands** = version-aware abstractions — CLI detects OCPP version, builds correct payload
- **Low-level passthrough** (`-p`) = user has full control, no version detection, no validation
- **Server is a passthrough by design** — CLI constructs correct payloads, server forwards to OCPP stack