### PR TITLE
feat(ui-server): allow override of station identity and CSMS credentials in addChargingStations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1061,8 +1061,11 @@ Set the WebSocket header _Sec-WebSocket-Protocol_ to `ui0.0.1`.
   `ProcedureName`: 'setSupervisionUrl'  
   `PDU`: {  
    `hashIds`: charging station unique identifier strings array (optional, default: all charging stations),  
-   `url`: string  
-  }
+   `url?`: string,  
+   `supervisionUser?`: string,  
+   `supervisionPassword?`: string  
+  }  
+  At least one of `url`, `supervisionUser` or `supervisionPassword` must be provided. Changes take effect on the next WebSocket (re)connect.
 
 - Response:  
   `PDU`: {  

--- a/README.md
+++ b/README.md
@@ -1016,13 +1016,18 @@ Set the WebSocket header _Sec-WebSocket-Protocol_ to `ui0.0.1`.
    `template`: string,  
    `numberOfStations`: number,  
    `options?`: {  
-   `supervisionUrls?`: string | string[],  
-   `persistentConfiguration?`: boolean,  
-   `autoStart?`: boolean,  
    `autoRegister?`: boolean,  
+   `autoStart?`: boolean,  
+   `baseName?`: string,  
    `enableStatistics?`: boolean,  
+   `fixedName?`: boolean,  
+   `nameSuffix?`: string,  
    `ocppStrictCompliance?`: boolean,  
-   `stopTransactionsOnStopped?`: boolean  
+   `persistentConfiguration?`: boolean,  
+   `stopTransactionsOnStopped?`: boolean,  
+   `supervisionPassword?`: string,  
+   `supervisionUrls?`: string | string[],  
+   `supervisionUser?`: string  
    }  
   }
 

--- a/README.md
+++ b/README.md
@@ -1061,11 +1061,11 @@ Set the WebSocket header _Sec-WebSocket-Protocol_ to `ui0.0.1`.
   `ProcedureName`: 'setSupervisionUrl'  
   `PDU`: {  
    `hashIds`: charging station unique identifier strings array (optional, default: all charging stations),  
-   `url?`: string,  
+   `url`: string,  
    `supervisionUser?`: string,  
    `supervisionPassword?`: string  
   }  
-  At least one of `url`, `supervisionUser` or `supervisionPassword` must be provided. Changes take effect on the next WebSocket (re)connect.
+  `url` is required. `supervisionUser` and `supervisionPassword` are each optional and independent: a string (including `""`, which clears the field) updates the value; omitting the field preserves the existing value. Changes take effect on the next WebSocket (re)connect.
 
 - Response:  
   `PDU`: {  

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -993,20 +993,42 @@ export class ChargingStation extends EventEmitter {
   }
 
   /**
-   * Updates the supervision server URL in configuration or station info.
-   * @param url - The new supervision server URL
+   * Updates the supervision server URL and/or credentials in configuration or station info.
+   * Any argument left undefined is preserved; pass an empty string to clear a credential.
+   * Changes take effect on the next WebSocket (re)connect.
+   * @param url - The new supervision server URL (optional)
+   * @param supervisionUser - The new CSMS basic auth user (optional)
+   * @param supervisionPassword - The new CSMS basic auth password (optional)
    */
-  public setSupervisionUrl (url: string): void {
-    if (
-      this.stationInfo?.supervisionUrlOcppConfiguration === true &&
-      isNotEmptyString(this.stationInfo.supervisionUrlOcppKey)
-    ) {
-      setConfigurationKeyValue(this, this.stationInfo.supervisionUrlOcppKey, url)
-    } else if (this.stationInfo != null) {
-      this.stationInfo.supervisionUrls = url
-      this.configuredSupervisionUrl = this.getConfiguredSupervisionUrl()
+  public setSupervisionUrl (
+    url?: string,
+    supervisionUser?: string,
+    supervisionPassword?: string
+  ): void {
+    if (url != null) {
+      if (
+        this.stationInfo?.supervisionUrlOcppConfiguration === true &&
+        isNotEmptyString(this.stationInfo.supervisionUrlOcppKey)
+      ) {
+        setConfigurationKeyValue(this, this.stationInfo.supervisionUrlOcppKey, url)
+      } else if (this.stationInfo != null) {
+        this.stationInfo.supervisionUrls = url
+        this.configuredSupervisionUrl = this.getConfiguredSupervisionUrl()
+      }
+    }
+    if (this.stationInfo != null) {
+      if (supervisionUser != null) {
+        this.stationInfo.supervisionUser = supervisionUser
+      }
+      if (supervisionPassword != null) {
+        this.stationInfo.supervisionPassword = supervisionPassword
+      }
       this.saveStationInfo()
     }
+    // Notify the UI server cache so `listChargingStations` reflects the
+    // new URL/credentials immediately (without having to stop/start or
+    // reconnect first).
+    this.emitChargingStationEvent(ChargingStationEvents.updated)
   }
 
   /** Starts the charging station, initializes connectors, and connects to the central server. */

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -1490,7 +1490,8 @@ export class ChargingStation extends EventEmitter {
   }
 
   private getStationInfo (options?: ChargingStationOptions): ChargingStationInfo {
-    const stationInfoFromTemplate = this.getStationInfoFromTemplate()
+    const { stationInfo: stationInfoFromTemplate, stationTemplate } =
+      this.getStationInfoFromTemplate()
     options?.persistentConfiguration != null &&
       (stationInfoFromTemplate.stationInfoPersistentConfiguration = options.persistentConfiguration)
     const stationInfoFromFile = this.getStationInfoFromFile(
@@ -1508,12 +1509,15 @@ export class ChargingStation extends EventEmitter {
     } else {
       stationInfo = stationInfoFromTemplate
       stationInfoFromFile != null &&
-        propagateSerialNumber(this.getTemplateFromFile(), stationInfoFromFile, stationInfo)
+        propagateSerialNumber(stationTemplate, stationInfoFromFile, stationInfo)
     }
-    return setChargingStationOptions(
+    stationInfo = setChargingStationOptions(
       mergeDeepRight(Constants.DEFAULT_STATION_INFO as ChargingStationInfo, stationInfo),
       options
     )
+    stationInfo.chargingStationId = getChargingStationId(this.index, stationInfo)
+    stationInfo.hashId = getHashId(this.index, stationTemplate, stationInfo.chargingStationId)
+    return stationInfo
   }
 
   private getStationInfoFromFile (
@@ -1536,7 +1540,10 @@ export class ChargingStation extends EventEmitter {
     return stationInfo
   }
 
-  private getStationInfoFromTemplate (): ChargingStationInfo {
+  private getStationInfoFromTemplate (): {
+    stationInfo: ChargingStationInfo
+    stationTemplate: ChargingStationTemplate
+  } {
     const stationTemplate = this.getTemplateFromFile()
     if (stationTemplate == null) {
       const errorMsg = `Failed to read charging station template file ${this.templateFile}`
@@ -1553,10 +1560,11 @@ export class ChargingStation extends EventEmitter {
       checkEvsesConfiguration(stationTemplate, this.logPrefix(), this.templateFile)
     }
     const stationInfo = stationTemplateToStationInfo(stationTemplate)
-    stationInfo.hashId = getHashId(this.index, stationTemplate)
+    // hashId and chargingStationId are intentionally not set here. They are derived
+    // at the end of getStationInfo() so that any identity overrides coming from
+    // ChargingStationOptions (baseName, fixedName, nameSuffix) are honoured.
     stationInfo.templateIndex = this.index
     stationInfo.templateName = buildTemplateName(this.templateFile)
-    stationInfo.chargingStationId = getChargingStationId(this.index, stationTemplate)
     createSerialNumber(stationTemplate, stationInfo)
     stationInfo.voltageOut = this.getVoltageOut(stationInfo)
     if (isNotEmptyArray<number>(stationTemplate.power)) {
@@ -1586,7 +1594,7 @@ export class ChargingStation extends EventEmitter {
     if (stationTemplate.resetTime != null) {
       stationInfo.resetTime = secondsToMilliseconds(stationTemplate.resetTime)
     }
-    return stationInfo
+    return { stationInfo, stationTemplate }
   }
 
   private getTemplateFromFile (): ChargingStationTemplate | undefined {

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -993,30 +993,27 @@ export class ChargingStation extends EventEmitter {
   }
 
   /**
-   * Updates the supervision server URL and/or credentials in configuration or station info.
-   * Any argument left undefined is preserved; pass an empty string to clear a credential.
-   * Changes take effect on the next WebSocket (re)connect.
-   * @param url - The new supervision server URL (optional)
-   * @param supervisionUser - The new CSMS basic auth user (optional)
-   * @param supervisionPassword - The new CSMS basic auth password (optional)
+   * Updates the supervision server URL and optionally the CSMS basic auth credentials in configuration or station info.
+   * @param url - The new supervision server URL
+   * @param supervisionUser - The new CSMS basic auth user (optional; "" clears, undefined preserves)
+   * @param supervisionPassword - The new CSMS basic auth password (optional; "" clears, undefined preserves)
    */
   public setSupervisionUrl (
-    url?: string,
+    url: string,
     supervisionUser?: string,
     supervisionPassword?: string
   ): void {
-    if (url != null) {
-      if (
-        this.stationInfo?.supervisionUrlOcppConfiguration === true &&
-        isNotEmptyString(this.stationInfo.supervisionUrlOcppKey)
-      ) {
-        setConfigurationKeyValue(this, this.stationInfo.supervisionUrlOcppKey, url)
-      } else if (this.stationInfo != null) {
-        this.stationInfo.supervisionUrls = url
-        this.configuredSupervisionUrl = this.getConfiguredSupervisionUrl()
-      }
+    if (
+      this.stationInfo?.supervisionUrlOcppConfiguration === true &&
+      isNotEmptyString(this.stationInfo.supervisionUrlOcppKey)
+    ) {
+      setConfigurationKeyValue(this, this.stationInfo.supervisionUrlOcppKey, url)
+    } else if (this.stationInfo != null) {
+      this.stationInfo.supervisionUrls = url
+      this.configuredSupervisionUrl = this.getConfiguredSupervisionUrl()
+      this.saveStationInfo()
     }
-    if (this.stationInfo != null) {
+    if (this.stationInfo != null && (supervisionUser != null || supervisionPassword != null)) {
       if (supervisionUser != null) {
         this.stationInfo.supervisionUser = supervisionUser
       }
@@ -1024,9 +1021,6 @@ export class ChargingStation extends EventEmitter {
         this.stationInfo.supervisionPassword = supervisionPassword
       }
       this.saveStationInfo()
-      // Notify the UI server cache so `listChargingStations` reflects the
-      // new URL/credentials immediately (without having to stop/start or
-      // reconnect first).
       this.emitChargingStationEvent(ChargingStationEvents.updated)
     }
   }

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -1024,11 +1024,11 @@ export class ChargingStation extends EventEmitter {
         this.stationInfo.supervisionPassword = supervisionPassword
       }
       this.saveStationInfo()
+      // Notify the UI server cache so `listChargingStations` reflects the
+      // new URL/credentials immediately (without having to stop/start or
+      // reconnect first).
+      this.emitChargingStationEvent(ChargingStationEvents.updated)
     }
-    // Notify the UI server cache so `listChargingStations` reflects the
-    // new URL/credentials immediately (without having to stop/start or
-    // reconnect first).
-    this.emitChargingStationEvent(ChargingStationEvents.updated)
   }
 
   /** Starts the charging station, initializes connectors, and connects to the central server. */

--- a/src/charging-station/Helpers.ts
+++ b/src/charging-station/Helpers.ts
@@ -81,7 +81,10 @@ export const buildTemplateName = (templateFile: string): string => {
   return join(templateFileParsedPath.dir, templateFileParsedPath.name)
 }
 
-export type ChargingStationNameTemplate = Pick<ChargingStationTemplate, 'baseName' | 'fixedName' | 'nameSuffix'>
+export type ChargingStationNameTemplate = Pick<
+  ChargingStationTemplate,
+  'baseName' | 'fixedName' | 'nameSuffix'
+>
 
 export const getChargingStationId = (
   index: number,

--- a/src/charging-station/Helpers.ts
+++ b/src/charging-station/Helpers.ts
@@ -81,22 +81,22 @@ export const buildTemplateName = (templateFile: string): string => {
   return join(templateFileParsedPath.dir, templateFileParsedPath.name)
 }
 
-export type StationIdentity = Pick<ChargingStationTemplate, 'baseName' | 'fixedName' | 'nameSuffix'>
+export type ChargingStationNameTemplate = Pick<ChargingStationTemplate, 'baseName' | 'fixedName' | 'nameSuffix'>
 
 export const getChargingStationId = (
   index: number,
-  identity: StationIdentity | undefined
+  nameTemplate: ChargingStationNameTemplate | undefined
 ): string => {
-  if (identity == null) {
+  if (nameTemplate == null) {
     return "Unknown 'chargingStationId'"
   }
   // In case of multiple instances: add instance index to charging station id
   const instanceIndex = env.CF_INSTANCE_INDEX ?? 0
-  const idSuffix = identity.nameSuffix ?? ''
+  const idSuffix = nameTemplate.nameSuffix ?? ''
   const idStr = `000000000${index.toString()}`
-  return identity.fixedName === true
-    ? identity.baseName
-    : `${identity.baseName}-${instanceIndex.toString()}${idStr.substring(
+  return nameTemplate.fixedName === true
+    ? nameTemplate.baseName
+    : `${nameTemplate.baseName}-${instanceIndex.toString()}${idStr.substring(
         idStr.length - 4
       )}${idSuffix}`
 }

--- a/src/charging-station/Helpers.ts
+++ b/src/charging-station/Helpers.ts
@@ -81,20 +81,22 @@ export const buildTemplateName = (templateFile: string): string => {
   return join(templateFileParsedPath.dir, templateFileParsedPath.name)
 }
 
+export type StationIdentity = Pick<ChargingStationTemplate, 'baseName' | 'fixedName' | 'nameSuffix'>
+
 export const getChargingStationId = (
   index: number,
-  stationTemplate: ChargingStationTemplate | undefined
+  identity: StationIdentity | undefined
 ): string => {
-  if (stationTemplate == null) {
+  if (identity == null) {
     return "Unknown 'chargingStationId'"
   }
   // In case of multiple instances: add instance index to charging station id
   const instanceIndex = env.CF_INSTANCE_INDEX ?? 0
-  const idSuffix = stationTemplate.nameSuffix ?? ''
+  const idSuffix = identity.nameSuffix ?? ''
   const idStr = `000000000${index.toString()}`
-  return stationTemplate.fixedName === true
-    ? stationTemplate.baseName
-    : `${stationTemplate.baseName}-${instanceIndex.toString()}${idStr.substring(
+  return identity.fixedName === true
+    ? identity.baseName
+    : `${identity.baseName}-${instanceIndex.toString()}${idStr.substring(
         idStr.length - 4
       )}${idSuffix}`
 }
@@ -156,7 +158,11 @@ export const removeExpiredReservations = async (
   }
 }
 
-export const getHashId = (index: number, stationTemplate: ChargingStationTemplate): string => {
+export const getHashId = (
+  index: number,
+  stationTemplate: ChargingStationTemplate,
+  chargingStationIdOverride?: string
+): string => {
   const chargingStationInfo = {
     chargePointModel: stationTemplate.chargePointModel,
     chargePointVendor: stationTemplate.chargePointVendor,
@@ -175,7 +181,9 @@ export const getHashId = (index: number, stationTemplate: ChargingStationTemplat
   }
   return hash(
     Constants.DEFAULT_HASH_ALGORITHM,
-    `${JSON.stringify(chargingStationInfo)}${getChargingStationId(index, stationTemplate)}`,
+    `${JSON.stringify(chargingStationInfo)}${
+      chargingStationIdOverride ?? getChargingStationId(index, stationTemplate)
+    }`,
     'hex'
   )
 }
@@ -428,6 +436,12 @@ export const setChargingStationOptions = (
   if (options?.supervisionUrls != null) {
     stationInfo.supervisionUrls = options.supervisionUrls
   }
+  if (options?.supervisionUser != null) {
+    stationInfo.supervisionUser = options.supervisionUser
+  }
+  if (options?.supervisionPassword != null) {
+    stationInfo.supervisionPassword = options.supervisionPassword
+  }
   if (options?.persistentConfiguration != null) {
     stationInfo.stationInfoPersistentConfiguration = options.persistentConfiguration
     stationInfo.ocppPersistentConfiguration = options.persistentConfiguration
@@ -448,6 +462,15 @@ export const setChargingStationOptions = (
   }
   if (options?.stopTransactionsOnStopped != null) {
     stationInfo.stopTransactionsOnStopped = options.stopTransactionsOnStopped
+  }
+  if (options?.baseName != null) {
+    stationInfo.baseName = options.baseName
+  }
+  if (options?.fixedName != null) {
+    stationInfo.fixedName = options.fixedName
+  }
+  if (options?.nameSuffix != null) {
+    stationInfo.nameSuffix = options.nameSuffix
   }
   return stationInfo
 }

--- a/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
+++ b/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
@@ -184,19 +184,15 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
         BroadcastChannelProcedureName.SET_SUPERVISION_URL,
         (requestPayload?: BroadcastChannelRequestPayload) => {
           const url = requestPayload?.url
-          const supervisionUser = requestPayload?.supervisionUser
-          const supervisionPassword = requestPayload?.supervisionPassword
-          if (
-            (typeof url !== 'string' || isEmpty(url)) &&
-            typeof supervisionUser !== 'string' &&
-            typeof supervisionPassword !== 'string'
-          ) {
+          if (typeof url !== 'string' || isEmpty(url)) {
             throw new BaseError(
-              `${this.chargingStation.logPrefix()} ${moduleName}.requestHandler: at least one of 'url', 'supervisionUser' or 'supervisionPassword' is required`
+              `${this.chargingStation.logPrefix()} ${moduleName}.requestHandler: 'url' field is required`
             )
           }
+          const supervisionUser = requestPayload?.supervisionUser
+          const supervisionPassword = requestPayload?.supervisionPassword
           this.chargingStation.setSupervisionUrl(
-            typeof url === 'string' && !isEmpty(url) ? url : undefined,
+            url,
             typeof supervisionUser === 'string' ? supervisionUser : undefined,
             typeof supervisionPassword === 'string' ? supervisionPassword : undefined
           )

--- a/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
+++ b/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
@@ -184,12 +184,22 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
         BroadcastChannelProcedureName.SET_SUPERVISION_URL,
         (requestPayload?: BroadcastChannelRequestPayload) => {
           const url = requestPayload?.url
-          if (typeof url !== 'string' || isEmpty(url)) {
+          const supervisionUser = requestPayload?.supervisionUser
+          const supervisionPassword = requestPayload?.supervisionPassword
+          if (
+            (typeof url !== 'string' || isEmpty(url)) &&
+            typeof supervisionUser !== 'string' &&
+            typeof supervisionPassword !== 'string'
+          ) {
             throw new BaseError(
-              `${this.chargingStation.logPrefix()} ${moduleName}.requestHandler: 'url' field is required`
+              `${this.chargingStation.logPrefix()} ${moduleName}.requestHandler: at least one of 'url', 'supervisionUser' or 'supervisionPassword' is required`
             )
           }
-          this.chargingStation.setSupervisionUrl(url)
+          this.chargingStation.setSupervisionUrl(
+            typeof url === 'string' && !isEmpty(url) ? url : undefined,
+            typeof supervisionUser === 'string' ? supervisionUser : undefined,
+            typeof supervisionPassword === 'string' ? supervisionPassword : undefined
+          )
         },
       ],
       [

--- a/src/charging-station/ui-server/mcp/MCPToolSchemas.ts
+++ b/src/charging-station/ui-server/mcp/MCPToolSchemas.ts
@@ -32,7 +32,19 @@ const emptyInputSchema = z.object({})
 const chargingStationOptionsSchema = z.object({
   autoRegister: z.boolean().optional().describe('Set stations as registered at boot notification'),
   autoStart: z.boolean().optional().describe('Enable automatic start of added charging station'),
+  baseName: z
+    .string()
+    .optional()
+    .describe('Override the template base name used to derive the chargingStationId'),
   enableStatistics: z.boolean().optional().describe('Enable charging station statistics'),
+  fixedName: z
+    .boolean()
+    .optional()
+    .describe('Use baseName verbatim as chargingStationId instead of appending index/suffix'),
+  nameSuffix: z
+    .string()
+    .optional()
+    .describe('Suffix appended to the derived chargingStationId (ignored when fixedName is true)'),
   ocppStrictCompliance: z
     .boolean()
     .optional()
@@ -45,10 +57,18 @@ const chargingStationOptionsSchema = z.object({
     .boolean()
     .optional()
     .describe('Enable stop transactions on station stop'),
+  supervisionPassword: z
+    .string()
+    .optional()
+    .describe('CSMS basic auth password used on the supervision WebSocket'),
   supervisionUrls: z
     .union([z.url(), z.array(z.url())])
     .optional()
     .describe('OCPP server supervision URL(s)'),
+  supervisionUser: z
+    .string()
+    .optional()
+    .describe('CSMS basic auth user used on the supervision WebSocket'),
 })
 
 /** Maps ProcedureName to OCPP JSON Schema file base names per version */

--- a/src/charging-station/ui-server/mcp/MCPToolSchemas.ts
+++ b/src/charging-station/ui-server/mcp/MCPToolSchemas.ts
@@ -338,18 +338,18 @@ export const mcpToolSchemas = new Map<ProcedureName, MCPToolSchema>([
     ProcedureName.SET_SUPERVISION_URL,
     {
       description:
-        'Set the OCPP server supervision URL and/or basic auth credentials for one or more charging stations. At least one of url, supervisionUser or supervisionPassword must be provided.',
+        'Set the OCPP server supervision URL for one or more charging stations. Optionally updates the CSMS basic auth credentials (empty string clears a credential, undefined preserves it).',
       inputSchema: z.object({
         hashIds,
         supervisionPassword: z
           .string()
           .optional()
-          .describe('CSMS basic auth password used on the supervision WebSocket'),
+          .describe('CSMS basic auth password (empty string clears)'),
         supervisionUser: z
           .string()
           .optional()
-          .describe('CSMS basic auth user used on the supervision WebSocket'),
-        url: z.url().optional().describe('The OCPP server supervision URL to set'),
+          .describe('CSMS basic auth user (empty string clears)'),
+        url: z.url().describe('The OCPP server supervision URL to set'),
       }),
     },
   ],

--- a/src/charging-station/ui-server/mcp/MCPToolSchemas.ts
+++ b/src/charging-station/ui-server/mcp/MCPToolSchemas.ts
@@ -337,10 +337,19 @@ export const mcpToolSchemas = new Map<ProcedureName, MCPToolSchema>([
   [
     ProcedureName.SET_SUPERVISION_URL,
     {
-      description: 'Set the OCPP server supervision URL for one or more charging stations',
+      description:
+        'Set the OCPP server supervision URL and/or basic auth credentials for one or more charging stations. At least one of url, supervisionUser or supervisionPassword must be provided.',
       inputSchema: z.object({
         hashIds,
-        url: z.url().describe('The OCPP server supervision URL to set'),
+        supervisionPassword: z
+          .string()
+          .optional()
+          .describe('CSMS basic auth password used on the supervision WebSocket'),
+        supervisionUser: z
+          .string()
+          .optional()
+          .describe('CSMS basic auth user used on the supervision WebSocket'),
+        url: z.url().optional().describe('The OCPP server supervision URL to set'),
       }),
     },
   ],

--- a/src/types/ChargingStationWorker.ts
+++ b/src/types/ChargingStationWorker.ts
@@ -50,11 +50,16 @@ export interface ChargingStationData extends WorkerData {
 export interface ChargingStationOptions extends JsonObject {
   autoRegister?: boolean
   autoStart?: boolean
+  baseName?: string
   enableStatistics?: boolean
+  fixedName?: boolean
+  nameSuffix?: string
   ocppStrictCompliance?: boolean
   persistentConfiguration?: boolean
   stopTransactionsOnStopped?: boolean
+  supervisionPassword?: string
   supervisionUrls?: string | string[]
+  supervisionUser?: string
 }
 
 export interface ChargingStationWorkerData extends WorkerData {

--- a/tests/charging-station/Helpers.test.ts
+++ b/tests/charging-station/Helpers.test.ts
@@ -20,6 +20,7 @@ import {
   hasPendingReservations,
   hasReservationExpired,
   resetConnectorStatus,
+  setChargingStationOptions,
   validateStationInfo,
 } from '../../src/charging-station/Helpers.js'
 import {
@@ -28,6 +29,7 @@ import {
   ChargingProfilePurposeType,
   type ChargingStationConfiguration,
   type ChargingStationInfo,
+  type ChargingStationOptions,
   type ChargingStationTemplate,
   type ConnectorStatus,
   ConnectorStatusEnum,
@@ -76,6 +78,117 @@ await describe('Helpers', async () => {
       getHashId(1, chargingStationTemplate),
       'b4b1e8ec4fca79091d99ea9a7ea5901548010e6c0e98be9296f604b9d68734444dfdae73d7d406b6124b42815214d088'
     )
+  })
+
+  await it('should return baseName verbatim when fixedName is true', () => {
+    const identity = {
+      baseName: 'DYNAMIC-STATION',
+      fixedName: true,
+    } satisfies Partial<ChargingStationTemplate>
+    assert.strictEqual(
+      getChargingStationId(1, identity as ChargingStationTemplate),
+      'DYNAMIC-STATION'
+    )
+  })
+
+  await it('should append nameSuffix to the indexed id when fixedName is false', () => {
+    const identity = {
+      baseName: 'CS',
+      fixedName: false,
+      nameSuffix: '-X',
+    } satisfies Partial<ChargingStationTemplate>
+    assert.strictEqual(getChargingStationId(7, identity as ChargingStationTemplate), 'CS-00007-X')
+  })
+
+  await it('should derive charging station id from stationInfo identity fields', () => {
+    // stationInfo satisfies the StationIdentity shape since it inherits baseName / fixedName / nameSuffix from the template type.
+    const stationInfo = {
+      baseName: 'INFO-STATION',
+      fixedName: true,
+    } satisfies Partial<ChargingStationInfo>
+    assert.strictEqual(getChargingStationId(1, stationInfo as ChargingStationInfo), 'INFO-STATION')
+  })
+
+  await it('should honour chargingStationId override in getHashId', () => {
+    const hashWithoutOverride = getHashId(1, chargingStationTemplate)
+    const hashWithOverride = getHashId(1, chargingStationTemplate, 'OVERRIDDEN-ID')
+    assert.notStrictEqual(hashWithoutOverride, hashWithOverride)
+    // Passing the default-derived id explicitly must reproduce the default hash.
+    assert.strictEqual(
+      getHashId(1, chargingStationTemplate, getChargingStationId(1, chargingStationTemplate)),
+      hashWithoutOverride
+    )
+  })
+
+  await it('should produce distinct hash ids when identity options differ', () => {
+    const baseId = getChargingStationId(1, chargingStationTemplate)
+    const overriddenId = getChargingStationId(1, {
+      ...chargingStationTemplate,
+      baseName: 'OTHER',
+    })
+    assert.notStrictEqual(
+      getHashId(1, chargingStationTemplate, baseId),
+      getHashId(1, chargingStationTemplate, overriddenId)
+    )
+  })
+
+  await describe('setChargingStationOptions', async () => {
+    const buildStationInfo = (): ChargingStationInfo =>
+      ({
+        baseName: TEST_CHARGING_STATION_BASE_NAME,
+        hashId: 'placeholder',
+        templateIndex: 0,
+        templateName: 'test-template',
+      }) as ChargingStationInfo
+
+    await it('should return stationInfo unchanged when options are undefined', () => {
+      const stationInfo = buildStationInfo()
+      const before = { ...stationInfo }
+      const result = setChargingStationOptions(stationInfo)
+      assert.deepStrictEqual(result, before)
+    })
+
+    await it('should apply baseName override', () => {
+      const options: ChargingStationOptions = { baseName: 'DYNAMIC' }
+      const result = setChargingStationOptions(buildStationInfo(), options)
+      assert.strictEqual(result.baseName, 'DYNAMIC')
+    })
+
+    await it('should apply fixedName override', () => {
+      const options: ChargingStationOptions = { fixedName: true }
+      const result = setChargingStationOptions(buildStationInfo(), options)
+      assert.strictEqual(result.fixedName, true)
+    })
+
+    await it('should apply nameSuffix override', () => {
+      const options: ChargingStationOptions = { nameSuffix: '-SUFFIX' }
+      const result = setChargingStationOptions(buildStationInfo(), options)
+      assert.strictEqual(result.nameSuffix, '-SUFFIX')
+    })
+
+    await it('should apply supervisionUser override', () => {
+      const options: ChargingStationOptions = { supervisionUser: 'alice' }
+      const result = setChargingStationOptions(buildStationInfo(), options)
+      assert.strictEqual(result.supervisionUser, 'alice')
+    })
+
+    await it('should apply supervisionPassword override', () => {
+      const options: ChargingStationOptions = { supervisionPassword: 'secret' }
+      const result = setChargingStationOptions(buildStationInfo(), options)
+      assert.strictEqual(result.supervisionPassword, 'secret')
+    })
+
+    await it('should not overwrite stationInfo fields when option value is undefined', () => {
+      const stationInfo = buildStationInfo()
+      stationInfo.baseName = 'KEEP-ME'
+      stationInfo.supervisionUser = 'original'
+      const result = setChargingStationOptions(stationInfo, {
+        autoStart: true,
+      })
+      assert.strictEqual(result.baseName, 'KEEP-ME')
+      assert.strictEqual(result.supervisionUser, 'original')
+      assert.strictEqual(result.autoStart, true)
+    })
   })
 
   await it('should throw when stationInfo is missing', () => {

--- a/tests/charging-station/Helpers.test.ts
+++ b/tests/charging-station/Helpers.test.ts
@@ -81,27 +81,27 @@ await describe('Helpers', async () => {
   })
 
   await it('should return baseName verbatim when fixedName is true', () => {
-    const identity = {
+    const template = {
       baseName: 'DYNAMIC-STATION',
       fixedName: true,
     } satisfies Partial<ChargingStationTemplate>
     assert.strictEqual(
-      getChargingStationId(1, identity as ChargingStationTemplate),
+      getChargingStationId(1, template as ChargingStationTemplate),
       'DYNAMIC-STATION'
     )
   })
 
   await it('should append nameSuffix to the indexed id when fixedName is false', () => {
-    const identity = {
+    const template = {
       baseName: 'CS',
       fixedName: false,
       nameSuffix: '-X',
     } satisfies Partial<ChargingStationTemplate>
-    assert.strictEqual(getChargingStationId(7, identity as ChargingStationTemplate), 'CS-00007-X')
+    assert.strictEqual(getChargingStationId(7, template as ChargingStationTemplate), 'CS-00007-X')
   })
 
   await it('should derive charging station id from stationInfo identity fields', () => {
-    // stationInfo satisfies the StationIdentity shape since it inherits baseName / fixedName / nameSuffix from the template type.
+    // stationInfo satisfies the ChargingStationNameTemplate shape since it inherits baseName / fixedName / nameSuffix from the template type.
     const stationInfo = {
       baseName: 'INFO-STATION',
       fixedName: true,

--- a/ui/common/src/types/ChargingStationType.ts
+++ b/ui/common/src/types/ChargingStationType.ts
@@ -233,11 +233,16 @@ export interface ChargingStationOcppConfiguration extends JsonObject {
 export interface ChargingStationOptions extends JsonObject {
   autoRegister?: boolean
   autoStart?: boolean
+  baseName?: string
   enableStatistics?: boolean
+  fixedName?: boolean
+  nameSuffix?: string
   ocppStrictCompliance?: boolean
   persistentConfiguration?: boolean
   stopTransactionsOnStopped?: boolean
+  supervisionPassword?: string
   supervisionUrls?: string | string[]
+  supervisionUser?: string
 }
 
 export interface ConfigurationKey extends OCPPConfigurationKey {

--- a/ui/web/src/components/actions/AddChargingStations.vue
+++ b/ui/web/src/components/actions/AddChargingStations.vue
@@ -43,9 +43,9 @@
         placeholder="<template value>"
         type="text"
       >
-      Append counter to name:
+      Fixed name (base name is full station name):
       <input
-        v-model="state.appendCounter"
+        v-model="state.fixedName"
         false-value="false"
         true-value="true"
         type="checkbox"
@@ -143,10 +143,10 @@ import {
 } from '@/composables'
 
 const state = ref<{
-  appendCounter: boolean
   autoStart: boolean
   baseName: string
   enableStatistics: boolean
+  fixedName: boolean
   numberOfStations: number
   ocppStrictCompliance: boolean
   persistentConfiguration: boolean
@@ -156,10 +156,10 @@ const state = ref<{
   supervisionUser: string
   template: string
 }>({
-  appendCounter: true,
   autoStart: false,
   baseName: '',
   enableStatistics: false,
+  fixedName: false,
   numberOfStations: 1,
   ocppStrictCompliance: true,
   persistentConfiguration: true,
@@ -186,9 +186,7 @@ const addChargingStations = (): void => {
       baseName: state.value.baseName.length > 0 ? state.value.baseName : undefined,
       enableStatistics: convertToBoolean(state.value.enableStatistics),
       fixedName:
-        state.value.baseName.length > 0 && !convertToBoolean(state.value.appendCounter)
-          ? true
-          : undefined,
+        state.value.baseName.length > 0 ? convertToBoolean(state.value.fixedName) : undefined,
       ocppStrictCompliance: convertToBoolean(state.value.ocppStrictCompliance),
       persistentConfiguration: convertToBoolean(state.value.persistentConfiguration),
       supervisionPassword:

--- a/ui/web/src/components/actions/AddChargingStations.vue
+++ b/ui/web/src/components/actions/AddChargingStations.vue
@@ -3,16 +3,8 @@
     Add Charging Stations
   </h1>
   <p>Template:</p>
-  <select
-    :key="state.renderTemplates"
-    v-model="state.template"
-  >
-    <option
-      disabled
-      value=""
-    >
-      Please select a template
-    </option>
+  <select :key="state.renderTemplates" v-model="state.template">
+    <option disabled value="">Please select a template</option>
     <option
       v-for="template in $templates"
       v-show="Array.isArray($templates) && $templates.length > 0"
@@ -30,9 +22,22 @@
     name="number-of-stations"
     placeholder="number of stations"
     type="number"
-  >
+  />
   <p>Template options overrides:</p>
   <ul class="template-options">
+    <li>
+      Base name:
+      <input
+        id="base-name"
+        v-model.trim="state.baseName"
+        class="base-name"
+        name="base-name"
+        placeholder="<template value>"
+        type="text"
+      />
+      Append counter to name:
+      <input v-model="state.appendCounter" false-value="false" true-value="true" type="checkbox" />
+    </li>
     <li>
       Supervision url:
       <input
@@ -42,16 +47,32 @@
         name="supervision-url"
         placeholder="wss://"
         type="url"
-      >
+      />
+    </li>
+    <li>
+      Supervision credentials:
+      <input
+        id="supervision-user"
+        v-model.trim="state.supervisionUser"
+        autocomplete="off"
+        class="supervision-user"
+        name="supervision-user"
+        placeholder="<username>"
+        type="text"
+      />
+      <input
+        id="supervision-password"
+        v-model="state.supervisionPassword"
+        autocomplete="off"
+        class="supervision-password"
+        name="supervision-password"
+        placeholder="<password>"
+        type="text"
+      />
     </li>
     <li>
       Auto start:
-      <input
-        v-model="state.autoStart"
-        false-value="false"
-        true-value="true"
-        type="checkbox"
-      >
+      <input v-model="state.autoStart" false-value="false" true-value="true" type="checkbox" />
     </li>
     <li>
       Persistent configuration:
@@ -60,7 +81,7 @@
         false-value="false"
         true-value="true"
         type="checkbox"
-      >
+      />
     </li>
     <li>
       OCPP strict compliance:
@@ -69,7 +90,7 @@
         false-value="false"
         true-value="true"
         type="checkbox"
-      >
+      />
     </li>
     <li>
       Performance statistics:
@@ -78,10 +99,10 @@
         false-value="false"
         true-value="true"
         type="checkbox"
-      >
+      />
     </li>
   </ul>
-  <br>
+  <br />
   <Button
     id="action-button"
     @click="addChargingStations()"
@@ -105,22 +126,30 @@ import {
 } from '@/composables'
 
 const state = ref<{
+  appendCounter: boolean
   autoStart: boolean
+  baseName: string
   enableStatistics: boolean
   numberOfStations: number
   ocppStrictCompliance: boolean
   persistentConfiguration: boolean
   renderTemplates: UUIDv4
+  supervisionPassword: string
   supervisionUrl: string
+  supervisionUser: string
   template: string
 }>({
+  appendCounter: true,
   autoStart: false,
+  baseName: '',
   enableStatistics: false,
   numberOfStations: 1,
   ocppStrictCompliance: true,
   persistentConfiguration: true,
   renderTemplates: randomUUID(),
+  supervisionPassword: '',
   supervisionUrl: '',
+  supervisionUser: '',
   template: '',
 })
 
@@ -137,11 +166,20 @@ const addChargingStations = (): void => {
   executeAction(
     $uiClient.addChargingStations(state.value.template, state.value.numberOfStations, {
       autoStart: convertToBoolean(state.value.autoStart),
+      baseName: state.value.baseName.length > 0 ? state.value.baseName : undefined,
       enableStatistics: convertToBoolean(state.value.enableStatistics),
+      fixedName:
+        state.value.baseName.length > 0 && !convertToBoolean(state.value.appendCounter)
+          ? true
+          : undefined,
       ocppStrictCompliance: convertToBoolean(state.value.ocppStrictCompliance),
       persistentConfiguration: convertToBoolean(state.value.persistentConfiguration),
+      supervisionPassword:
+        state.value.supervisionPassword.length > 0 ? state.value.supervisionPassword : undefined,
       supervisionUrls:
         state.value.supervisionUrl.length > 0 ? state.value.supervisionUrl : undefined,
+      supervisionUser:
+        state.value.supervisionUser.length > 0 ? state.value.supervisionUser : undefined,
     }),
     'Charging stations successfully added',
     'Error at adding charging stations',
@@ -162,8 +200,17 @@ const addChargingStations = (): void => {
   text-align: center;
 }
 
+.supervision-url,
+.base-name,
+.supervision-user,
+.supervision-password {
+  width: 100%;
+  max-width: 40rem;
+  text-align: left;
+}
+
 .template-options {
-  list-style: circle inside;
+  list-style: circle;
   text-align: left;
 }
 </style>

--- a/ui/web/src/components/actions/AddChargingStations.vue
+++ b/ui/web/src/components/actions/AddChargingStations.vue
@@ -3,8 +3,16 @@
     Add Charging Stations
   </h1>
   <p>Template:</p>
-  <select :key="state.renderTemplates" v-model="state.template">
-    <option disabled value="">Please select a template</option>
+  <select
+    :key="state.renderTemplates"
+    v-model="state.template"
+  >
+    <option
+      disabled
+      value=""
+    >
+      Please select a template
+    </option>
     <option
       v-for="template in $templates"
       v-show="Array.isArray($templates) && $templates.length > 0"
@@ -22,7 +30,7 @@
     name="number-of-stations"
     placeholder="number of stations"
     type="number"
-  />
+  >
   <p>Template options overrides:</p>
   <ul class="template-options">
     <li>
@@ -34,9 +42,14 @@
         name="base-name"
         placeholder="<template value>"
         type="text"
-      />
+      >
       Append counter to name:
-      <input v-model="state.appendCounter" false-value="false" true-value="true" type="checkbox" />
+      <input
+        v-model="state.appendCounter"
+        false-value="false"
+        true-value="true"
+        type="checkbox"
+      >
     </li>
     <li>
       Supervision url:
@@ -47,7 +60,7 @@
         name="supervision-url"
         placeholder="wss://"
         type="url"
-      />
+      >
     </li>
     <li>
       Supervision credentials:
@@ -59,7 +72,7 @@
         name="supervision-user"
         placeholder="<username>"
         type="text"
-      />
+      >
       <input
         id="supervision-password"
         v-model="state.supervisionPassword"
@@ -68,11 +81,16 @@
         name="supervision-password"
         placeholder="<password>"
         type="text"
-      />
+      >
     </li>
     <li>
       Auto start:
-      <input v-model="state.autoStart" false-value="false" true-value="true" type="checkbox" />
+      <input
+        v-model="state.autoStart"
+        false-value="false"
+        true-value="true"
+        type="checkbox"
+      >
     </li>
     <li>
       Persistent configuration:
@@ -81,7 +99,7 @@
         false-value="false"
         true-value="true"
         type="checkbox"
-      />
+      >
     </li>
     <li>
       OCPP strict compliance:
@@ -90,7 +108,7 @@
         false-value="false"
         true-value="true"
         type="checkbox"
-      />
+      >
     </li>
     <li>
       Performance statistics:
@@ -99,10 +117,10 @@
         false-value="false"
         true-value="true"
         type="checkbox"
-      />
+      >
     </li>
   </ul>
-  <br />
+  <br>
   <Button
     id="action-button"
     @click="addChargingStations()"

--- a/ui/web/src/components/actions/AddChargingStations.vue
+++ b/ui/web/src/components/actions/AddChargingStations.vue
@@ -76,11 +76,10 @@
       <input
         id="supervision-password"
         v-model="state.supervisionPassword"
-        autocomplete="off"
         class="supervision-password"
         name="supervision-password"
         placeholder="<password>"
-        type="text"
+        type="password"
       >
     </li>
     <li>

--- a/ui/web/src/components/actions/SetSupervisionUrl.vue
+++ b/ui/web/src/components/actions/SetSupervisionUrl.vue
@@ -3,7 +3,7 @@
     Set Supervision Url
   </h1>
   <h2>{{ chargingStationId }}</h2>
-  <p>Supervision Url:</p>
+  <p>Supervision url:</p>
   <input
     id="supervision-url"
     v-model.trim="state.supervisionUrl"
@@ -11,6 +11,25 @@
     name="supervision-url"
     placeholder="wss://"
     type="url"
+  >
+  <p>Supervision credentials:</p>
+  <input
+    id="supervision-user"
+    v-model.trim="state.supervisionUser"
+    autocomplete="off"
+    class="supervision-user"
+    name="supervision-user"
+    placeholder="<username>"
+    type="text"
+  >
+  <input
+    id="supervision-password"
+    v-model="state.supervisionPassword"
+    autocomplete="off"
+    class="supervision-password"
+    name="supervision-password"
+    placeholder="<password>"
+    type="text"
   >
   <br>
   <Button
@@ -24,6 +43,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
+import { useToast } from 'vue-toast-notification'
 
 import Button from '@/components/buttons/Button.vue'
 import { resetToggleButtonState, ROUTE_NAMES, useExecuteAction, useUIClient } from '@/composables'
@@ -33,17 +53,37 @@ const props = defineProps<{
   hashId: string
 }>()
 
-const state = ref<{ supervisionUrl: string }>({
+const state = ref<{
+  supervisionPassword: string
+  supervisionUrl: string
+  supervisionUser: string
+}>({
+  supervisionPassword: '',
   supervisionUrl: '',
+  supervisionUser: '',
 })
 
 const $uiClient = useUIClient()
 const $router = useRouter()
+const $toast = useToast()
 const executeAction = useExecuteAction()
 
 const setSupervisionUrl = (): void => {
+  if (
+    state.value.supervisionUrl.length === 0 &&
+    state.value.supervisionUser.length === 0 &&
+    state.value.supervisionPassword.length === 0
+  ) {
+    $toast.error('At least one of url, user or password must be set')
+    return
+  }
   executeAction(
-    $uiClient.setSupervisionUrl(props.hashId, state.value.supervisionUrl),
+    $uiClient.setSupervisionUrl(
+      props.hashId,
+      state.value.supervisionUrl.length > 0 ? state.value.supervisionUrl : undefined,
+      state.value.supervisionUser.length > 0 ? state.value.supervisionUser : undefined,
+      state.value.supervisionPassword.length > 0 ? state.value.supervisionPassword : undefined
+    ),
     'Supervision url successfully set',
     'Error at setting supervision url',
     {
@@ -55,3 +95,13 @@ const setSupervisionUrl = (): void => {
   )
 }
 </script>
+
+<style scoped>
+.supervision-url,
+.supervision-user,
+.supervision-password {
+  width: 100%;
+  max-width: 40rem;
+  text-align: left;
+}
+</style>

--- a/ui/web/src/components/actions/SetSupervisionUrl.vue
+++ b/ui/web/src/components/actions/SetSupervisionUrl.vue
@@ -68,20 +68,16 @@ const $toast = useToast()
 const executeAction = useExecuteAction()
 
 const setSupervisionUrl = (): void => {
-  if (
-    state.value.supervisionUrl.length === 0 &&
-    state.value.supervisionUser.length === 0 &&
-    state.value.supervisionPassword.length === 0
-  ) {
-    $toast.error('At least one of url, user or password must be set')
+  if (state.value.supervisionUrl.length === 0) {
+    $toast.error('Supervision url is required')
     return
   }
   executeAction(
     $uiClient.setSupervisionUrl(
       props.hashId,
-      state.value.supervisionUrl.length > 0 ? state.value.supervisionUrl : undefined,
-      state.value.supervisionUser.length > 0 ? state.value.supervisionUser : undefined,
-      state.value.supervisionPassword.length > 0 ? state.value.supervisionPassword : undefined
+      state.value.supervisionUrl,
+      state.value.supervisionUser,
+      state.value.supervisionPassword
     ),
     'Supervision url successfully set',
     'Error at setting supervision url',

--- a/ui/web/src/components/actions/SetSupervisionUrl.vue
+++ b/ui/web/src/components/actions/SetSupervisionUrl.vue
@@ -25,11 +25,10 @@
   <input
     id="supervision-password"
     v-model="state.supervisionPassword"
-    autocomplete="off"
     class="supervision-password"
     name="supervision-password"
     placeholder="<password>"
-    type="text"
+    type="password"
   >
   <br>
   <Button

--- a/ui/web/src/composables/UIClient.ts
+++ b/ui/web/src/composables/UIClient.ts
@@ -129,10 +129,17 @@ export class UIClient {
     })
   }
 
-  public async setSupervisionUrl (hashId: string, supervisionUrl: string): Promise<ResponsePayload> {
+  public async setSupervisionUrl (
+    hashId: string,
+    supervisionUrl?: string,
+    supervisionUser?: string,
+    supervisionPassword?: string
+  ): Promise<ResponsePayload> {
     return this.sendRequest(ProcedureName.SET_SUPERVISION_URL, {
       hashIds: [hashId],
-      url: supervisionUrl,
+      ...(supervisionUrl != null && supervisionUrl.length > 0 && { url: supervisionUrl }),
+      ...(supervisionUser != null && { supervisionUser }),
+      ...(supervisionPassword != null && { supervisionPassword }),
     })
   }
 

--- a/ui/web/src/composables/UIClient.ts
+++ b/ui/web/src/composables/UIClient.ts
@@ -131,13 +131,13 @@ export class UIClient {
 
   public async setSupervisionUrl (
     hashId: string,
-    supervisionUrl?: string,
+    supervisionUrl: string,
     supervisionUser?: string,
     supervisionPassword?: string
   ): Promise<ResponsePayload> {
     return this.sendRequest(ProcedureName.SET_SUPERVISION_URL, {
       hashIds: [hashId],
-      ...(supervisionUrl != null && supervisionUrl.length > 0 && { url: supervisionUrl }),
+      url: supervisionUrl,
       ...(supervisionUser != null && { supervisionUser }),
       ...(supervisionPassword != null && { supervisionPassword }),
     })

--- a/ui/web/start.js
+++ b/ui/web/start.js
@@ -1,4 +1,5 @@
 import finalhandler from 'finalhandler'
+import { readFileSync } from 'node:fs'
 import { createServer } from 'node:http'
 import { dirname, join } from 'node:path'
 import { env } from 'node:process'
@@ -11,8 +12,18 @@ const isCFEnvironment = env.VCAP_APPLICATION != null
 const PORT = isCFEnvironment ? Number.parseInt(env.PORT) : UI_DEV_SERVER_PORT
 const uiPath = join(dirname(fileURLToPath(import.meta.url)), './dist')
 
+const indexHtml = readFileSync(join(uiPath, 'index.html'))
 const serve = serveStatic(uiPath)
 
-const server = createServer((req, res) => serve(req, res, finalhandler(req, res)))
+const server = createServer((req, res) => {
+  serve(req, res, () => {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      finalhandler(req, res)()
+      return
+    }
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+    res.end(indexHtml)
+  })
+})
 
 server.listen(PORT, () => console.info(`Web UI running at: http://localhost:${PORT}`))

--- a/ui/web/tests/unit/AddChargingStations.test.ts
+++ b/ui/web/tests/unit/AddChargingStations.test.ts
@@ -135,11 +135,11 @@ describe('AddChargingStations', () => {
     )
   })
 
-  it('should pass fixedName only when baseName is set and appendCounter is unchecked', async () => {
+  it('should pass fixedName: true when baseName is set and fixedName checkbox is checked', async () => {
     const wrapper = mountComponent()
     await wrapper.find('#base-name').setValue('DEV-STATION')
     const checkboxes = wrapper.findAll('input[type="checkbox"]')
-    await checkboxes[0].setValue(false)
+    await checkboxes[0].setValue(true)
     await wrapper.find('button').trigger('click')
     await flushPromises()
     expect(mockClient.addChargingStations).toHaveBeenCalledWith(

--- a/ui/web/tests/unit/AddChargingStations.test.ts
+++ b/ui/web/tests/unit/AddChargingStations.test.ts
@@ -91,7 +91,7 @@ describe('AddChargingStations', () => {
   it('should render option checkboxes', () => {
     const wrapper = mountComponent()
     const checkboxes = wrapper.findAll('input[type="checkbox"]')
-    expect(checkboxes.length).toBe(4)
+    expect(checkboxes.length).toBe(5)
   })
 
   it('should pass supervision URL option when provided', async () => {
@@ -114,6 +114,38 @@ describe('AddChargingStations', () => {
       expect.anything(),
       expect.anything(),
       expect.objectContaining({ supervisionUrls: undefined })
+    )
+  })
+
+  it('should pass baseName and credentials when provided', async () => {
+    const wrapper = mountComponent()
+    await wrapper.find('#base-name').setValue('DEV-STATION')
+    await wrapper.find('#supervision-user').setValue('alice')
+    await wrapper.find('#supervision-password').setValue('s3cret')
+    await wrapper.find('button').trigger('click')
+    await flushPromises()
+    expect(mockClient.addChargingStations).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        baseName: 'DEV-STATION',
+        supervisionPassword: 's3cret',
+        supervisionUser: 'alice',
+      })
+    )
+  })
+
+  it('should pass fixedName only when baseName is set and appendCounter is unchecked', async () => {
+    const wrapper = mountComponent()
+    await wrapper.find('#base-name').setValue('DEV-STATION')
+    const checkboxes = wrapper.findAll('input[type="checkbox"]')
+    await checkboxes[0].setValue(false)
+    await wrapper.find('button').trigger('click')
+    await flushPromises()
+    expect(mockClient.addChargingStations).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ baseName: 'DEV-STATION', fixedName: true })
     )
   })
 })

--- a/ui/web/tests/unit/SetSupervisionUrl.test.ts
+++ b/ui/web/tests/unit/SetSupervisionUrl.test.ts
@@ -63,7 +63,7 @@ describe('SetSupervisionUrl', () => {
     expect(wrapper.find('#supervision-password').exists()).toBe(true)
   })
 
-  it('should call setSupervisionUrl with only url when only url is set', async () => {
+  it('should send empty credential strings when only url is set', async () => {
     const wrapper = mountComponent()
     await wrapper.find('#supervision-url').setValue('wss://new-server.com:9000')
     await wrapper.find('button').trigger('click')
@@ -71,8 +71,8 @@ describe('SetSupervisionUrl', () => {
     expect(mockClient.setSupervisionUrl).toHaveBeenCalledWith(
       TEST_HASH_ID,
       'wss://new-server.com:9000',
-      undefined,
-      undefined
+      '',
+      ''
     )
   })
 
@@ -91,8 +91,24 @@ describe('SetSupervisionUrl', () => {
     )
   })
 
-  it('should not call setSupervisionUrl when all fields are empty', async () => {
+  it('should send empty password when only user is typed', async () => {
     const wrapper = mountComponent()
+    await wrapper.find('#supervision-url').setValue('wss://new-server.com:9000')
+    await wrapper.find('#supervision-user').setValue('alice')
+    await wrapper.find('button').trigger('click')
+    await flushPromises()
+    expect(mockClient.setSupervisionUrl).toHaveBeenCalledWith(
+      TEST_HASH_ID,
+      'wss://new-server.com:9000',
+      'alice',
+      ''
+    )
+  })
+
+  it('should not call setSupervisionUrl when url is empty', async () => {
+    const wrapper = mountComponent()
+    await wrapper.find('#supervision-user').setValue('alice')
+    await wrapper.find('#supervision-password').setValue('s3cret')
     await wrapper.find('button').trigger('click')
     await flushPromises()
     expect(mockClient.setSupervisionUrl).not.toHaveBeenCalled()

--- a/ui/web/tests/unit/SetSupervisionUrl.test.ts
+++ b/ui/web/tests/unit/SetSupervisionUrl.test.ts
@@ -56,25 +56,52 @@ describe('SetSupervisionUrl', () => {
     expect(wrapper.text()).toContain(TEST_STATION_ID)
   })
 
-  it('should render supervision URL input', () => {
+  it('should render supervision URL and credential inputs', () => {
     const wrapper = mountComponent()
     expect(wrapper.find('#supervision-url').exists()).toBe(true)
+    expect(wrapper.find('#supervision-user').exists()).toBe(true)
+    expect(wrapper.find('#supervision-password').exists()).toBe(true)
   })
 
-  it('should call setSupervisionUrl on button click', async () => {
+  it('should call setSupervisionUrl with only url when only url is set', async () => {
     const wrapper = mountComponent()
-    const input = wrapper.find('#supervision-url')
-    await input.setValue('wss://new-server.com:9000')
+    await wrapper.find('#supervision-url').setValue('wss://new-server.com:9000')
     await wrapper.find('button').trigger('click')
     await flushPromises()
     expect(mockClient.setSupervisionUrl).toHaveBeenCalledWith(
       TEST_HASH_ID,
-      'wss://new-server.com:9000'
+      'wss://new-server.com:9000',
+      undefined,
+      undefined
     )
+  })
+
+  it('should call setSupervisionUrl with credentials when all fields are set', async () => {
+    const wrapper = mountComponent()
+    await wrapper.find('#supervision-url').setValue('wss://new-server.com:9000')
+    await wrapper.find('#supervision-user').setValue('alice')
+    await wrapper.find('#supervision-password').setValue('s3cret')
+    await wrapper.find('button').trigger('click')
+    await flushPromises()
+    expect(mockClient.setSupervisionUrl).toHaveBeenCalledWith(
+      TEST_HASH_ID,
+      'wss://new-server.com:9000',
+      'alice',
+      's3cret'
+    )
+  })
+
+  it('should not call setSupervisionUrl when all fields are empty', async () => {
+    const wrapper = mountComponent()
+    await wrapper.find('button').trigger('click')
+    await flushPromises()
+    expect(mockClient.setSupervisionUrl).not.toHaveBeenCalled()
+    expect(toastMock.error).toHaveBeenCalled()
   })
 
   it('should navigate to charging-stations after submission', async () => {
     const wrapper = mountComponent()
+    await wrapper.find('#supervision-url').setValue('wss://new-server.com:9000')
     await wrapper.find('button').trigger('click')
     await flushPromises()
     expect(mockRouter.push).toHaveBeenCalledWith({ name: 'charging-stations' })
@@ -83,6 +110,7 @@ describe('SetSupervisionUrl', () => {
   it('should show error toast on failure', async () => {
     const wrapper = mountComponent()
     mockClient.setSupervisionUrl = vi.fn().mockRejectedValue(new Error('Network error'))
+    await wrapper.find('#supervision-url').setValue('wss://new-server.com:9000')
     await wrapper.find('button').trigger('click')
     await flushPromises()
     expect(toastMock.error).toHaveBeenCalled()

--- a/ui/web/tests/unit/UIClient.test.ts
+++ b/ui/web/tests/unit/UIClient.test.ts
@@ -349,6 +349,26 @@ describe('UIClient', () => {
       })
     })
 
+    it('should send SET_SUPERVISION_URL with credentials when provided', async () => {
+      const url = 'ws://new-supervision:9001'
+      await client.setSupervisionUrl(TEST_HASH_ID, url, 'alice', 's3cret')
+      expect(sendRequestSpy).toHaveBeenCalledWith(ProcedureName.SET_SUPERVISION_URL, {
+        hashIds: [TEST_HASH_ID],
+        supervisionPassword: 's3cret',
+        supervisionUser: 'alice',
+        url,
+      })
+    })
+
+    it('should send SET_SUPERVISION_URL with only credentials when url is omitted', async () => {
+      await client.setSupervisionUrl(TEST_HASH_ID, undefined, 'alice', 's3cret')
+      expect(sendRequestSpy).toHaveBeenCalledWith(ProcedureName.SET_SUPERVISION_URL, {
+        hashIds: [TEST_HASH_ID],
+        supervisionPassword: 's3cret',
+        supervisionUser: 'alice',
+      })
+    })
+
     it('should send AUTHORIZE with hashIds and idTag', async () => {
       await client.authorize(TEST_HASH_ID, TEST_ID_TAG)
       expect(sendRequestSpy).toHaveBeenCalledWith(ProcedureName.AUTHORIZE, {

--- a/ui/web/tests/unit/UIClient.test.ts
+++ b/ui/web/tests/unit/UIClient.test.ts
@@ -360,15 +360,6 @@ describe('UIClient', () => {
       })
     })
 
-    it('should send SET_SUPERVISION_URL with only credentials when url is omitted', async () => {
-      await client.setSupervisionUrl(TEST_HASH_ID, undefined, 'alice', 's3cret')
-      expect(sendRequestSpy).toHaveBeenCalledWith(ProcedureName.SET_SUPERVISION_URL, {
-        hashIds: [TEST_HASH_ID],
-        supervisionPassword: 's3cret',
-        supervisionUser: 'alice',
-      })
-    })
-
     it('should send AUTHORIZE with hashIds and idTag', async () => {
       await client.authorize(TEST_HASH_ID, TEST_ID_TAG)
       expect(sendRequestSpy).toHaveBeenCalledWith(ProcedureName.AUTHORIZE, {


### PR DESCRIPTION
## PR Checklist

- [x] Please add a description of your changes.
- [x] Please ensure title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] We need your changes to come with unit tests in order to keep this project in quality and easy to maintain.
- [x] If your changes contain any new feature please be sure to document it.
- [x] Please add a link to the open issue or task that this pull request will resolve.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


# Summary

Extend ChargingStationOptions (used in addChargingStations procedure) with optional
* baseName
* fixedName
* nameSuffix
* supervisionUser
* supervisionPassword

Also exposes this in the add-dialog on the UI

Extends SetSupervisionUrl with:
* supervisionUser
* supervisionPassword

Also exposes this in the dialogue in the UI

Details that make changing the basename work:  
Identity derivation (chargingStationId, hashId) moves to the tail of getStationInfo, after setChargingStationOptions runs, so the merged stationInfo is the single source of truth for baseName/fixedName/nameSuffix. getChargingStationId now accepts a narrow StationIdentity pick that both ChargingStationTemplate and ChargingStationInfo satisfy; getHashId grows an optional chargingStationIdOverride so the new identity flows through without altering the hashed payload shape for existing callers.

Default behaviour is unchanged: hash ID regression test pins the pre-existing hash, and omitted options leave stationInfo untouched.

### Side note

* Also fixes web UI reload not working when a dialog was opened
* Commits split logically, so it might be easier to review commit-by-commit

Disclosure: mostly written by Claude Code

Fixes #1647