### PR TITLE
fix(utils): make file persistence atomic across writers

### DIFF
--- a/src/charging-station/BootstrapStateUtils.ts
+++ b/src/charging-station/BootstrapStateUtils.ts
@@ -150,8 +150,7 @@ export const writeStateFile = async (
       JSON.stringify(stateData, undefined, 2),
       FileType.SimulatorState,
       logPrefixFn?.() ?? '',
-      undefined,
-      { throwError: false }
+      { errorParams: { throwError: false } }
     )
   })
 }

--- a/src/charging-station/BootstrapStateUtils.ts
+++ b/src/charging-station/BootstrapStateUtils.ts
@@ -1,15 +1,7 @@
 // Partial Copyright Jerome Benoit. 2021-2025. All Rights Reserved.
 
-import {
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  renameSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs'
-import { basename, dirname, join } from 'node:path'
+import { existsSync, readdirSync, readFileSync, renameSync, rmSync } from 'node:fs'
+import { basename, join } from 'node:path'
 
 import type { TemplateStatistics } from '../types/index.js'
 
@@ -17,6 +9,7 @@ import { FileType } from '../types/index.js'
 import {
   AsyncLock,
   AsyncLockType,
+  atomicWriteFileSync,
   ensureError,
   formatLogPrefix,
   handleFileException,
@@ -148,29 +141,17 @@ export const writeStateFile = async (
   logPrefixFn?: () => string
 ): Promise<void> => {
   await AsyncLock.runExclusive(AsyncLockType.simulatorState, () => {
-    const tmpFile = `${stateFilePath}.tmp`
-    try {
-      mkdirSync(dirname(stateFilePath), { recursive: true })
-      const stateData: SimulatorStateFile = {
-        started,
-        version: STATE_FILE_VERSION,
-      }
-      writeFileSync(tmpFile, JSON.stringify(stateData, undefined, 2), 'utf8')
-      renameSync(tmpFile, stateFilePath)
-    } catch (error) {
-      // Best-effort tmp cleanup; ignore secondary failure to surface the original error.
-      try {
-        rmSync(tmpFile, { force: true })
-      } catch {
-        // Ignore
-      }
-      handleFileException(
-        stateFilePath,
-        FileType.SimulatorState,
-        ensureError(error),
-        logPrefixFn?.() ?? '',
-        { throwError: false }
-      )
+    const stateData: SimulatorStateFile = {
+      started,
+      version: STATE_FILE_VERSION,
     }
+    atomicWriteFileSync(
+      stateFilePath,
+      JSON.stringify(stateData, undefined, 2),
+      FileType.SimulatorState,
+      logPrefixFn?.() ?? '',
+      undefined,
+      { throwError: false }
+    )
   })
 }

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -3,7 +3,7 @@
 import { millisecondsToSeconds, secondsToMilliseconds } from 'date-fns'
 import { hash, randomInt } from 'node:crypto'
 import { EventEmitter } from 'node:events'
-import { existsSync, type FSWatcher, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, type FSWatcher, mkdirSync, readFileSync, rmSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { URL } from 'node:url'
 import { parentPort } from 'node:worker_threads'
@@ -69,6 +69,7 @@ import {
   ACElectricUtils,
   AsyncLock,
   AsyncLockType,
+  atomicWriteFileSync,
   buildAddedMessage,
   buildChargingStationAutomaticTransactionGeneratorConfiguration,
   buildConnectorsStatus,
@@ -2589,10 +2590,11 @@ export class ChargingStation extends EventEmitter {
             configurationData.configurationHash = configurationHash
             const measureId = `${FileType.ChargingStationConfiguration} write`
             const beginId = PerformanceStatistics.beginMeasure(measureId)
-            writeFileSync(
+            atomicWriteFileSync(
               this.configurationFile,
               JSON.stringify(configurationData, undefined, 2),
-              'utf8'
+              FileType.ChargingStationConfiguration,
+              this.logPrefix()
             )
             PerformanceStatistics.endMeasure(measureId, beginId)
             this.sharedLRUCache.deleteChargingStationConfiguration(this.configurationFileHash)

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -2601,13 +2601,26 @@ export class ChargingStation extends EventEmitter {
             this.sharedLRUCache.setChargingStationConfiguration(configurationData)
             this.configurationFileHash = configurationHash
           }).catch((error: unknown) => {
-            handleFileException(
-              this.configurationFile,
-              FileType.ChargingStationConfiguration,
-              ensureError(error),
-              this.logPrefix(),
-              { throwError: false }
-            )
+            // File-system failures are already logged at error level by the atomic
+            // write via handleFileException; absorb them here at debug level. Other
+            // failures inside the lock body (JSON serialization, cache mutation, ...)
+            // would otherwise go unobserved, so log them at error level.
+            const isErrnoException =
+              typeof error === 'object' &&
+              error !== null &&
+              'code' in error &&
+              typeof (error as NodeJS.ErrnoException).code === 'string'
+            if (isErrnoException) {
+              logger.debug(
+                `${this.logPrefix()} ${moduleName}.saveConfiguration: configuration save rejected:`,
+                error
+              )
+            } else {
+              logger.error(
+                `${this.logPrefix()} ${moduleName}.saveConfiguration: unexpected error inside configuration save lock:`,
+                ensureError(error)
+              )
+            }
           })
         } else {
           logger.debug(

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -2605,7 +2605,8 @@ export class ChargingStation extends EventEmitter {
               this.configurationFile,
               FileType.ChargingStationConfiguration,
               ensureError(error),
-              this.logPrefix()
+              this.logPrefix(),
+              { throwError: false }
             )
           })
         } else {

--- a/src/charging-station/ocpp/2.0/OCPP20CertificateManager.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20CertificateManager.ts
@@ -419,9 +419,13 @@ export class OCPP20CertificateManager {
         await mkdir(dirPath, { recursive: true })
       }
 
-      await atomicWriteFile(filePath, pemData, FileType.Certificate, '', {
-        ensureDir: false,
-      })
+      await atomicWriteFile(
+        filePath,
+        pemData,
+        FileType.Certificate,
+        `${stationHashId} OCPP20CertificateManager.storeCertificate |`,
+        { ensureDir: false }
+      )
 
       return {
         filePath,

--- a/src/charging-station/ocpp/2.0/OCPP20CertificateManager.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20CertificateManager.ts
@@ -1,7 +1,7 @@
 // Copyright Jerome Benoit. 2021-2025. All Rights Reserved.
 
 import { hash, X509Certificate } from 'node:crypto'
-import { mkdir, readdir, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdir, readdir, readFile, realpath, rm, stat } from 'node:fs/promises'
 import { join, resolve, sep } from 'node:path'
 
 import type { ChargingStation } from '../../index.js'
@@ -12,11 +12,18 @@ import {
   type CertificateHashDataType,
   CertificateSigningUseEnumType,
   DeleteCertificateStatusEnumType,
+  FileType,
   GetCertificateIdUseEnumType,
   HashAlgorithmEnumType,
   InstallCertificateUseEnumType,
 } from '../../../types/index.js'
-import { convertToDate, getErrorMessage, isEmpty, isNotEmptyArray } from '../../../utils/index.js'
+import {
+  atomicWriteFile,
+  convertToDate,
+  getErrorMessage,
+  isEmpty,
+  isNotEmptyArray,
+} from '../../../utils/index.js'
 import { extractDerIssuer } from './Asn1DerUtils.js'
 
 /**
@@ -412,7 +419,9 @@ export class OCPP20CertificateManager {
         await mkdir(dirPath, { recursive: true })
       }
 
-      await writeFile(filePath, pemData, 'utf8')
+      await atomicWriteFile(filePath, pemData, FileType.Certificate, '', {
+        ensureDir: false,
+      })
 
       return {
         filePath,

--- a/src/charging-station/ocpp/2.0/OCPP20CertificateManager.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20CertificateManager.ts
@@ -1,7 +1,7 @@
 // Copyright Jerome Benoit. 2021-2025. All Rights Reserved.
 
 import { hash, X509Certificate } from 'node:crypto'
-import { mkdir, readdir, readFile, realpath, rm, stat } from 'node:fs/promises'
+import { readdir, readFile, realpath, rm, stat } from 'node:fs/promises'
 import { join, resolve, sep } from 'node:path'
 
 import type { ChargingStation } from '../../index.js'
@@ -69,7 +69,8 @@ export interface OCPP20CertificateManagerInterface {
   storeCertificate(
     stationHashId: string,
     certType: CertificateSigningUseEnumType | InstallCertificateUseEnumType,
-    pemData: string
+    pemData: string,
+    logPrefix: string
   ): Promise<StoreCertificateResult> | StoreCertificateResult
   validateCertificateFormat(pemData: unknown): boolean
   validateCertificateX509(pem: string): ValidateCertificateX509Result
@@ -384,12 +385,14 @@ export class OCPP20CertificateManager {
    * @param certType - Certificate type for storage (InstallCertificateUseEnumType for root certificates
    *   or CertificateSigningUseEnumType for signed leaf certificates)
    * @param pemData - PEM-encoded certificate data
+   * @param logPrefix - Caller-supplied log prefix used for atomic write error logging
    * @returns Storage result with success status and file path or error
    */
   public async storeCertificate (
     stationHashId: string,
     certType: CertificateSigningUseEnumType | InstallCertificateUseEnumType,
-    pemData: string
+    pemData: string,
+    logPrefix: string
   ): Promise<StoreCertificateResult> {
     if (!this.validateCertificateFormat(pemData)) {
       return {
@@ -414,18 +417,16 @@ export class OCPP20CertificateManager {
 
       await this.validateCertificatePath(filePath, OCPP20CertificateManager.BASE_CERT_PATH)
 
-      const dirPath = resolve(filePath, '..')
-      if (!(await this.pathExists(dirPath))) {
-        await mkdir(dirPath, { recursive: true })
-      }
-
-      await atomicWriteFile(
-        filePath,
-        pemData,
-        FileType.Certificate,
-        `${stationHashId} OCPP20CertificateManager.storeCertificate |`,
-        { ensureDir: false }
-      )
+      // Per-path serialization is implicit: the destination path is keyed by the
+      // certificate serial number, so concurrent calls writing byte-identical PEMs
+      // collapse to equivalent writes, and certificates with distinct serials use
+      // distinct paths. No external AsyncLock is required for these cases. Concurrent
+      // calls writing different PEM bytes to the same serial (rare in practice) are
+      // last-writer-wins. Parent directory creation is delegated to atomicWriteFile
+      // via its default `ensureDir: true`.
+      await atomicWriteFile(filePath, pemData, FileType.Certificate, logPrefix, {
+        mode: 0o600,
+      })
 
       return {
         filePath,

--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -1542,7 +1542,8 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
       const result = chargingStation.certificateManager.storeCertificate(
         chargingStation.stationInfo?.hashId ?? '',
         certificateType ?? CertificateSigningUseEnumType.ChargingStationCertificate,
-        certificateChain
+        certificateChain,
+        chargingStation.logPrefix()
       )
 
       const storeResult = result instanceof Promise ? await result : result
@@ -2073,7 +2074,8 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
       const rawResult = chargingStation.certificateManager.storeCertificate(
         chargingStation.stationInfo?.hashId ?? '',
         certificateType,
-        certificate
+        certificate,
+        chargingStation.logPrefix()
       )
       const resultPromise: Promise<StoreCertificateResult> =
         rawResult instanceof Promise

--- a/src/performance/storage/JsonFileStorage.ts
+++ b/src/performance/storage/JsonFileStorage.ts
@@ -37,15 +37,15 @@ export class JsonFileStorage extends Storage {
   public async storePerformanceStatistics (performanceStatistics: Statistics): Promise<void> {
     this.setPerformanceStatistics(performanceStatistics)
     await AsyncLock.runExclusive(AsyncLockType.performance, () => {
-      // The storage directory is created by `open()`; skip the per-write `mkdir`
-      // to keep the per-sample cost minimal.
+      // Performance records are observability data; skip the per-sample `mkdir` (the
+      // directory is created by `open()`) and `fsync` (durability across crashes is
+      // not required for telemetry) to keep the hot path cheap.
       atomicWriteFileSync(
         this.dbName,
         JSONStringify([...this.getPerformanceStatistics()], 2, MapStringifyFormat.object),
         FileType.PerformanceRecords,
         this.logPrefix,
-        { ensureDir: false },
-        { throwError: false }
+        { ensureDir: false, errorParams: { throwError: false }, flush: false }
       )
     })
   }

--- a/src/performance/storage/JsonFileStorage.ts
+++ b/src/performance/storage/JsonFileStorage.ts
@@ -36,26 +36,17 @@ export class JsonFileStorage extends Storage {
 
   public async storePerformanceStatistics (performanceStatistics: Statistics): Promise<void> {
     this.setPerformanceStatistics(performanceStatistics)
-    try {
-      await AsyncLock.runExclusive(AsyncLockType.performance, () => {
-        // The storage directory is created by `open()`; skip the per-write `mkdir`
-        // to keep the per-sample cost minimal.
-        atomicWriteFileSync(
-          this.dbName,
-          JSONStringify([...this.getPerformanceStatistics()], 2, MapStringifyFormat.object),
-          FileType.PerformanceRecords,
-          this.logPrefix,
-          { ensureDir: false }
-        )
-      })
-    } catch (error) {
-      handleFileException(
+    await AsyncLock.runExclusive(AsyncLockType.performance, () => {
+      // The storage directory is created by `open()`; skip the per-write `mkdir`
+      // to keep the per-sample cost minimal.
+      atomicWriteFileSync(
         this.dbName,
+        JSONStringify([...this.getPerformanceStatistics()], 2, MapStringifyFormat.object),
         FileType.PerformanceRecords,
-        ensureError(error),
         this.logPrefix,
+        { ensureDir: false },
         { throwError: false }
       )
-    }
+    })
   }
 }

--- a/src/performance/storage/JsonFileStorage.ts
+++ b/src/performance/storage/JsonFileStorage.ts
@@ -1,12 +1,10 @@
 // Copyright Jerome Benoit. 2021-2025. All Rights Reserved.
 
-import { closeSync, openSync, writeSync } from 'node:fs'
-
-import { BaseError } from '../../exception/index.js'
 import { FileType, MapStringifyFormat, type Statistics } from '../../types/index.js'
 import {
   AsyncLock,
   AsyncLockType,
+  atomicWriteFileSync,
   ensureError,
   handleFileException,
   JSONStringify,
@@ -14,8 +12,6 @@ import {
 import { Storage } from './Storage.js'
 
 export class JsonFileStorage extends Storage {
-  private fd?: number
-
   constructor (storageUri: string, logPrefix: string) {
     super(storageUri, logPrefix)
     this.dbName = this.storageUri.pathname
@@ -23,27 +19,11 @@ export class JsonFileStorage extends Storage {
 
   public close (): void {
     this.clearPerformanceStatistics()
-    try {
-      if (this.fd != null) {
-        closeSync(this.fd)
-        delete this.fd
-      }
-    } catch (error) {
-      handleFileException(
-        this.dbName,
-        FileType.PerformanceRecords,
-        ensureError(error),
-        this.logPrefix
-      )
-    }
   }
 
   public open (): void {
     try {
-      if (this.fd == null) {
-        this.ensureDBDirectory()
-        this.fd = openSync(this.dbName, 'w')
-      }
+      this.ensureDBDirectory()
     } catch (error) {
       handleFileException(
         this.dbName,
@@ -54,32 +34,28 @@ export class JsonFileStorage extends Storage {
     }
   }
 
-  public storePerformanceStatistics (performanceStatistics: Statistics): void {
+  public async storePerformanceStatistics (performanceStatistics: Statistics): Promise<void> {
     this.setPerformanceStatistics(performanceStatistics)
-    const fd = this.checkPerformanceRecordsFile()
-    AsyncLock.runExclusive(AsyncLockType.performance, () => {
-      writeSync(
-        fd,
-        JSONStringify([...this.getPerformanceStatistics()], 2, MapStringifyFormat.object),
-        0,
-        'utf8'
-      )
-    }).catch((error: unknown) => {
+    try {
+      await AsyncLock.runExclusive(AsyncLockType.performance, () => {
+        // The storage directory is created by `open()`; skip the per-write `mkdir`
+        // to keep the per-sample cost minimal.
+        atomicWriteFileSync(
+          this.dbName,
+          JSONStringify([...this.getPerformanceStatistics()], 2, MapStringifyFormat.object),
+          FileType.PerformanceRecords,
+          this.logPrefix,
+          { ensureDir: false }
+        )
+      })
+    } catch (error) {
       handleFileException(
         this.dbName,
         FileType.PerformanceRecords,
         ensureError(error),
-        this.logPrefix
-      )
-    })
-  }
-
-  private checkPerformanceRecordsFile (): number {
-    if (this.fd == null) {
-      throw new BaseError(
-        `${this.logPrefix} Performance records '${this.dbName}' file descriptor not found`
+        this.logPrefix,
+        { throwError: false }
       )
     }
-    return this.fd
   }
 }

--- a/src/performance/storage/JsonFileStorage.ts
+++ b/src/performance/storage/JsonFileStorage.ts
@@ -1,5 +1,7 @@
 // Copyright Jerome Benoit. 2021-2025. All Rights Reserved.
 
+import { fileURLToPath } from 'node:url'
+
 import { FileType, MapStringifyFormat, type Statistics } from '../../types/index.js'
 import {
   AsyncLock,
@@ -14,7 +16,13 @@ import { Storage } from './Storage.js'
 export class JsonFileStorage extends Storage {
   constructor (storageUri: string, logPrefix: string) {
     super(storageUri, logPrefix)
-    this.dbName = this.storageUri.pathname
+    // Decode `file:` URIs into a native filesystem path; `URL.pathname` would yield
+    // `/C:/...` on Windows which is not usable as-is. Other schemes (typically a relative
+    // path passed as `jsonfile:./...`) keep `pathname` semantics for backward compatibility.
+    this.dbName =
+      this.storageUri.protocol === 'file:'
+        ? fileURLToPath(this.storageUri)
+        : this.storageUri.pathname
   }
 
   public close (): void {

--- a/src/types/FileType.ts
+++ b/src/types/FileType.ts
@@ -1,5 +1,6 @@
 export enum FileType {
   Authorization = 'authorization',
+  Certificate = 'certificate',
   ChargingStationConfiguration = 'charging station configuration',
   ChargingStationTemplate = 'charging station template',
   Configuration = 'configuration',

--- a/src/utils/FileUtils.ts
+++ b/src/utils/FileUtils.ts
@@ -1,12 +1,76 @@
-import { type FSWatcher, watch, type WatchListener } from 'node:fs'
+// Copyright Jerome Benoit. 2021-2025. All Rights Reserved.
 
-import type { FileType } from '../types/index.js'
+import {
+  type FSWatcher,
+  mkdirSync,
+  renameSync,
+  rmSync,
+  watch,
+  type WatchListener,
+  type WriteFileOptions,
+  writeFileSync,
+} from 'node:fs'
+import { mkdir, rename, rm, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { pid } from 'node:process'
+
+import type { EmptyObject, FileType, HandleErrorParams } from '../types/index.js'
 
 import { ensureError, handleFileException } from './ErrorUtils.js'
 import { logger } from './Logger.js'
 import { isNotEmptyString } from './Utils.js'
 
 const moduleName = 'FileUtils'
+
+/**
+ * Default file mode for newly created files (umask is applied by the OS).
+ */
+const DEFAULT_FILE_MODE = 0o666
+
+/**
+ * Monotonic counter used together with the process id to build unique temp filenames.
+ * Single-process simulators do not need cryptographic randomness here; uniqueness within
+ * the process suffices because callers serialize concurrent writes externally.
+ */
+let tmpInvocationCounter = 0
+
+/**
+ * Options for atomic file write operations.
+ */
+export interface AtomicWriteOptions {
+  /**
+   * Character encoding when `data` is a string. Defaults to `'utf8'`.
+   */
+  encoding?: BufferEncoding
+  /**
+   * Whether to call `mkdir(dirname(file), { recursive: true })` before writing.
+   * Defaults to `true`.
+   */
+  ensureDir?: boolean
+  /**
+   * Whether to flush (`fsync`) the temp file to the storage device before renaming.
+   * Provides crash durability at a small performance cost. Defaults to `true`.
+   */
+  flush?: boolean
+  /**
+   * File mode to apply when creating the temp file. The OS umask is applied on top.
+   * Defaults to `0o666`.
+   */
+  mode?: number
+}
+
+/**
+ * Builds a unique temporary file path placed in the same directory as `file`.
+ *
+ * Same-directory placement guarantees `rename(2)` cannot fail with `EXDEV` and that
+ * the rename is atomic at the filesystem level.
+ * @param file - Final destination file path.
+ * @returns Temporary file path.
+ */
+const buildTmpPath = (file: string): string => {
+  tmpInvocationCounter += 1
+  return `${file}.${pid.toString()}.${tmpInvocationCounter.toString()}.tmp`
+}
 
 export const watchJsonFile = (
   file: string,
@@ -26,5 +90,103 @@ export const watchJsonFile = (
     logger.info(
       `${logPrefix} ${moduleName}.watchJsonFile: No ${fileType} file to watch given. Not monitoring its changes`
     )
+  }
+}
+
+/**
+ * Asynchronously writes `data` to `file` atomically using a write-then-rename strategy.
+ *
+ * The data is first written to a unique temporary file in the same directory as `file`,
+ * optionally flushed to disk, then atomically renamed to `file`. Concurrent readers see
+ * either the previous file content or the complete new content, never a partial write.
+ *
+ * Concurrent writers to the same `file` MUST be serialized externally (for example via
+ * `AsyncLock.runExclusive`); this primitive does not queue or deduplicate calls.
+ *
+ * On error, the temporary file is removed best-effort and the failure is funnelled
+ * through {@link handleFileException} using `fileType` and `logPrefix`.
+ * @param file - Destination file path.
+ * @param data - Content to write.
+ * @param fileType - File type used for error logging.
+ * @param logPrefix - Caller-supplied log prefix used for error logging.
+ * @param options - Atomic write options.
+ * @param errorParams - Error handling parameters forwarded to {@link handleFileException}.
+ * @returns A promise that resolves once the rename has completed, or rejects when
+ *   `errorParams.throwError !== false` and the write failed.
+ */
+export const atomicWriteFile = async (
+  file: string,
+  data: NodeJS.ArrayBufferView | string,
+  fileType: FileType,
+  logPrefix: string,
+  options?: AtomicWriteOptions,
+  errorParams?: HandleErrorParams<EmptyObject>
+): Promise<void> => {
+  const { encoding, ensureDir, flush, mode } = {
+    encoding: 'utf8' as BufferEncoding,
+    ensureDir: true,
+    flush: true,
+    mode: DEFAULT_FILE_MODE,
+    ...options,
+  }
+  const tmpFile = buildTmpPath(file)
+  try {
+    if (ensureDir) {
+      await mkdir(dirname(file), { recursive: true })
+    }
+    await writeFile(tmpFile, data, { encoding, flush, mode })
+    await rename(tmpFile, file)
+  } catch (error) {
+    try {
+      await rm(tmpFile, { force: true })
+    } catch {
+      // Ignore secondary cleanup failure to surface the original error.
+    }
+    handleFileException(file, fileType, ensureError(error), logPrefix, errorParams)
+  }
+}
+
+/**
+ * Synchronous variant of {@link atomicWriteFile}.
+ *
+ * Same algorithm and contract as the asynchronous variant. Useful for shutdown paths
+ * and other synchronous code where awaiting is not possible.
+ * @param file - Destination file path.
+ * @param data - Content to write.
+ * @param fileType - File type used for error logging.
+ * @param logPrefix - Caller-supplied log prefix used for error logging.
+ * @param options - Atomic write options.
+ * @param errorParams - Error handling parameters forwarded to {@link handleFileException}.
+ */
+export const atomicWriteFileSync = (
+  file: string,
+  data: NodeJS.ArrayBufferView | string,
+  fileType: FileType,
+  logPrefix: string,
+  options?: AtomicWriteOptions,
+  errorParams?: HandleErrorParams<EmptyObject>
+): void => {
+  const { encoding, ensureDir, flush, mode } = {
+    encoding: 'utf8' as BufferEncoding,
+    ensureDir: true,
+    flush: true,
+    mode: DEFAULT_FILE_MODE,
+    ...options,
+  }
+  const tmpFile = buildTmpPath(file)
+  try {
+    if (ensureDir) {
+      mkdirSync(dirname(file), { recursive: true })
+    }
+    const writeOptions: WriteFileOptions = { encoding, flush, mode }
+    writeFileSync(tmpFile, data, writeOptions)
+    renameSync(tmpFile, file)
+  } catch (error) {
+    try {
+      rmSync(tmpFile, { force: true })
+    } catch {
+      // Ignore secondary cleanup failure to surface the original error.
+    }
+    handleFileException(file, fileType, ensureError(error), logPrefix, errorParams)
   }
 }

--- a/src/utils/FileUtils.ts
+++ b/src/utils/FileUtils.ts
@@ -13,6 +13,7 @@ import {
 import { mkdir, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { pid } from 'node:process'
+import { threadId } from 'node:worker_threads'
 
 import type { EmptyObject, FileType, HandleErrorParams } from '../types/index.js'
 
@@ -22,21 +23,10 @@ import { isNotEmptyString } from './Utils.js'
 
 const moduleName = 'FileUtils'
 
-/**
- * Default file mode for newly created files (umask is applied by the OS).
- */
 const DEFAULT_FILE_MODE = 0o666
 
-/**
- * Monotonic counter used together with the process id to build unique temp filenames.
- * Single-process simulators do not need cryptographic randomness here; uniqueness within
- * the process suffices because callers serialize concurrent writes externally.
- */
 let tmpInvocationCounter = 0
 
-/**
- * Options for atomic file write operations.
- */
 export interface AtomicWriteOptions {
   /**
    * Character encoding when `data` is a string. Defaults to `'utf8'`.
@@ -48,28 +38,25 @@ export interface AtomicWriteOptions {
    */
   ensureDir?: boolean
   /**
+   * Error handling parameters forwarded to {@link handleFileException}. Defaults
+   * to `{ throwError: true, consoleOut: false }` (log at error level and rethrow).
+   */
+  errorParams?: HandleErrorParams<EmptyObject>
+  /**
    * Whether to flush (`fsync`) the temp file to the storage device before renaming.
-   * Provides crash durability at a small performance cost. Defaults to `true`.
+   * Defaults to `true`.
    */
   flush?: boolean
   /**
-   * File mode to apply when creating the temp file. The OS umask is applied on top.
-   * Defaults to `0o666`.
+   * File mode applied at temp file creation; the OS umask is applied on top. The
+   * destination inherits the temp file's mode after rename. Defaults to `0o666`.
    */
   mode?: number
 }
 
-/**
- * Builds a unique temporary file path placed in the same directory as `file`.
- *
- * Same-directory placement guarantees `rename(2)` cannot fail with `EXDEV` and that
- * the rename is atomic at the filesystem level.
- * @param file - Final destination file path.
- * @returns Temporary file path.
- */
 const buildTmpPath = (file: string): string => {
   tmpInvocationCounter += 1
-  return `${file}.${pid.toString()}.${tmpInvocationCounter.toString()}.tmp`
+  return `${file}.${pid.toString()}.${threadId.toString()}.${tmpInvocationCounter.toString()}.tmp`
 }
 
 export const watchJsonFile = (
@@ -97,38 +84,57 @@ export const watchJsonFile = (
  * Asynchronously writes `data` to `file` atomically using a write-then-rename strategy.
  *
  * The data is first written to a unique temporary file in the same directory as `file`,
- * optionally flushed to disk, then atomically renamed to `file`. Concurrent readers see
- * either the previous file content or the complete new content, never a partial write.
+ * optionally flushed to disk via `fsync`, then renamed to `file`. The rename step is
+ * atomic at the filesystem level, so a concurrent reader observes either the previous
+ * file content or the complete new content, never a partially written file.
  *
- * Concurrent writers to the same `file` MUST be serialized externally (for example via
- * `AsyncLock.runExclusive`); this primitive does not queue or deduplicate calls.
+ * Temporary file name encodes `pid`, `threadId` (0 in the main thread, non-zero per
+ * worker thread), and a per-thread monotonic counter. This guarantees uniqueness across
+ * processes and worker threads of the same process.
  *
- * On error, the temporary file is removed best-effort and the failure is funnelled
- * through {@link handleFileException} using `fileType` and `logPrefix`.
+ * Concurrent writers to the same `file` must be serialized externally (typically via
+ * `AsyncLock.runExclusive`); this primitive does not queue, deduplicate, or order
+ * concurrent calls. The `AsyncLock` instances in the project are per-thread, so when a
+ * given destination can be written from multiple threads the caller must additionally
+ * partition paths or coordinate across threads.
+ *
+ * Durability: when `flush` is `true` (default) the temporary file is fsync'd before
+ * `rename`. The parent directory entry is not separately fsync'd, so a kernel-level
+ * crash between `rename` and the directory inode flush may, on some filesystems,
+ * revert the rename. This is acceptable for the simulator's persistence needs (config
+ * files, simulator state, performance records, certificates) but is not full POSIX D
+ * durability.
+ *
+ * On `SIGKILL`, OOM kill, or power loss between `writeFile` and `rename`, the
+ * temporary `<file>.<pid>.<threadId>.<n>.tmp` artifact may remain on disk; it is inert
+ * and safe to delete manually. Normal failure paths clean it up best-effort.
+ *
+ * On error, the temporary file is removed best-effort and the failure is forwarded to
+ * {@link handleFileException} using `fileType`, `logPrefix`, and `options.errorParams`.
  * @param file - Destination file path.
  * @param data - Content to write.
  * @param fileType - File type used for error logging.
  * @param logPrefix - Caller-supplied log prefix used for error logging.
  * @param options - Atomic write options.
- * @param errorParams - Error handling parameters forwarded to {@link handleFileException}.
- * @returns A promise that resolves once the rename has completed, or rejects when
- *   `errorParams.throwError !== false` and the write failed.
+ * @returns A promise that resolves once the rename has completed.
+ * @throws {Error} When the write fails and `options.errorParams.throwError !== false`
+ *   (the default). The thrown error is the underlying `NodeJS.ErrnoException`
+ *   re-thrown by {@link handleFileException} after logging.
  */
 export const atomicWriteFile = async (
   file: string,
   data: NodeJS.ArrayBufferView | string,
   fileType: FileType,
   logPrefix: string,
-  options?: AtomicWriteOptions,
-  errorParams?: HandleErrorParams<EmptyObject>
+  options?: AtomicWriteOptions
 ): Promise<void> => {
-  const { encoding, ensureDir, flush, mode } = {
-    encoding: 'utf8' as BufferEncoding,
-    ensureDir: true,
-    flush: true,
-    mode: DEFAULT_FILE_MODE,
-    ...options,
-  }
+  const {
+    encoding = 'utf8',
+    ensureDir = true,
+    errorParams,
+    flush = true,
+    mode = DEFAULT_FILE_MODE,
+  } = options ?? {}
   const tmpFile = buildTmpPath(file)
   try {
     if (ensureDir) {
@@ -156,23 +162,24 @@ export const atomicWriteFile = async (
  * @param fileType - File type used for error logging.
  * @param logPrefix - Caller-supplied log prefix used for error logging.
  * @param options - Atomic write options.
- * @param errorParams - Error handling parameters forwarded to {@link handleFileException}.
+ * @throws {Error} When the write fails and `options.errorParams.throwError !== false`
+ *   (the default). The thrown error is the underlying `NodeJS.ErrnoException`
+ *   re-thrown by {@link handleFileException} after logging.
  */
 export const atomicWriteFileSync = (
   file: string,
   data: NodeJS.ArrayBufferView | string,
   fileType: FileType,
   logPrefix: string,
-  options?: AtomicWriteOptions,
-  errorParams?: HandleErrorParams<EmptyObject>
+  options?: AtomicWriteOptions
 ): void => {
-  const { encoding, ensureDir, flush, mode } = {
-    encoding: 'utf8' as BufferEncoding,
-    ensureDir: true,
-    flush: true,
-    mode: DEFAULT_FILE_MODE,
-    ...options,
-  }
+  const {
+    encoding = 'utf8',
+    ensureDir = true,
+    errorParams,
+    flush = true,
+    mode = DEFAULT_FILE_MODE,
+  } = options ?? {}
   const tmpFile = buildTmpPath(file)
   try {
     if (ensureDir) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,7 +19,12 @@ export {
   handleUncaughtException,
   handleUnhandledRejection,
 } from './ErrorUtils.js'
-export { watchJsonFile } from './FileUtils.js'
+export {
+  atomicWriteFile,
+  atomicWriteFileSync,
+  type AtomicWriteOptions,
+  watchJsonFile,
+} from './FileUtils.js'
 export { logger } from './Logger.js'
 export {
   buildAddedMessage,

--- a/tests/charging-station/ocpp/2.0/OCPP20CertificateManager.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20CertificateManager.test.ts
@@ -57,7 +57,8 @@ await describe('I02-I04 - ISO15118 Certificate Management', async () => {
       const result = await manager.storeCertificate(
         TEST_CHARGING_STATION_HASH_ID,
         TEST_CERT_TYPE,
-        VALID_PEM_CERTIFICATE_EXTENDED
+        VALID_PEM_CERTIFICATE_EXTENDED,
+        'test |'
       )
 
       assert.notStrictEqual(result, undefined)
@@ -74,7 +75,8 @@ await describe('I02-I04 - ISO15118 Certificate Management', async () => {
       const result = await manager.storeCertificate(
         TEST_CHARGING_STATION_HASH_ID,
         TEST_CERT_TYPE,
-        INVALID_PEM_CERTIFICATE_MISSING_MARKERS
+        INVALID_PEM_CERTIFICATE_MISSING_MARKERS,
+        'test |'
       )
 
       assert.notStrictEqual(result, undefined)
@@ -89,7 +91,8 @@ await describe('I02-I04 - ISO15118 Certificate Management', async () => {
       const result = await manager.storeCertificate(
         TEST_CHARGING_STATION_HASH_ID,
         TEST_CERT_TYPE,
-        EMPTY_PEM_CERTIFICATE
+        EMPTY_PEM_CERTIFICATE,
+        'test |'
       )
 
       assert.notStrictEqual(result, undefined)
@@ -101,7 +104,8 @@ await describe('I02-I04 - ISO15118 Certificate Management', async () => {
       const result = await manager.storeCertificate(
         TEST_CHARGING_STATION_HASH_ID,
         InstallCertificateUseEnumType.V2GRootCertificate,
-        VALID_PEM_CERTIFICATE_EXTENDED
+        VALID_PEM_CERTIFICATE_EXTENDED,
+        'test |'
       )
 
       assert.notStrictEqual(result, undefined)
@@ -411,12 +415,14 @@ await describe('I02-I04 - ISO15118 Certificate Management', async () => {
         manager.storeCertificate(
           TEST_CHARGING_STATION_HASH_ID,
           InstallCertificateUseEnumType.CSMSRootCertificate,
-          VALID_PEM_CERTIFICATE_EXTENDED
+          VALID_PEM_CERTIFICATE_EXTENDED,
+          'test |'
         ),
         manager.storeCertificate(
           TEST_CHARGING_STATION_HASH_ID,
           InstallCertificateUseEnumType.V2GRootCertificate,
-          VALID_PEM_CERTIFICATE_EXTENDED
+          VALID_PEM_CERTIFICATE_EXTENDED,
+          'test |'
         ),
         manager.getInstalledCertificates(TEST_CHARGING_STATION_HASH_ID),
       ])
@@ -433,7 +439,8 @@ await describe('I02-I04 - ISO15118 Certificate Management', async () => {
       const result = await manager.storeCertificate(
         TEST_CHARGING_STATION_HASH_ID,
         TEST_CERT_TYPE,
-        longChain
+        longChain,
+        'test |'
       )
 
       assert.notStrictEqual(result, undefined)

--- a/tests/performance/storage/JsonFileStorage.test.ts
+++ b/tests/performance/storage/JsonFileStorage.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @file Tests for JsonFileStorage
+ * @description Unit tests for the JSON file performance storage backend.
+ */
+import assert from 'node:assert/strict'
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, it } from 'node:test'
+import { pathToFileURL } from 'node:url'
+
+import { JsonFileStorage } from '../../../src/performance/storage/JsonFileStorage.js'
+import { logger } from '../../../src/utils/index.js'
+import { createLoggerMocks, standardCleanup } from '../../helpers/TestLifecycleHelpers.js'
+import { buildTestStatistics } from './StorageTestHelpers.js'
+
+const LOG_PREFIX = 'JsonFileStorage-test |'
+
+const buildStorageUri = (filePath: string): string => pathToFileURL(filePath).toString()
+
+await describe('JsonFileStorage', async () => {
+  let tmpDir: string
+  let dbPath: string
+  let storage: JsonFileStorage
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'json-file-storage-test-'))
+    dbPath = join(tmpDir, 'perf.json')
+    storage = new JsonFileStorage(buildStorageUri(dbPath), LOG_PREFIX)
+    storage.open()
+  })
+
+  afterEach(() => {
+    storage.close()
+    standardCleanup()
+    rmSync(tmpDir, { force: true, recursive: true })
+  })
+
+  await it('should write performance statistics atomically and leave no temp artifact behind', async () => {
+    const stats = buildTestStatistics('cs-1')
+
+    await storage.storePerformanceStatistics(stats)
+
+    assert.strictEqual(existsSync(dbPath), true)
+    const written = JSON.parse(readFileSync(dbPath, 'utf8')) as { id: string }[]
+    assert.strictEqual(Array.isArray(written), true)
+    assert.strictEqual(written.length, 1)
+    assert.strictEqual(written[0].id, 'cs-1')
+    assert.deepStrictEqual(
+      readdirSync(tmpDir).filter(name => name.endsWith('.tmp')),
+      []
+    )
+  })
+
+  await it('should overwrite the records file with the latest snapshot on each store call', async () => {
+    await storage.storePerformanceStatistics(buildTestStatistics('cs-1'))
+    await storage.storePerformanceStatistics(buildTestStatistics('cs-2'))
+
+    const written = JSON.parse(readFileSync(dbPath, 'utf8')) as { id: string }[]
+    const ids = written.map(entry => entry.id).sort()
+    assert.deepStrictEqual(ids, ['cs-1', 'cs-2'])
+  })
+
+  await it('should serialize the statisticsData Map via MapStringifyFormat.object', async () => {
+    const stats = buildTestStatistics('cs-1', 'station-with-map')
+
+    await storage.storePerformanceStatistics(stats)
+
+    const written = JSON.parse(readFileSync(dbPath, 'utf8')) as {
+      statisticsData: Record<string, { requestCount: number }>
+    }[]
+    assert.ok(typeof written[0].statisticsData === 'object', 'statisticsData must be an object')
+    assert.strictEqual(written[0].statisticsData.Heartbeat.requestCount, 100)
+  })
+
+  await it('should log a warning and not throw when the storage directory is removed at runtime', async t => {
+    const { warnMock } = createLoggerMocks(t, logger)
+    rmSync(tmpDir, { force: true, recursive: true })
+
+    await assert.doesNotReject(storage.storePerformanceStatistics(buildTestStatistics('cs-1')))
+
+    assert.strictEqual(existsSync(dbPath), false)
+    assert.strictEqual(warnMock.mock.calls.length, 1)
+  })
+
+  await it('should reflect every parallel writer in the final snapshot when serialized via AsyncLock', async () => {
+    const stations = Array.from({ length: 4 }, (_, i) => buildTestStatistics(`cs-${i.toString()}`))
+
+    await Promise.all(stations.map(async stats => storage.storePerformanceStatistics(stats)))
+
+    const written = JSON.parse(readFileSync(dbPath, 'utf8')) as { id: string }[]
+    const ids = written.map(entry => entry.id).sort()
+    assert.deepStrictEqual(ids, ['cs-0', 'cs-1', 'cs-2', 'cs-3'])
+    assert.deepStrictEqual(
+      readdirSync(tmpDir).filter(name => name.endsWith('.tmp')),
+      []
+    )
+  })
+})

--- a/tests/utils/FileUtils.test.ts
+++ b/tests/utils/FileUtils.test.ts
@@ -1,95 +1,276 @@
 /**
  * @file Tests for FileUtils
- * @description Unit tests for file watching utility functions
+ * @description Unit tests for file watching and atomic file write utility functions.
  */
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, type WatchListener, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  type WatchListener,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, it } from 'node:test'
+import { afterEach, beforeEach, describe, it } from 'node:test'
 
 import { FileType } from '../../src/types/index.js'
-import { watchJsonFile } from '../../src/utils/FileUtils.js'
+import { atomicWriteFile, atomicWriteFileSync, watchJsonFile } from '../../src/utils/FileUtils.js'
 import { logger } from '../../src/utils/index.js'
 import { createLoggerMocks, standardCleanup } from '../helpers/TestLifecycleHelpers.js'
+
+const LOG_PREFIX = 'FileUtils-test |'
 
 const noop: WatchListener<string> = () => {
   /* intentionally empty */
 }
 
+const listTmpArtifacts = (dir: string, baseName: string): string[] =>
+  readdirSync(dir).filter(name => name.startsWith(`${baseName}.`) && name.endsWith('.tmp'))
+
 await describe('FileUtils', async () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'fileutils-test-'))
+  })
+
   afterEach(() => {
     standardCleanup()
+    rmSync(tmpDir, { force: true, recursive: true })
   })
 
-  await it('should return undefined and log info for empty file path', t => {
-    const infoMock = t.mock.method(logger, 'info')
+  await describe('watchJsonFile', async () => {
+    await it('should return undefined and log info for empty file path', t => {
+      const infoMock = t.mock.method(logger, 'info')
 
-    const result = watchJsonFile('', FileType.Authorization, 'test prefix |', noop)
+      const result = watchJsonFile('', FileType.Authorization, 'test prefix |', noop)
 
-    assert.strictEqual(result, undefined)
-    assert.strictEqual(infoMock.mock.calls.length, 1)
-  })
+      assert.strictEqual(result, undefined)
+      assert.strictEqual(infoMock.mock.calls.length, 1)
+    })
 
-  await it('should include file type and log prefix in info log message for empty path', t => {
-    const infoMock = t.mock.method(logger, 'info')
+    await it('should include file type and log prefix in info log message for empty path', t => {
+      const infoMock = t.mock.method(logger, 'info')
 
-    watchJsonFile('', FileType.ChargingStationConfiguration, 'CS-001 |', noop)
+      watchJsonFile('', FileType.ChargingStationConfiguration, 'CS-001 |', noop)
 
-    assert.strictEqual(infoMock.mock.calls.length, 1)
-    const logMessage = infoMock.mock.calls[0].arguments[0] as unknown as string
-    assert.ok(logMessage.includes(FileType.ChargingStationConfiguration))
-    assert.ok(logMessage.includes('CS-001 |'))
-  })
+      assert.strictEqual(infoMock.mock.calls.length, 1)
+      const logMessage = infoMock.mock.calls[0].arguments[0] as unknown as string
+      assert.ok(logMessage.includes(FileType.ChargingStationConfiguration))
+      assert.ok(logMessage.includes('CS-001 |'))
+    })
 
-  await it('should handle watch error and return undefined for nonexistent file', t => {
-    const { warnMock } = createLoggerMocks(t, logger)
+    await it('should handle watch error and return undefined for nonexistent file', t => {
+      const { warnMock } = createLoggerMocks(t, logger)
 
-    const result = watchJsonFile(
-      '/nonexistent/path/to/file.json',
-      FileType.Authorization,
-      'test prefix |',
-      noop
-    )
+      const result = watchJsonFile(
+        '/nonexistent/path/to/file.json',
+        FileType.Authorization,
+        'test prefix |',
+        noop
+      )
 
-    assert.strictEqual(result, undefined)
-    assert.strictEqual(warnMock.mock.calls.length, 1)
-  })
+      assert.strictEqual(result, undefined)
+      assert.strictEqual(warnMock.mock.calls.length, 1)
+    })
 
-  await it('should return FSWatcher for valid file path', () => {
-    const tmpDir = mkdtempSync(join(tmpdir(), 'fileutils-test-'))
-    const tmpFile = join(tmpDir, 'test.json')
-    writeFileSync(tmpFile, '{}')
+    await it('should return FSWatcher for valid file path', () => {
+      const target = join(tmpDir, 'test.json')
+      writeFileSync(target, '{}')
 
-    try {
-      const result = watchJsonFile(tmpFile, FileType.Authorization, 'test |', noop)
+      const result = watchJsonFile(target, FileType.Authorization, 'test |', noop)
 
       assert.notStrictEqual(result, undefined)
       result?.close()
-    } finally {
-      rmSync(tmpDir, { recursive: true })
-    }
-  })
+    })
 
-  await it('should call watch with file and listener arguments', () => {
-    const tmpDir = mkdtempSync(join(tmpdir(), 'fileutils-test-'))
-    const tmpFile = join(tmpDir, 'test.json')
-    writeFileSync(tmpFile, '{}')
+    await it('should call watch with file and listener arguments', () => {
+      const target = join(tmpDir, 'test.json')
+      writeFileSync(target, '{}')
 
-    try {
       let receivedEvent = false
       const listener: WatchListener<string> = () => {
         receivedEvent = true
       }
 
-      const result = watchJsonFile(tmpFile, FileType.Authorization, 'test |', listener)
+      const result = watchJsonFile(target, FileType.Authorization, 'test |', listener)
 
       assert.notStrictEqual(result, undefined)
       assert.strictEqual(typeof result?.close, 'function')
       result?.close()
       assert.strictEqual(receivedEvent, false)
-    } finally {
-      rmSync(tmpDir, { recursive: true })
-    }
+    })
+  })
+
+  await describe('atomicWriteFileSync', async () => {
+    await it('should write string content atomically and leave no temp file behind', () => {
+      const target = join(tmpDir, 'output.json')
+
+      atomicWriteFileSync(target, '{"ok":true}', FileType.SimulatorState, LOG_PREFIX)
+
+      assert.strictEqual(readFileSync(target, 'utf8'), '{"ok":true}')
+      assert.deepStrictEqual(listTmpArtifacts(tmpDir, 'output.json'), [])
+    })
+
+    await it('should write Uint8Array content atomically', () => {
+      const target = join(tmpDir, 'binary.bin')
+      const data = new Uint8Array([0x00, 0x01, 0x02, 0x03])
+
+      atomicWriteFileSync(target, data, FileType.PerformanceRecords, LOG_PREFIX)
+
+      assert.deepStrictEqual(new Uint8Array(readFileSync(target)), data)
+    })
+
+    await it('should overwrite an existing file atomically', () => {
+      const target = join(tmpDir, 'existing.json')
+      writeFileSync(target, 'old content', 'utf8')
+
+      atomicWriteFileSync(target, 'new content', FileType.SimulatorState, LOG_PREFIX)
+
+      assert.strictEqual(readFileSync(target, 'utf8'), 'new content')
+    })
+
+    await it('should create missing parent directories when ensureDir is enabled (default)', () => {
+      const target = join(tmpDir, 'nested', 'deep', 'output.json')
+
+      atomicWriteFileSync(target, '{}', FileType.SimulatorState, LOG_PREFIX)
+
+      assert.strictEqual(existsSync(target), true)
+      assert.strictEqual(readFileSync(target, 'utf8'), '{}')
+    })
+
+    await it('should fail and clean up the temp file when ensureDir is disabled and the parent does not exist', t => {
+      const { errorMock } = createLoggerMocks(t, logger)
+      const parent = join(tmpDir, 'missing-parent')
+      const target = join(parent, 'output.json')
+
+      assert.throws(() => {
+        atomicWriteFileSync(target, '{}', FileType.SimulatorState, LOG_PREFIX, {
+          ensureDir: false,
+        })
+      })
+
+      assert.strictEqual(existsSync(target), false)
+      assert.strictEqual(existsSync(parent), false)
+      assert.strictEqual(errorMock.mock.calls.length, 1)
+    })
+
+    await it('should not throw when errorParams.throwError is false', t => {
+      const { errorMock, warnMock } = createLoggerMocks(t, logger)
+      const target = join(tmpDir, 'missing-parent', 'output.json')
+
+      assert.doesNotThrow(() => {
+        atomicWriteFileSync(
+          target,
+          '{}',
+          FileType.SimulatorState,
+          LOG_PREFIX,
+          { ensureDir: false },
+          { throwError: false }
+        )
+      })
+
+      assert.strictEqual(existsSync(target), false)
+      assert.strictEqual(warnMock.mock.calls.length, 1)
+      assert.strictEqual(errorMock.mock.calls.length, 0)
+    })
+
+    await it('should support a custom encoding', () => {
+      const target = join(tmpDir, 'latin1.txt')
+
+      atomicWriteFileSync(target, 'café', FileType.Configuration, LOG_PREFIX, {
+        encoding: 'latin1',
+      })
+
+      assert.strictEqual(readFileSync(target, 'latin1'), 'café')
+    })
+  })
+
+  await describe('atomicWriteFile', async () => {
+    await it('should write string content atomically and leave no temp file behind', async () => {
+      const target = join(tmpDir, 'output.json')
+
+      await atomicWriteFile(target, '{"ok":true}', FileType.SimulatorState, LOG_PREFIX)
+
+      assert.strictEqual(readFileSync(target, 'utf8'), '{"ok":true}')
+      assert.deepStrictEqual(listTmpArtifacts(tmpDir, 'output.json'), [])
+    })
+
+    await it('should overwrite an existing file atomically', async () => {
+      const target = join(tmpDir, 'existing.json')
+      writeFileSync(target, 'old content', 'utf8')
+
+      await atomicWriteFile(target, 'new content', FileType.SimulatorState, LOG_PREFIX)
+
+      assert.strictEqual(readFileSync(target, 'utf8'), 'new content')
+    })
+
+    await it('should create missing parent directories when ensureDir is enabled (default)', async () => {
+      const target = join(tmpDir, 'nested', 'deep', 'output.json')
+
+      await atomicWriteFile(target, '{}', FileType.SimulatorState, LOG_PREFIX)
+
+      assert.strictEqual(existsSync(target), true)
+      assert.strictEqual(readFileSync(target, 'utf8'), '{}')
+    })
+
+    await it('should fail and clean up the temp file when ensureDir is disabled and the parent does not exist', async t => {
+      const { errorMock } = createLoggerMocks(t, logger)
+      const parent = join(tmpDir, 'missing-parent')
+      const target = join(parent, 'output.json')
+
+      await assert.rejects(
+        atomicWriteFile(target, '{}', FileType.SimulatorState, LOG_PREFIX, {
+          ensureDir: false,
+        })
+      )
+
+      assert.strictEqual(existsSync(target), false)
+      assert.strictEqual(existsSync(parent), false)
+      assert.strictEqual(errorMock.mock.calls.length, 1)
+    })
+
+    await it('should not throw when errorParams.throwError is false', async t => {
+      const { errorMock, warnMock } = createLoggerMocks(t, logger)
+      const target = join(tmpDir, 'missing-parent', 'output.json')
+
+      await assert.doesNotReject(
+        atomicWriteFile(
+          target,
+          '{}',
+          FileType.SimulatorState,
+          LOG_PREFIX,
+          { ensureDir: false },
+          { throwError: false }
+        )
+      )
+
+      assert.strictEqual(existsSync(target), false)
+      assert.strictEqual(warnMock.mock.calls.length, 1)
+      assert.strictEqual(errorMock.mock.calls.length, 0)
+    })
+
+    await it('should support concurrent writes to distinct paths without temp-name collisions', async () => {
+      const targets = Array.from({ length: 8 }, (_, i) =>
+        join(tmpDir, `concurrent-${i.toString()}.txt`)
+      )
+
+      await Promise.all(
+        targets.map(async (target, i) =>
+          atomicWriteFile(target, `payload-${i.toString()}`, FileType.SimulatorState, LOG_PREFIX)
+        )
+      )
+
+      for (const [i, target] of targets.entries()) {
+        assert.strictEqual(readFileSync(target, 'utf8'), `payload-${i.toString()}`)
+      }
+      assert.deepStrictEqual(
+        readdirSync(tmpDir).filter(name => name.endsWith('.tmp')),
+        []
+      )
+    })
   })
 })

--- a/tests/utils/FileUtils.test.ts
+++ b/tests/utils/FileUtils.test.ts
@@ -5,10 +5,12 @@
 import assert from 'node:assert/strict'
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
   rmSync,
+  statSync,
   type WatchListener,
   writeFileSync,
 } from 'node:fs'
@@ -147,11 +149,14 @@ await describe('FileUtils', async () => {
       const parent = join(tmpDir, 'missing-parent')
       const target = join(parent, 'output.json')
 
-      assert.throws(() => {
-        atomicWriteFileSync(target, '{}', FileType.SimulatorState, LOG_PREFIX, {
-          ensureDir: false,
-        })
-      })
+      assert.throws(
+        () => {
+          atomicWriteFileSync(target, '{}', FileType.SimulatorState, LOG_PREFIX, {
+            ensureDir: false,
+          })
+        },
+        { code: 'ENOENT' }
+      )
 
       assert.strictEqual(existsSync(target), false)
       assert.strictEqual(existsSync(parent), false)
@@ -163,14 +168,10 @@ await describe('FileUtils', async () => {
       const target = join(tmpDir, 'missing-parent', 'output.json')
 
       assert.doesNotThrow(() => {
-        atomicWriteFileSync(
-          target,
-          '{}',
-          FileType.SimulatorState,
-          LOG_PREFIX,
-          { ensureDir: false },
-          { throwError: false }
-        )
+        atomicWriteFileSync(target, '{}', FileType.SimulatorState, LOG_PREFIX, {
+          ensureDir: false,
+          errorParams: { throwError: false },
+        })
       })
 
       assert.strictEqual(existsSync(target), false)
@@ -225,7 +226,8 @@ await describe('FileUtils', async () => {
       await assert.rejects(
         atomicWriteFile(target, '{}', FileType.SimulatorState, LOG_PREFIX, {
           ensureDir: false,
-        })
+        }),
+        { code: 'ENOENT' }
       )
 
       assert.strictEqual(existsSync(target), false)
@@ -238,14 +240,10 @@ await describe('FileUtils', async () => {
       const target = join(tmpDir, 'missing-parent', 'output.json')
 
       await assert.doesNotReject(
-        atomicWriteFile(
-          target,
-          '{}',
-          FileType.SimulatorState,
-          LOG_PREFIX,
-          { ensureDir: false },
-          { throwError: false }
-        )
+        atomicWriteFile(target, '{}', FileType.SimulatorState, LOG_PREFIX, {
+          ensureDir: false,
+          errorParams: { throwError: false },
+        })
       )
 
       assert.strictEqual(existsSync(target), false)
@@ -270,6 +268,25 @@ await describe('FileUtils', async () => {
       assert.deepStrictEqual(
         readdirSync(tmpDir).filter(name => name.endsWith('.tmp')),
         []
+      )
+    })
+
+    await it('should leave the destination intact and clean up the temp file when rename fails', async () => {
+      const target = join(tmpDir, 'preserved-dir')
+      mkdirSync(target)
+      mkdirSync(join(target, 'child'))
+
+      await assert.rejects(
+        atomicWriteFile(target, 'NEW', FileType.SimulatorState, LOG_PREFIX),
+        (err: NodeJS.ErrnoException) =>
+          err.code === 'EISDIR' || err.code === 'ENOTEMPTY' || err.code === 'EPERM'
+      )
+
+      assert.ok(statSync(target).isDirectory(), 'target directory must remain intact')
+      assert.deepStrictEqual(
+        readdirSync(tmpDir).filter(name => name.endsWith('.tmp')),
+        [],
+        'temp file should be cleaned up after rename failure'
       )
     })
   })


### PR DESCRIPTION
<!--
  Thanks for contributing to EVSE simulator project.
  Please be sure to read our [contributing guidelines](https://github.com/sap/e-mobility-charging-stations-simulator/blob/main/CONTRIBUTING.md).
-->

## PR Checklist

- [x] Please add a description of your changes.
- [x] Please ensure title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] We need your changes to come with unit tests in order to keep this project in quality and easy to maintain.
- [x] If your changes contain any new feature please be sure to document it.
- [ ] Please add a link to the open issue or task that this pull request will resolve.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

---

### Summary

Add a unified atomic file write primitive — `atomicWriteFile` / `atomicWriteFileSync` — to `src/utils/FileUtils.ts` and route every file-replace call site in `src/` through it. Concurrent readers and crash-mid-write scenarios can no longer expose a partially written file at any of the migrated paths.

### Migrated call sites

| Location | Before | After |
|---|---|---|
| `BootstrapStateUtils.writeStateFile` | inline `writeFileSync` + `renameSync` (no fsync) | `atomicWriteFileSync` (fsync by default) |
| `ChargingStation.saveConfiguration` | `writeFileSync` direct to target | `atomicWriteFileSync` |
| `JsonFileStorage.storePerformanceStatistics` | persistent `openSync('w')` fd + `writeSync(fd, …, 0)` (truncated to 0 bytes on every sample) | atomic write through `AsyncLock` with `flush: false` (telemetry) |
| `OCPP20CertificateManager.storeCertificate` | `writeFile(filePath, pemData, 'utf8')` | `atomicWriteFile` with `mode: 0o600` |

`Logger.ts` (winston `DailyRotateFile`, append-only) and the OCPP 1.6 `GetDiagnostics` `createWriteStream` (single-producer / single-consumer streaming archive) are intentionally out of scope — file-replace atomicity does not apply.

### Primitive design

- Two named arrow function exports (`atomicWriteFile` async, `atomicWriteFileSync` sync) following the `src/utils/` house style.
- Algorithm: `mkdir(dirname, recursive)` (opt-out via `ensureDir: false`) → `writeFile` to a unique temp path `${file}.${pid}.${threadId}.${counter}.tmp` in the **same directory** (rules out `EXDEV`) with `{ encoding, flush, mode }` → atomic `rename(tmp, file)` → on error, best-effort `rm(tmp, { force: true })` and forward through `handleFileException`.
- Single trailing `AtomicWriteOptions` bag groups `encoding`, `ensureDir`, `flush`, `mode`, and `errorParams` (forwarded to `handleFileException`).
- Tmp filename includes `pid`, `threadId` (from `node:worker_threads`), and a per-thread monotonic counter so uniqueness holds across worker threads of the same process.
- Durability: `flush: true` (default) calls `fsync` on the temp file before `rename`, using the Node 22+ `{ flush: true }` option of `writeFile` / `writeFileSync`. The parent directory inode is not separately fsync'd; this is acceptable for the simulator's persistence needs and explicitly documented.
- No internal queue, no signal-exit handler, no `realpath`/`chown`/mode-preservation. Concurrent writers to the same path must be serialized externally; the four migrated paths each satisfy this either through `AsyncLock.runExclusive` or through path partitioning (certificate paths are keyed by serial number).

### Tests

- `tests/utils/FileUtils.test.ts` — 13 cases covering happy-path string and `Uint8Array` writes, atomic overwrite, `ensureDir` toggling, error matcher tightening (`{ code: 'ENOENT' }`), `errorParams.throwError === false` swallowing, custom encoding, concurrent writes to distinct paths, and a deterministic rename-failure case asserting the destination remains intact and the temp file is cleaned up.
- `tests/performance/storage/JsonFileStorage.test.ts` (new) — 5 focused cases covering happy path, snapshot overwrite, Map serialization via `MapStringifyFormat.object`, runtime storage directory removal (logs warn, does not throw), and parallel writers converging via `AsyncLock`.
- `tests/charging-station/ocpp/2.0/OCPP20CertificateManager.test.ts` — migrated to the new `storeCertificate(stationHashId, certType, pemData, logPrefix)` signature.

### Notable behavior changes

1. `BootstrapStateUtils.writeStateFile` now fsyncs the temp file before rename — strict durability improvement; a power loss between rename and disk flush can no longer drop the persisted state.
2. `JsonFileStorage` drops the long-lived `openSync('w')` file descriptor. Each `storePerformanceStatistics` call now performs a fresh write+rename. This **silently fixes a pre-existing latent bug**: the previous `writeSync(fd, …, 0)` rewrote from offset 0 every sample but did not truncate, leaving trailing bytes on disk whenever a sample produced a shorter JSON than the previous one. The new design overwrites the file completely via rename.
3. `JsonFileStorage` writes are tagged `flush: false` since performance records are observability data; this trades durability across crashes (acceptable for telemetry) for not blocking the event loop on per-sample fsync.
4. `OCPP20CertificateManager.storeCertificate` now takes a required `logPrefix` parameter, applies `mode: 0o600` to PEM material, and delegates parent directory creation to the primitive (the manual `mkdir`+`pathExists` block is removed).
5. `ChargingStation.saveConfiguration`'s outer `.catch` no longer funnels the same error through `handleFileException` a second time; filesystem failures are absorbed at debug level (already logged at error by the primitive), and unexpected non-fs failures inside the lock body are surfaced at error level.

### Quality gates

```
pnpm typecheck   # OK
pnpm lint        # OK
pnpm format      # OK
pnpm test        # 2411 pass / 0 fail / 6 pre-existing skipped
pnpm build       # OK
```

### Out of scope

- OCPP 1.6 `GetDiagnostics` `createWriteStream` for the `_logs.tar.gz` archive: streaming, single-producer/single-consumer (write → FTP upload), file-replace atomicity does not apply.
- `winston-daily-rotate-file` log writes: append-only, third-party rotation.
- UI packages (`ui/common`, `ui/cli`, `ui/web`) and `scripts/`: no Node-side file-replace writes that warrant atomicity (the audit found only a static `writeFileSync` in `ui/cli` for skill installation and `localStorage` writes in the browser, which the platform makes atomic per-key).
- A coalescing/debouncing wrapper around `JsonFileStorage` writes (`steno`-style). Tracked as follow-up if a benchmark shows it matters.