### PR TITLE
test(ui-web): mock useTheme/useSkin in SimulatorBar.test.ts to fix vitest 4.x teardown RPC leak

### DIFF
--- a/ui/web/tests/unit/skins/modern/SimulatorBar.test.ts
+++ b/ui/web/tests/unit/skins/modern/SimulatorBar.test.ts
@@ -3,11 +3,48 @@
  * @description Server switcher, simulator state display, action buttons.
  */
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { SKIN_IDS, THEME_IDS } from 'ui-common'
+import { describe, expect, it, vi } from 'vitest'
 
 import SimulatorBar from '@/skins/modern/components/SimulatorBar.vue'
 
 import { createUIServerConfig } from '../../constants.js'
+
+// Mock useTheme/useSkin to avoid post-teardown console.warn from
+// validateTokenContract() (scheduled via requestAnimationFrame) and from
+// the floating switchSkin() Promise. Vitest 4.x rejects pending RPC at
+// teardown ("Closing rpc while \"onUserConsoleLog\" was pending"), and
+// jsdom does not resolve --color-* CSS variables so the contract check
+// would log ~24 warnings per <select> change.
+const switchThemeMock = vi.fn()
+const switchSkinMock = vi.fn().mockResolvedValue(true)
+
+vi.mock('@/shared/composables/useTheme.js', async importOriginal => {
+  const { readonly, ref } = await import('vue')
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    useTheme: () => ({
+      activeThemeId: readonly(ref(THEME_IDS[0])),
+      availableThemes: THEME_IDS,
+      lastError: readonly(ref(null)),
+      switchTheme: switchThemeMock,
+    }),
+  }
+})
+
+vi.mock('@/shared/composables/useSkin.js', async importOriginal => {
+  const { readonly, ref } = await import('vue')
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    useSkin: () => ({
+      activeSkinId: readonly(ref<(typeof SKIN_IDS)[number]>('modern')),
+      availableSkins: SKIN_IDS.map(id => ({ id, label: id })),
+      isSwitching: readonly(ref(false)),
+      lastError: readonly(ref(null)),
+      switchSkin: switchSkinMock,
+    }),
+  }
+})
 
 const baseServer = createUIServerConfig({ name: 'Alpha' })
 const altServer = createUIServerConfig({ host: 'beta', name: 'Beta' })
@@ -122,14 +159,18 @@ describe('SimulatorBar', () => {
     const wrapper = mountBar()
     const themeSelect = wrapper.find('.modern-bar__select[aria-label="Theme"]')
     expect(themeSelect.exists()).toBe(true)
+    await themeSelect.setValue('dracula')
     await themeSelect.trigger('change')
+    expect(switchThemeMock).toHaveBeenCalledWith('dracula')
   })
 
   it('should call switchSkin when skin select changes', async () => {
     const wrapper = mountBar()
     const skinSelect = wrapper.find('.modern-bar__select[aria-label="Skin"]')
     expect(skinSelect.exists()).toBe(true)
+    await skinSelect.setValue('classic')
     await skinSelect.trigger('change')
+    expect(switchSkinMock).toHaveBeenCalledWith('classic')
   })
 
   it('should emit switch-server with selectedIndex when server select changes via trigger', async () => {

--- a/ui/web/tests/unit/skins/modern/SimulatorBar.test.ts
+++ b/ui/web/tests/unit/skins/modern/SimulatorBar.test.ts
@@ -4,7 +4,7 @@
  */
 import { mount } from '@vue/test-utils'
 import { SKIN_IDS, THEME_IDS } from 'ui-common'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import SimulatorBar from '@/skins/modern/components/SimulatorBar.vue'
 
@@ -65,6 +65,10 @@ function mountBar (props: Record<string, unknown> = {}) {
 }
 
 describe('SimulatorBar', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('should show Disconnected pill when simulatorState is undefined', () => {
     const wrapper = mountBar()
     expect(wrapper.text()).toContain('Disconnected')

--- a/ui/web/tests/unit/skins/modern/SimulatorBar.test.ts
+++ b/ui/web/tests/unit/skins/modern/SimulatorBar.test.ts
@@ -159,18 +159,22 @@ describe('SimulatorBar', () => {
     const wrapper = mountBar()
     const themeSelect = wrapper.find('.modern-bar__select[aria-label="Theme"]')
     expect(themeSelect.exists()).toBe(true)
-    await themeSelect.setValue('dracula')
+    // Pick a theme that differs from the mocked activeThemeId (THEME_IDS[0]).
+    const targetTheme = THEME_IDS[1]
+    await themeSelect.setValue(targetTheme)
     await themeSelect.trigger('change')
-    expect(switchThemeMock).toHaveBeenCalledWith('dracula')
+    expect(switchThemeMock).toHaveBeenCalledWith(targetTheme)
   })
 
   it('should call switchSkin when skin select changes', async () => {
     const wrapper = mountBar()
     const skinSelect = wrapper.find('.modern-bar__select[aria-label="Skin"]')
     expect(skinSelect.exists()).toBe(true)
-    await skinSelect.setValue('classic')
+    // Pick a skin that differs from the mocked activeSkinId ('modern').
+    const targetSkin = SKIN_IDS.find(id => id !== 'modern') ?? SKIN_IDS[0]
+    await skinSelect.setValue(targetSkin)
     await skinSelect.trigger('change')
-    expect(switchSkinMock).toHaveBeenCalledWith('classic')
+    expect(switchSkinMock).toHaveBeenCalledWith(targetSkin)
   })
 
   it('should emit switch-server with selectedIndex when server select changes via trigger', async () => {

--- a/ui/web/tests/unit/skins/modern/SimulatorBar.test.ts
+++ b/ui/web/tests/unit/skins/modern/SimulatorBar.test.ts
@@ -159,22 +159,18 @@ describe('SimulatorBar', () => {
     const wrapper = mountBar()
     const themeSelect = wrapper.find('.modern-bar__select[aria-label="Theme"]')
     expect(themeSelect.exists()).toBe(true)
-    // Pick a theme that differs from the mocked activeThemeId (THEME_IDS[0]).
-    const targetTheme = THEME_IDS[1]
-    await themeSelect.setValue(targetTheme)
+    await themeSelect.setValue('dracula')
     await themeSelect.trigger('change')
-    expect(switchThemeMock).toHaveBeenCalledWith(targetTheme)
+    expect(switchThemeMock).toHaveBeenCalledWith('dracula')
   })
 
   it('should call switchSkin when skin select changes', async () => {
     const wrapper = mountBar()
     const skinSelect = wrapper.find('.modern-bar__select[aria-label="Skin"]')
     expect(skinSelect.exists()).toBe(true)
-    // Pick a skin that differs from the mocked activeSkinId ('modern').
-    const targetSkin = SKIN_IDS.find(id => id !== 'modern') ?? SKIN_IDS[0]
-    await skinSelect.setValue(targetSkin)
+    await skinSelect.setValue('classic')
     await skinSelect.trigger('change')
-    expect(switchSkinMock).toHaveBeenCalledWith(targetSkin)
+    expect(switchSkinMock).toHaveBeenCalledWith('classic')
   })
 
   it('should emit switch-server with selectedIndex when server select changes via trigger', async () => {


### PR DESCRIPTION
## Summary

Fix a `vitest@4.x` teardown-time RPC leak that intermittently fails the `Build dashboard` matrix on `ubuntu-latest`/Node 22 (and cascades cancellations to every other matrix cell). All tests pass; the job exits 1 because of:

```
EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
This error originated in "tests/unit/skins/modern/SimulatorBar.test.ts"
```

## Root cause

The two final tests in `SimulatorBar.test.ts` mounted the component with the **real** `useTheme` / `useSkin` composables. Both code paths schedule `console.warn` output **after** the synchronous test body resolves:

1. `validateTokenContract()` (`src/shared/tokens/contract.ts`) wraps its work in `requestAnimationFrame` and warns when CSS variables are missing. jsdom does not resolve `--color-*` CSS variables, so the contract check logs ~24 warnings via rAF on every theme/skin switch.
2. `switchSkin()` returns `Promise<boolean>`, but the `@change` handler discards the promise and `trigger('change')` only awaits Vue's `nextTick`. The unawaited `loadStyles()` dynamic import resolves later and may also call `console.warn`.

`vitest@4.x` tightened teardown to **fail** rather than swallow pending RPC calls — hence the surfaced symptom. The bug pre-existed the bump; reproducibly fails on Linux/Node 22 in CI but passes on macOS/Node 24 because rAF + dynamic-import timing differs.

## Fix

Mirror the existing precedent in `tests/unit/router.test.ts`: `vi.mock` both composables at the top of the test file, returning shapes that match the real contract (`THEME_IDS` / `SKIN_IDS` imported from `ui-common`, not hand-rolled subsets). The mocked `switchSkin` resolves immediately so no teardown leak occurs.

Also tightens the two affected tests to actually assert what their names claim (`switchTheme` / `switchSkin` called with the selected value), instead of merely checking the `<select>` exists.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ — `Test Files 31 passed (31) | Tests 531 passed (531)`, exit 0, **3/3 consecutive runs locally** with zero `EnvironmentTeardownError` / `Unhandled Rejection`.

## Notes

- No production code changed. Test-only fix.
- `availableSkins` in the mock uses `SKIN_IDS.map(id => ({ id, label: id }))` which is a structural subset of `SkinDefinition` (no `loader`); sufficient for the `<select>` rendering exercised by these tests, and analogous to the precedent in `router.test.ts`.
