### PR TITLE
test(ui-web): drain dynamic imports globally for async components

### DIFF
--- a/ui/web/tests/setup.ts
+++ b/ui/web/tests/setup.ts
@@ -26,6 +26,7 @@ vi.mock('vue-toast-notification', () => ({
   useToast: () => toastMock,
 }))
 
-afterEach(() => {
+afterEach(async () => {
   localStorage.clear()
+  await vi.dynamicImportSettled()
 })

--- a/ui/web/tests/unit/skins/modern/ModernLayout.test.ts
+++ b/ui/web/tests/unit/skins/modern/ModernLayout.test.ts
@@ -364,6 +364,8 @@ describe('ModernLayout', () => {
     await flushPromises()
     // Verify dialog components exist (stubbed to true = rendered when dialog state is set)
     expect(wrapper.findComponent({ name: 'AuthorizeDialog' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'SetSupervisionUrlDialog' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'StartTransactionDialog' }).exists()).toBe(true)
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Summary

Add `vi.dynamicImportSettled()` to the global `afterEach` hook so `defineAsyncComponent` loaders and lazy routes settle before Vitest tears down the test environment.

## Root cause

`ModernLayout.vue` and `App.vue` wrap children in `defineAsyncComponent({ loader: () => import(...) })`. Under filtered runs, transitive `.vue` imports resolved after teardown, surfacing as `EnvironmentTeardownError`. `global.stubs: true` does not cancel scheduled `import()`s; `vi.dynamicImportSettled()` is the canonical drain (Vitest guide; used in `@vue/test-utils` own test suite).

## Scope

Single global guard in `ui/web/tests/setup.ts`. Covers all async-component and lazy-route sites: `App.vue`, `ModernLayout.vue`, classic action routes.

## Verification

- `DEBUG=vite:load pnpm exec vitest run tests/unit/skins/modern/ModernLayout.test.ts -t "should open authorize dialog" --reporter=dot --coverage=false` — passes, no unhandled rejection
- `pnpm exec vitest run tests/unit/skins/modern/ModernLayout.test.ts --reporter=dot --coverage=false` — 14/14
- `pnpm test` — 531/531
- `pnpm typecheck`, `pnpm lint`, `pnpm build` — clean

## PR Checklist

- [x] Description added
- [x] Title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Test-only change covered by `tests/unit/skins/modern/ModernLayout.test.ts`
- [x] No new feature
- [ ] No related open issue (Vitest 4 upgrade side-effect)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No