### PR TITLE
fix(ui-web): skip dev-only diagnostics under Vitest

### DIFF
--- a/ui/web/src/core/env.ts
+++ b/ui/web/src/core/env.ts
@@ -1,0 +1,8 @@
+/**
+ * Whether the application runs in a real DEV environment (`pnpm dev` /
+ * Vite serve), excluding production builds and Vitest runs. Use to gate
+ * dev-only diagnostics that would otherwise emit noise in tests or race
+ * environment teardown via `requestAnimationFrame` / async callbacks.
+ * @returns Whether the runtime is DEV and not a Vitest test run
+ */
+export const isDev = (): boolean => import.meta.env.DEV && import.meta.env.MODE !== 'test'

--- a/ui/web/src/core/index.ts
+++ b/ui/web/src/core/index.ts
@@ -12,6 +12,7 @@ export {
   UI_SERVER_CONFIGURATION_INDEX_KEY,
   WH_PER_KWH,
 } from './Constants.js'
+export { isDev } from './env.js'
 export {
   chargingStationsKey,
   configurationKey,

--- a/ui/web/src/core/providers.ts
+++ b/ui/web/src/core/providers.ts
@@ -3,6 +3,7 @@ import type { InjectionKey, Ref } from 'vue'
 
 import { inject } from 'vue'
 
+import { isDev } from './env.js'
 import { UIClient } from './UIClient.js'
 
 export const configurationKey: InjectionKey<Ref<ConfigurationData>> = Symbol('configuration')
@@ -14,7 +15,7 @@ export const uiClientKey: InjectionKey<UIClient> = Symbol('uiClient')
 export const useUIClient = (): UIClient => {
   const injected = inject(uiClientKey, undefined)
   if (injected != null) return injected
-  if (import.meta.env.DEV) {
+  if (isDev()) {
     console.debug('[useUIClient] Accessed outside provide scope — using singleton fallback')
   }
   return UIClient.getInstance()

--- a/ui/web/src/core/storage.ts
+++ b/ui/web/src/core/storage.ts
@@ -1,11 +1,12 @@
 import { SHARED_TOGGLE_BUTTON_KEY_PREFIX, TOGGLE_BUTTON_KEY_PREFIX } from './Constants.js'
+import { isDev } from './env.js'
 
 export const getFromLocalStorage = <T>(key: string, defaultValue: T): T => {
   try {
     const item = localStorage.getItem(key)
     return item != null ? (JSON.parse(item) as T) : defaultValue
   } catch {
-    if (import.meta.env.DEV) {
+    if (isDev()) {
       console.debug(`[localStorage] Failed to read key '${key}', using default`)
     }
     return defaultValue
@@ -21,7 +22,7 @@ export const setToLocalStorage = <T>(key: string, value: T): void => {
     // - QuotaExceededError when the origin's storage quota is genuinely exceeded
     // - SecurityError when storage is blocked by user settings or browser policies
     //   (e.g., "Block All Cookies" in Safari, third-party iframe in Chrome, file: URLs)
-    if (import.meta.env.DEV) {
+    if (isDev()) {
       console.debug(`[localStorage] Failed to write key '${key}'`)
     }
   }
@@ -31,7 +32,7 @@ export const deleteFromLocalStorage = (key: string): void => {
   try {
     localStorage.removeItem(key)
   } catch {
-    if (import.meta.env.DEV) {
+    if (isDev()) {
       console.debug(`[localStorage] Failed to delete key '${key}'`)
     }
   }
@@ -56,7 +57,7 @@ export const deleteLocalStorageByKeyPattern = (pattern: string): void => {
       deleteFromLocalStorage(key)
     }
   } catch {
-    if (import.meta.env.DEV) {
+    if (isDev()) {
       console.debug(`[localStorage] Failed to delete keys matching '${pattern}'`)
     }
   }

--- a/ui/web/src/main.ts
+++ b/ui/web/src/main.ts
@@ -13,6 +13,7 @@ import {
   configurationKey,
   DEFAULT_SKIN,
   getFromLocalStorage,
+  isDev,
   LEGACY_UI_SERVER_CONFIG_KEY,
   setToLocalStorage,
   templatesKey,
@@ -40,7 +41,7 @@ import './assets/themes/tokyo-night-storm.css'
 const initializeApp = async (app: AppType, config: ConfigurationData): Promise<void> => {
   app.config.errorHandler = (error, instance, info) => {
     console.error('Error:', error)
-    if (import.meta.env.DEV) {
+    if (isDev()) {
       console.info('Vue instance:', instance)
       console.info('Error info:', info)
     }

--- a/ui/web/src/shared/tokens/contract.ts
+++ b/ui/web/src/shared/tokens/contract.ts
@@ -7,6 +7,8 @@
  *
  * Every theme file MUST define a value for each token (as `--{token-name}`).
  */
+import { isDev } from '@/core/index.js'
+
 export const TOKEN_CONTRACT = [
   'color-accent',
   'color-bg',
@@ -53,7 +55,9 @@ export type TokenName = (typeof TOKEN_CONTRACT)[number]
  * @param contextId - The skin/theme id that was just applied
  */
 export function validateTokenContract (source: string, contextId: string): void {
-  if (!import.meta.env.DEV || typeof document === 'undefined') return
+  if (!isDev() || typeof document === 'undefined') {
+    return
+  }
   requestAnimationFrame(() => {
     const style = getComputedStyle(document.documentElement)
     for (const token of TOKEN_CONTRACT) {

--- a/ui/web/src/skins/classic/components/buttons/ToggleButton.vue
+++ b/ui/web/src/skins/classic/components/buttons/ToggleButton.vue
@@ -13,6 +13,7 @@ import { ref } from 'vue'
 import {
   getFromLocalStorage,
   getLocalStorage,
+  isDev,
   setToLocalStorage,
   SHARED_TOGGLE_BUTTON_KEY_PREFIX,
   TOGGLE_BUTTON_KEY_PREFIX,
@@ -48,7 +49,7 @@ const click = (): void => {
         setToLocalStorage<boolean>(key, false)
       }
     } catch {
-      if (import.meta.env.DEV) {
+      if (isDev()) {
         console.debug('[ToggleButton] Failed to clear shared toggle buttons')
       }
     }

--- a/ui/web/tests/unit/shared/tokens/contract.test.ts
+++ b/ui/web/tests/unit/shared/tokens/contract.test.ts
@@ -1,12 +1,13 @@
 /**
- * @file Tests for TOKEN_CONTRACT theme compliance
- * @description Ensures every theme CSS file defines all CSS custom properties declared in TOKEN_CONTRACT.
+ * @file Tests for TOKEN_CONTRACT theme compliance and validateTokenContract guard
+ * @description Ensures every theme CSS file defines all CSS custom properties declared in
+ *   TOKEN_CONTRACT, and that validateTokenContract is a no-op under Vitest.
  */
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { TOKEN_CONTRACT } from '@/shared/tokens/contract.js'
+import { TOKEN_CONTRACT, validateTokenContract } from '@/shared/tokens/contract.js'
 
 const themesDir = resolve(__dirname, '../../../../src/assets/themes')
 const themeFiles = ['tokyo-night-storm.css', 'catppuccin-latte.css', 'sap-horizon.css']
@@ -20,5 +21,13 @@ describe('TOKEN_CONTRACT', () => {
       const propRegex = new RegExp(`^\\s*${prop.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*:`, 'm')
       expect(css, `Missing ${prop} in ${themeFile} or base.css`).toMatch(propRegex)
     }
+  })
+})
+
+describe('validateTokenContract', () => {
+  it('should be a no-op under Vitest', () => {
+    const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame')
+    validateTokenContract('useTheme', 'tokyo-night-storm')
+    expect(rafSpy).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

Extract `isDev()` helper in `ui/web/src/core/env.ts` returning `true` only when running in real DEV (excludes production build and Vitest). Migrate the 7 existing `import.meta.env.DEV` check sites to the helper.

## Root cause

[`validateTokenContract`](https://github.com/SAP/e-mobility-charging-stations-simulator/blob/main/ui/web/src/shared/tokens/contract.ts) schedules a `requestAnimationFrame` whose body calls `console.warn` when CSS custom properties are missing. jsdom does not resolve `--color-*` tokens, so every theme/skin switch under Vitest 4 queued a `console.warn` that fired after the environment was torn down, surfacing as:

```
EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
```

Reproducibly fails on Linux/Node 22 in CI; passes on macOS/Node 24 due to rAF timing differences. The `vi.dynamicImportSettled()` global drain added in #1893 covers dynamic imports, not rAF callbacks.

## Scope

Single helper at the canonical source. No production-API change.

| Site | Before | After |
|---|---|---|
| `core/env.ts` | _(new file)_ | `isDev()` helper |
| `shared/tokens/contract.ts:55` (rAF leak) | `if (!import.meta.env.DEV \|\| ...)` | `if (!isDev() \|\| ...)` |
| `core/storage.ts:8,24,34,59` | `if (import.meta.env.DEV)` × 4 | `if (isDev())` × 4 |
| `core/providers.ts:17` | `if (import.meta.env.DEV)` | `if (isDev())` |
| `main.ts:43` | `if (import.meta.env.DEV)` | `if (isDev())` |
| `skins/classic/components/buttons/ToggleButton.vue:51` | `if (import.meta.env.DEV)` | `if (isDev())` |

Side effect: silences `console.debug` / `console.info` noise from `storage.ts`, `providers.ts`, `ToggleButton.vue`, `main.ts` under Vitest. `dev`/`build` behaviour unchanged.

## Verification

- New regression test in `ui/web/tests/unit/shared/tokens/contract.test.ts` asserts `requestAnimationFrame` is not called by `validateTokenContract` under Vitest
- `pnpm test` — 532/532
- `pnpm typecheck`, `pnpm lint`, `pnpm build` — clean
- `grep import.meta.env.DEV ui/web/src/` — single occurrence, in `core/env.ts` (single source of truth)

## PR Checklist

- [x] Description added
- [x] Title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Regression test added
- [x] No new feature
- [ ] No related open issue (Vitest 4 teardown class follow-up to #1884 / #1893)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No