### PR TITLE
fix(config): tighten Zod validation on uiServer.options.port (#1874)

### DIFF
--- a/src/utils/ConfigurationSchema.ts
+++ b/src/utils/ConfigurationSchema.ts
@@ -139,6 +139,27 @@ export const UIServerAccessPolicySchema = z
   })
   .strict()
 
+/**
+ * UIServerListenOptionsSchema — bridge schema for `node:net` `ListenOptions`.
+ * Validates known primitive fields (port, host, backlog, ...) at boot time so
+ * that bad transport-level values (e.g. `port: "not-a-number"`) fail in
+ * `ConfigurationSchema.safeParse` rather than later in `Server.listen`.
+ * Unknown keys are passed through to preserve the `ListenOptions` extension
+ * surface (e.g. `signal: AbortSignal`).
+ */
+const UIServerListenOptionsObjectSchema = z
+  .object({
+    backlog: z.number().int().nonnegative().optional(),
+    exclusive: z.boolean().optional(),
+    host: z.string().min(1).optional(),
+    ipv6Only: z.boolean().optional(),
+    path: z.string().min(1).optional(),
+    port: z.number().int().min(0).max(65535).optional(),
+    readableAll: z.boolean().optional(),
+    writableAll: z.boolean().optional(),
+  })
+  .loose()
+
 const UIServerListenOptionsSchema = z
   .custom<ListenOptions>(
     value => value != null && typeof value === 'object' && !Array.isArray(value),
@@ -147,6 +168,7 @@ const UIServerListenOptionsSchema = z
   .refine(value => !Object.hasOwn(value as object, 'accessPolicy'), {
     message: "'accessPolicy' must be configured under 'uiServer', not 'uiServer.options'",
   })
+  .pipe(UIServerListenOptionsObjectSchema)
 
 /**
  * UIServerConfiguration — UI server configuration section.

--- a/src/utils/ConfigurationSchema.ts
+++ b/src/utils/ConfigurationSchema.ts
@@ -140,12 +140,12 @@ export const UIServerAccessPolicySchema = z
   .strict()
 
 /**
- * UIServerListenOptionsSchema — bridge schema for `node:net` `ListenOptions`.
- * Validates known primitive fields (port, host, backlog, ...) at boot time so
- * that bad transport-level values (e.g. `port: "not-a-number"`) fail in
- * `ConfigurationSchema.safeParse` rather than later in `Server.listen`.
- * Unknown keys are passed through to preserve the `ListenOptions` extension
- * surface (e.g. `signal: AbortSignal`).
+ * UIServerListenOptionsObjectSchema — typed object layer for `node:net`
+ * `ListenOptions`. Validates known primitive fields (port, host, backlog, ...)
+ * at boot time so that bad transport-level values (e.g. `port: "not-a-number"`)
+ * fail in `ConfigurationSchema.safeParse` rather than later in `Server.listen`.
+ * Unknown keys are passed through (`.loose()`) to preserve the `ListenOptions`
+ * extension surface (e.g. `signal: AbortSignal`).
  */
 const UIServerListenOptionsObjectSchema = z
   .object({
@@ -160,6 +160,11 @@ const UIServerListenOptionsObjectSchema = z
   })
   .loose()
 
+/**
+ * UIServerListenOptionsSchema — composite schema for `uiServer.options`:
+ * non-array object guard → `accessPolicy` misplacement refinement → typed
+ * field validation via `UIServerListenOptionsObjectSchema`.
+ */
 const UIServerListenOptionsSchema = z
   .custom<ListenOptions>(
     value => value != null && typeof value === 'object' && !Array.isArray(value),
@@ -172,8 +177,9 @@ const UIServerListenOptionsSchema = z
 
 /**
  * UIServerConfiguration — UI server configuration section.
- * `options` is structurally typed as `ListenOptions` from node:net; the schema
- * uses `z.custom<ListenOptions>()` to bridge the external surface.
+ * `options` is structurally typed as `ListenOptions` from node:net and
+ * validated by `UIServerListenOptionsSchema` (object guard → `accessPolicy`
+ * refinement → typed field validation).
  */
 export const UIServerConfigurationSchema = z
   .object({

--- a/tests/utils/ConfigurationSchema.test.ts
+++ b/tests/utils/ConfigurationSchema.test.ts
@@ -282,6 +282,126 @@ await describe('ConfigurationSchema', async () => {
       )
     })
 
+    await describe('uiServer.options.port', async () => {
+      await it('should reject non-numeric string port "not-a-number"', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: { options: { host: 'localhost', port: 'not-a-number' } },
+          })
+        )
+        assert.ok(!result.success)
+        const paths = result.error.issues.map(i => i.path.join('.'))
+        assert.ok(
+          paths.includes('uiServer.options.port'),
+          `Expected error path 'uiServer.options.port' in ${JSON.stringify(paths)}`
+        )
+      })
+
+      await it('should reject negative port (-1)', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: { options: { host: 'localhost', port: -1 } },
+          })
+        )
+        assert.ok(!result.success)
+        assert.ok(result.error.issues.some(i => i.path.join('.') === 'uiServer.options.port'))
+      })
+
+      await it('should reject port 65536 (out of range)', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: { options: { host: 'localhost', port: 65536 } },
+          })
+        )
+        assert.ok(!result.success)
+        assert.ok(result.error.issues.some(i => i.path.join('.') === 'uiServer.options.port'))
+      })
+
+      await it('should reject non-integer port 3.14', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: { options: { host: 'localhost', port: 3.14 } },
+          })
+        )
+        assert.ok(!result.success)
+        assert.ok(result.error.issues.some(i => i.path.join('.') === 'uiServer.options.port'))
+      })
+
+      await it('should accept port 8080', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: { options: { host: 'localhost', port: 8080 } },
+          })
+        )
+        assert.ok(
+          result.success,
+          `Expected port 8080 to be accepted: ${result.success ? '' : JSON.stringify(result.error.issues)}`
+        )
+      })
+
+      await it('should accept port 0 (OS-picked port)', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: { options: { host: 'localhost', port: 0 } },
+          })
+        )
+        assert.ok(
+          result.success,
+          `Expected port 0 to be accepted: ${result.success ? '' : JSON.stringify(result.error.issues)}`
+        )
+      })
+
+      await it('should accept port 65535 (max valid)', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: { options: { host: 'localhost', port: 65535 } },
+          })
+        )
+        assert.ok(
+          result.success,
+          `Expected port 65535 to be accepted: ${result.success ? '' : JSON.stringify(result.error.issues)}`
+        )
+      })
+    })
+
+    await describe('uiServer.options.host', async () => {
+      await it('should reject empty host string', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: { options: { host: '', port: 8080 } },
+          })
+        )
+        assert.ok(!result.success)
+        const paths = result.error.issues.map(i => i.path.join('.'))
+        assert.ok(
+          paths.includes('uiServer.options.host'),
+          `Expected error path 'uiServer.options.host' in ${JSON.stringify(paths)}`
+        )
+      })
+
+      await it('should accept host "localhost"', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: { options: { host: 'localhost', port: 8080 } },
+          })
+        )
+        assert.ok(
+          result.success,
+          `Expected host 'localhost' to be accepted: ${result.success ? '' : JSON.stringify(result.error.issues)}`
+        )
+      })
+
+      await it('should reject non-string host', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: { options: { host: 1234, port: 8080 } },
+          })
+        )
+        assert.ok(!result.success)
+        assert.ok(result.error.issues.some(i => i.path.join('.') === 'uiServer.options.host'))
+      })
+    })
+
     await it('should reject hostnames in trustedProxies', () => {
       const result = ConfigurationSchema.safeParse(
         buildMinimalConfiguration({

--- a/tests/utils/ConfigurationValidation.test.ts
+++ b/tests/utils/ConfigurationValidation.test.ts
@@ -488,5 +488,30 @@ await describe('ConfigurationValidation', async () => {
         assert.strictEqual(error.message, EXPECTED_SNAPSHOT)
       }
     })
+
+    await it('should fail-fast with structured uiServer.options.port path on invalid port', () => {
+      const parsed = buildMinimalConfiguration({
+        uiServer: {
+          enabled: true,
+          options: { host: 'localhost', port: 'not-a-number' },
+          type: 'ws',
+        },
+      })
+      try {
+        validateConfiguration(parsed, 'bad-port.json')
+        assert.fail('Expected ConfigurationValidationError')
+      } catch (error) {
+        assert.ok(error instanceof ConfigurationValidationError)
+        assert.strictEqual(error.phase, 'schema')
+        const portErrors = error.fieldErrors.filter(e => e.path === 'uiServer.options.port')
+        assert.strictEqual(
+          portErrors.length,
+          1,
+          `Expected one fieldError on 'uiServer.options.port', got ${JSON.stringify(error.fieldErrors)}`
+        )
+        assert.match(error.message, /uiServer\.options\.port/)
+        assert.match(error.message, /\[schema\]/)
+      }
+    })
   })
 })


### PR DESCRIPTION
## Summary

The Zod schema introduced in #1874 promised fail-fast configuration
validation at boot, but `uiServer.options` was bridged with a permissive
`z.custom<ListenOptions>` that only checks the value is a non-array
object. As a result, primitive-typed fields like `port` and `host` were
not validated: a `port: "not-a-number"` accepts at boot, stations
register and exchange `BootNotification`, then the process crashes
inside `node:net.Server.listen` with
`RangeError [ERR_SOCKET_BAD_PORT]: options.port should be >= 0 and < 65536`.

This change replaces the permissive bridge with a typed object schema
piped after the existing structural refinement. Known primitive fields
are validated at boot; unknown keys are still passed through (`.loose()`)
so the `ListenOptions` extension surface (e.g. `signal: AbortSignal`)
remains usable. The existing `accessPolicy` misplacement refinement is
preserved via `.pipe()`.

## Validation surface

| Field          | Constraint                            |
| -------------- | ------------------------------------- |
| `port`         | integer in `[0, 65535]`               |
| `host`         | non-empty string                      |
| `backlog`      | non-negative integer                  |
| `path`         | non-empty string (unix socket path)   |
| `exclusive`    | boolean                               |
| `ipv6Only`     | boolean                               |
| `readableAll`  | boolean                               |
| `writableAll`  | boolean                               |
| _other keys_   | passed through (e.g. `signal`)        |

## Reproduction (mandatory pre/post evidence)

Setup (identical for BEFORE and AFTER):

```shell
pnpm build && pnpm --filter cli build
cp dist/assets/config.json /tmp/config-backup.json
jq '.uiServer.options.port = "not-a-number"' /tmp/config-backup.json \
  > dist/assets/config.json
```

### BEFORE (main @ 61026d79) — bug confirmed

Command:

```shell
timeout 8 node --enable-source-maps dist/start.js
echo "EXIT=$?"
```

Stderr (last lines) + exit code:

```
Startup error:  RangeError [ERR_SOCKET_BAD_PORT]: options.port should be >= 0 and < 65536. Received type string ('not-a-number').
    at Server.listen (node:net:2159:5)
    at Zi.startHttpServer (file:///.../dist/start.js:3:236957)
    at Zi.start (file:///.../dist/start.js:11:2782)
    at r.startUIServer (file:///.../dist/start.js:12:417)
    at file:///.../dist/start.js:12:14641
    ...
  code: 'ERR_SOCKET_BAD_PORT'
EXIT=124
```

`EXIT=124` is the `timeout(1)` signal: the simulator boots successfully,
the UI server crashes with `ERR_SOCKET_BAD_PORT`, but the process
keeps running (no fail-fast) until `timeout` kills it after 8s.

### AFTER (this PR) — fail-fast at boot

Command:

```shell
timeout 8 node --enable-source-maps dist/start.js > /dev/null 2> stderr.log
echo "node-exit=$?"
cat stderr.log
```

Stderr + exit code:

```
6/15/2026, 4:53:47 PM Simulator configuration | ConfigurationValidation: Configuration validation failed [schema] for '/.../dist/assets/config.json':
  - uiServer.options.port: Invalid input: expected number, received string
node-exit=1
```

- Exit code **`1`** (non-zero) — fail-fast.
- Wall-clock time to error: **~1.6 s** (most of which is node + tsx startup).
- Error path: `uiServer.options.port` — structured, machine-readable.
- Routed through `ConfigurationValidationError` (`phase: 'schema'`) — the
  existing typed error machinery, not a raw `Error`.

## Tests

`tests/utils/ConfigurationSchema.test.ts` (10 new cases under
`uiServer.options.port` and `uiServer.options.host` describes):

| Case                                  | Expected          |
| ------------------------------------- | ----------------- |
| `port = "not-a-number"`               | reject (path)     |
| `port = -1`                           | reject (path)     |
| `port = 65536`                        | reject (path)     |
| `port = 3.14`                         | reject (path)     |
| `port = 8080`                         | accept            |
| `port = 0` (OS-picked)                | accept            |
| `port = 65535` (max)                  | accept            |
| `host = ""`                           | reject (path)     |
| `host = "localhost"`                  | accept            |
| `host = 1234` (non-string)            | reject (path)     |

`tests/utils/ConfigurationValidation.test.ts` (1 new integration case)
asserts the end-to-end pipeline surfaces `uiServer.options.port` in
`ConfigurationValidationError.fieldErrors` with `phase: 'schema'`.

## Quality gates

| Command                                         | Result                          |
| ----------------------------------------------- | ------------------------------- |
| `pnpm --filter . typecheck`                     | exit 0                          |
| `pnpm --filter . lint`                          | exit 0                          |
| `pnpm format`                                   | exit 0                          |
| `pnpm test`                                     | 2730 pass / 0 fail / 6 skipped  |
| `pnpm circular-deps`                            | 62 cycles (= baseline)          |
| Reproduction (BEFORE)                           | exit 124, `ERR_SOCKET_BAD_PORT` |
| Reproduction (AFTER)                            | exit 1, structured Zod error    |

## Out of scope

- OCPP wire schema and station templates — not touched.
- `BaseError` / `OCPPError` class hierarchy — not refactored.

## Severity

MAJOR — boot-time validation gap.