### PR TITLE
fix(config): enforce Zod simulator-config validation at boot (#1874)

### DIFF
--- a/src/utils/ConfigurationSchema.ts
+++ b/src/utils/ConfigurationSchema.ts
@@ -172,7 +172,7 @@ export const UIServerAccessPolicySchema = z
       ),
     {
       message: "'allowLoopbackProxy' requires at least one entry in 'trustedProxies'",
-      path: ['allowLoopbackProxy'],
+      path: ['trustedProxies'],
     }
   )
 

--- a/src/utils/ConfigurationSchema.ts
+++ b/src/utils/ConfigurationSchema.ts
@@ -85,6 +85,12 @@ export const StorageConfigurationSchema = z
  * at the field level (`min(1)`, RFC 7617 `':'` ban on `username`) and at the
  * object level (both required when `enabled === true`) so misconfigurations
  * fail at boot rather than silently bypassing Basic-Auth at runtime.
+ *
+ * Field-level constraints (`min(1)`, no `':'`) apply unconditionally — the
+ * schema is intentionally stricter than the runtime guard in `UIServerFactory`
+ * so that an `enabled: false` configuration cannot ship a value that becomes
+ * an authentication bypass the moment `enabled` is flipped on (including via
+ * configuration hot-reload). Defense-in-depth runtime checks remain.
  */
 export const UIServerAuthenticationSchema = z
   .object({
@@ -102,6 +108,7 @@ export const UIServerAuthenticationSchema = z
   .strict()
   .refine(value => !(value.enabled && (value.username == null || value.password == null)), {
     message: "'username' and 'password' are required when 'authentication.enabled' is true",
+    path: ['username'],
   })
 
 export const UI_SERVER_ACCESS_POLICY_DEFAULTS = {

--- a/src/utils/ConfigurationSchema.ts
+++ b/src/utils/ConfigurationSchema.ts
@@ -81,17 +81,28 @@ export const StorageConfigurationSchema = z
 
 /**
  * UIServerAuthentication — credentials for the UI server.
- * `enabled` and `type` are required; `username`/`password` are optional and
- * depend on the chosen authentication scheme.
+ * `enabled` and `type` are required. `username` and `password` are validated
+ * at the field level (`min(1)`, RFC 7617 `':'` ban on `username`) and at the
+ * object level (both required when `enabled === true`) so misconfigurations
+ * fail at boot rather than silently bypassing Basic-Auth at runtime.
  */
 export const UIServerAuthenticationSchema = z
   .object({
     enabled: z.boolean(),
-    password: z.string().optional(),
+    password: z.string().min(1).optional(),
     type: z.enum(AuthenticationType),
-    username: z.string().optional(),
+    username: z
+      .string()
+      .min(1)
+      .refine(value => !value.includes(':'), {
+        message: "must not contain ':' (RFC 7617)",
+      })
+      .optional(),
   })
   .strict()
+  .refine(value => !(value.enabled && (value.username == null || value.password == null)), {
+    message: "'username' and 'password' are required when 'authentication.enabled' is true",
+  })
 
 export const UI_SERVER_ACCESS_POLICY_DEFAULTS = {
   allowedHosts: [],
@@ -138,6 +149,17 @@ export const UIServerAccessPolicySchema = z
       .optional(),
   })
   .strict()
+  .refine(
+    value =>
+      !(
+        value.allowLoopbackProxy === true &&
+        (value.trustedProxies == null || value.trustedProxies.length === 0)
+      ),
+    {
+      message: "'allowLoopbackProxy' requires at least one entry in 'trustedProxies'",
+      path: ['allowLoopbackProxy'],
+    }
+  )
 
 /**
  * UIServerListenOptionsObjectSchema — typed object layer for `node:net`

--- a/src/utils/ConfigurationSchema.ts
+++ b/src/utils/ConfigurationSchema.ts
@@ -80,17 +80,12 @@ export const StorageConfigurationSchema = z
   .strict()
 
 /**
- * UIServerAuthentication — credentials for the UI server.
- * `enabled` and `type` are required. `username` and `password` are validated
- * at the field level (`min(1)`, RFC 7617 `':'` ban on `username`) and at the
- * object level (both required when `enabled === true`) so misconfigurations
- * fail at boot rather than silently bypassing Basic-Auth at runtime.
- *
- * Field-level constraints (`min(1)`, no `':'`) apply unconditionally — the
- * schema is intentionally stricter than the runtime guard in `UIServerFactory`
- * so that an `enabled: false` configuration cannot ship a value that becomes
- * an authentication bypass the moment `enabled` is flipped on (including via
- * configuration hot-reload). Defense-in-depth runtime checks remain.
+ * UIServerAuthentication — credentials for the UI server. `username` is a
+ * non-empty string without `':'` (RFC 7617); `password` is a non-empty
+ * string. Both are required when `enabled` is true. Field-level constraints
+ * fire unconditionally — intentionally stricter than the runtime guard in
+ * `UIServerFactory` to block dormant Basic-Auth bypasses across hot-reload
+ * toggles of `enabled`.
  */
 export const UIServerAuthenticationSchema = z
   .object({

--- a/src/utils/ConfigurationSchema.ts
+++ b/src/utils/ConfigurationSchema.ts
@@ -84,8 +84,8 @@ export const StorageConfigurationSchema = z
  * non-empty string without `':'` (RFC 7617); `password` is a non-empty
  * string. Both are required when `enabled` is true. Field-level constraints
  * fire unconditionally — intentionally stricter than the runtime guard in
- * `UIServerFactory` to block dormant Basic-Auth bypasses across hot-reload
- * toggles of `enabled`.
+ * `UIServerFactory` so empty placeholders cannot ship under `enabled: false`
+ * and become a Basic-Auth bypass on the next boot with `enabled: true`.
  */
 export const UIServerAuthenticationSchema = z
   .object({

--- a/src/utils/ConfigurationSchema.ts
+++ b/src/utils/ConfigurationSchema.ts
@@ -101,9 +101,22 @@ export const UIServerAuthenticationSchema = z
       .optional(),
   })
   .strict()
-  .refine(value => !(value.enabled && (value.username == null || value.password == null)), {
-    message: "'username' and 'password' are required when 'authentication.enabled' is true",
-    path: ['username'],
+  .superRefine((value, ctx) => {
+    if (!value.enabled) return
+    if (value.username == null) {
+      ctx.addIssue({
+        code: 'custom',
+        message: "'username' is required when 'authentication.enabled' is true",
+        path: ['username'],
+      })
+    }
+    if (value.password == null) {
+      ctx.addIssue({
+        code: 'custom',
+        message: "'password' is required when 'authentication.enabled' is true",
+        path: ['password'],
+      })
+    }
   })
 
 export const UI_SERVER_ACCESS_POLICY_DEFAULTS = {

--- a/tests/utils/ConfigurationSchema.test.ts
+++ b/tests/utils/ConfigurationSchema.test.ts
@@ -690,7 +690,7 @@ await describe('ConfigurationSchema', async () => {
         )
         assert.ok(!result.success)
         assert.ok(
-          result.error.issues.some(i => i.path.join('.').includes('uiServer.authentication'))
+          result.error.issues.some(i => i.path.join('.').startsWith('uiServer.authentication'))
         )
       })
 
@@ -708,7 +708,7 @@ await describe('ConfigurationSchema', async () => {
         )
         assert.ok(!result.success)
         assert.ok(
-          result.error.issues.some(i => i.path.join('.').includes('uiServer.authentication'))
+          result.error.issues.some(i => i.path.join('.').startsWith('uiServer.authentication'))
         )
       })
 
@@ -1049,7 +1049,7 @@ await describe('ConfigurationSchema', async () => {
       assert.ok(!result.success)
       const paths = result.error.issues.map(i => i.path.join('.'))
       assert.ok(
-        paths.some(p => p.includes('uiServer.authentication')),
+        paths.some(p => p.startsWith('uiServer.authentication')),
         `Expected an issue under 'uiServer.authentication' (unknown-key rejection) in ${JSON.stringify(paths)}`
       )
     })

--- a/tests/utils/ConfigurationSchema.test.ts
+++ b/tests/utils/ConfigurationSchema.test.ts
@@ -609,6 +609,189 @@ await describe('ConfigurationSchema', async () => {
       )
       assert.ok(!result.success)
     })
+
+    await describe('uiServer.authentication credentials', async () => {
+      await it('should reject empty username', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: {
+              authentication: {
+                enabled: true,
+                password: 'p',
+                type: 'protocol-basic-auth',
+                username: '',
+              },
+            },
+          })
+        )
+        assert.ok(!result.success)
+        const paths = result.error.issues.map(i => i.path.join('.'))
+        assert.ok(
+          paths.includes('uiServer.authentication.username'),
+          `Expected error path 'uiServer.authentication.username' in ${JSON.stringify(paths)}`
+        )
+      })
+
+      await it('should reject empty password', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: {
+              authentication: {
+                enabled: true,
+                password: '',
+                type: 'protocol-basic-auth',
+                username: 'u',
+              },
+            },
+          })
+        )
+        assert.ok(!result.success)
+        const paths = result.error.issues.map(i => i.path.join('.'))
+        assert.ok(
+          paths.includes('uiServer.authentication.password'),
+          `Expected error path 'uiServer.authentication.password' in ${JSON.stringify(paths)}`
+        )
+      })
+
+      await it("should reject username containing ':' (RFC 7617)", () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: {
+              authentication: {
+                enabled: true,
+                password: 'p',
+                type: 'protocol-basic-auth',
+                username: 'a:b',
+              },
+            },
+          })
+        )
+        assert.ok(!result.success)
+        const usernameIssues = result.error.issues.filter(i =>
+          i.path.join('.').includes('uiServer.authentication.username')
+        )
+        assert.ok(usernameIssues.length > 0)
+        assert.ok(
+          usernameIssues.some(i => i.message.includes('RFC 7617')),
+          `Expected an issue mentioning 'RFC 7617' in ${JSON.stringify(usernameIssues)}`
+        )
+      })
+
+      await it('should reject authentication enabled without username and password', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: {
+              authentication: {
+                enabled: true,
+                type: 'protocol-basic-auth',
+              },
+            },
+          })
+        )
+        assert.ok(!result.success)
+        assert.ok(
+          result.error.issues.some(i => i.path.join('.').includes('uiServer.authentication'))
+        )
+      })
+
+      await it('should reject authentication enabled with username but no password', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: {
+              authentication: {
+                enabled: true,
+                type: 'protocol-basic-auth',
+                username: 'u',
+              },
+            },
+          })
+        )
+        assert.ok(!result.success)
+        assert.ok(
+          result.error.issues.some(i => i.path.join('.').includes('uiServer.authentication'))
+        )
+      })
+
+      await it('should accept authentication disabled without credentials', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: {
+              authentication: {
+                enabled: false,
+                type: 'protocol-basic-auth',
+              },
+            },
+          })
+        )
+        assert.ok(
+          result.success,
+          `Expected disabled auth without credentials to be accepted: ${result.success ? '' : JSON.stringify(result.error.issues)}`
+        )
+      })
+
+      await it('should accept real shipped credentials shape (admin/admin)', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: {
+              authentication: {
+                enabled: true,
+                password: 'admin',
+                type: 'protocol-basic-auth',
+                username: 'admin',
+              },
+              enabled: true,
+              type: 'ws',
+            },
+          })
+        )
+        assert.ok(
+          result.success,
+          `Expected admin/admin to be accepted: ${result.success ? '' : JSON.stringify(result.error.issues)}`
+        )
+      })
+    })
+
+    await describe('uiServer.accessPolicy allowLoopbackProxy/trustedProxies coupling', async () => {
+      await it('should reject allowLoopbackProxy=true with empty trustedProxies', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: {
+              accessPolicy: {
+                allowLoopbackProxy: true,
+                trustedProxies: [],
+              },
+              enabled: true,
+              type: 'ws',
+            },
+          })
+        )
+        assert.ok(!result.success)
+        const paths = result.error.issues.map(i => i.path.join('.'))
+        assert.ok(
+          paths.some(p => p.includes('allowLoopbackProxy') || p.includes('trustedProxies')),
+          `Expected error path naming allowLoopbackProxy or trustedProxies in ${JSON.stringify(paths)}`
+        )
+      })
+
+      await it('should accept allowLoopbackProxy=false with empty trustedProxies (docker shape)', () => {
+        const result = ConfigurationSchema.safeParse(
+          buildMinimalConfiguration({
+            uiServer: {
+              accessPolicy: {
+                allowLoopbackProxy: false,
+                trustedProxies: [],
+              },
+              enabled: true,
+              type: 'ws',
+            },
+          })
+        )
+        assert.ok(
+          result.success,
+          `Expected docker-shape accessPolicy to be accepted: ${result.success ? '' : JSON.stringify(result.error.issues)}`
+        )
+      })
+    })
   })
 
   await describe('mixed-type fields', async () => {
@@ -854,7 +1037,9 @@ await describe('ConfigurationSchema', async () => {
             authentication: {
               bogusAuthKey: 'x',
               enabled: true,
+              password: 'p',
               type: 'protocol-basic-auth',
+              username: 'u',
             },
             enabled: true,
             type: 'ws',
@@ -862,6 +1047,11 @@ await describe('ConfigurationSchema', async () => {
         })
       )
       assert.ok(!result.success)
+      const paths = result.error.issues.map(i => i.path.join('.'))
+      assert.ok(
+        paths.some(p => p.includes('uiServer.authentication')),
+        `Expected an issue under 'uiServer.authentication' (unknown-key rejection) in ${JSON.stringify(paths)}`
+      )
     })
   })
 

--- a/tests/utils/ConfigurationSchema.test.ts
+++ b/tests/utils/ConfigurationSchema.test.ts
@@ -689,8 +689,14 @@ await describe('ConfigurationSchema', async () => {
           })
         )
         assert.ok(!result.success)
+        const paths = result.error.issues.map(i => i.path.join('.'))
         assert.ok(
-          result.error.issues.some(i => i.path.join('.').startsWith('uiServer.authentication'))
+          paths.includes('uiServer.authentication.username'),
+          `Expected error path 'uiServer.authentication.username' in ${JSON.stringify(paths)}`
+        )
+        assert.ok(
+          paths.includes('uiServer.authentication.password'),
+          `Expected error path 'uiServer.authentication.password' in ${JSON.stringify(paths)}`
         )
       })
 
@@ -707,8 +713,10 @@ await describe('ConfigurationSchema', async () => {
           })
         )
         assert.ok(!result.success)
+        const paths = result.error.issues.map(i => i.path.join('.'))
         assert.ok(
-          result.error.issues.some(i => i.path.join('.').startsWith('uiServer.authentication'))
+          paths.includes('uiServer.authentication.password'),
+          `Expected error path 'uiServer.authentication.password' in ${JSON.stringify(paths)}`
         )
       })
 
@@ -1047,10 +1055,11 @@ await describe('ConfigurationSchema', async () => {
         })
       )
       assert.ok(!result.success)
-      const paths = result.error.issues.map(i => i.path.join('.'))
       assert.ok(
-        paths.some(p => p.startsWith('uiServer.authentication')),
-        `Expected an issue under 'uiServer.authentication' (unknown-key rejection) in ${JSON.stringify(paths)}`
+        result.error.issues.some(
+          i => i.code === 'unrecognized_keys' && i.path.join('.') === 'uiServer.authentication'
+        ),
+        `Expected an 'unrecognized_keys' issue at 'uiServer.authentication' in ${JSON.stringify(result.error.issues)}`
       )
     })
   })

--- a/tests/utils/ConfigurationSchema.test.ts
+++ b/tests/utils/ConfigurationSchema.test.ts
@@ -776,8 +776,8 @@ await describe('ConfigurationSchema', async () => {
         assert.ok(!result.success)
         const paths = result.error.issues.map(i => i.path.join('.'))
         assert.ok(
-          paths.some(p => p.includes('allowLoopbackProxy') || p.includes('trustedProxies')),
-          `Expected error path naming allowLoopbackProxy or trustedProxies in ${JSON.stringify(paths)}`
+          paths.includes('uiServer.accessPolicy.trustedProxies'),
+          `Expected error path 'uiServer.accessPolicy.trustedProxies' in ${JSON.stringify(paths)}`
         )
       })
 

--- a/tests/utils/ConfigurationSchema.test.ts
+++ b/tests/utils/ConfigurationSchema.test.ts
@@ -667,8 +667,8 @@ await describe('ConfigurationSchema', async () => {
           })
         )
         assert.ok(!result.success)
-        const usernameIssues = result.error.issues.filter(i =>
-          i.path.join('.').includes('uiServer.authentication.username')
+        const usernameIssues = result.error.issues.filter(
+          i => i.path.join('.') === 'uiServer.authentication.username'
         )
         assert.ok(usernameIssues.length > 0)
         assert.ok(

--- a/ui/common/src/config/schema.ts
+++ b/ui/common/src/config/schema.ts
@@ -19,8 +19,9 @@ export const THEME_IDS = [
  * string without `':'` (RFC 7617); `password` is a non-empty string. Both are
  * required when `enabled` is true and `type === 'protocol-basic-auth'`.
  * Field-level constraints fire unconditionally — intentionally stricter than
- * the runtime auth flow to block dormant Basic-Auth bypasses across hot-reload
- * toggles of `enabled`.
+ * the runtime auth flow so empty placeholders cannot ship under
+ * `enabled: false` and become a Basic-Auth bypass on the next boot with
+ * `enabled: true`.
  */
 export const authenticationConfigSchema = z
   .object({

--- a/ui/common/src/config/schema.ts
+++ b/ui/common/src/config/schema.ts
@@ -14,30 +14,46 @@ export const THEME_IDS = [
   'tokyo-night-storm',
 ] as const
 
+/**
+ * authenticationConfig — Web UI client credentials. `username` is a non-empty
+ * string without `':'` (RFC 7617); `password` is a non-empty string. Both are
+ * required when `enabled` is true and `type === 'protocol-basic-auth'`.
+ * Field-level constraints fire unconditionally — intentionally stricter than
+ * the runtime auth flow to block dormant Basic-Auth bypasses across hot-reload
+ * toggles of `enabled`.
+ */
 export const authenticationConfigSchema = z
   .object({
     enabled: z.boolean(),
-    password: z.string().optional(),
+    password: z.string().min(1).optional(),
     type: z.enum(AuthenticationType),
     username: z
       .string()
-      .regex(/^[^:]*$/, 'must not contain ":"')
+      .min(1)
+      .refine(value => !value.includes(':'), {
+        message: "must not contain ':' (RFC 7617)",
+      })
       .optional(),
   })
-  .refine(
-    data =>
-      !data.enabled ||
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      data.type !== AuthenticationType.PROTOCOL_BASIC_AUTH ||
-      (data.username != null &&
-        data.username.length > 0 &&
-        data.password != null &&
-        data.password.length > 0),
-    {
-      message:
-        'username and password are required when authentication is enabled with protocol-basic-auth',
+  .superRefine((value, ctx) => {
+    if (!value.enabled) return
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (value.type !== AuthenticationType.PROTOCOL_BASIC_AUTH) return
+    if (value.username == null) {
+      ctx.addIssue({
+        code: 'custom',
+        message: "'username' is required when authentication is enabled with protocol-basic-auth",
+        path: ['username'],
+      })
     }
-  )
+    if (value.password == null) {
+      ctx.addIssue({
+        code: 'custom',
+        message: "'password' is required when authentication is enabled with protocol-basic-auth",
+        path: ['password'],
+      })
+    }
+  })
 
 export const uiServerConfigSchema = z.object({
   authentication: authenticationConfigSchema.optional(),

--- a/ui/common/tests/config.test.ts
+++ b/ui/common/tests/config.test.ts
@@ -118,6 +118,15 @@ await describe('config schema validation', async () => {
       version: '0.0.1',
     })
     assert.strictEqual(result.success, false)
+    const paths = result.error.issues.map(i => i.path.join('.'))
+    assert.ok(
+      paths.includes('authentication.username'),
+      `Expected error path 'authentication.username' in ${JSON.stringify(paths)}`
+    )
+    assert.ok(
+      paths.includes('authentication.password'),
+      `Expected error path 'authentication.password' in ${JSON.stringify(paths)}`
+    )
   })
 
   await it('should reject auth config when enabled with protocol-basic-auth but empty username', () => {
@@ -134,6 +143,96 @@ await describe('config schema validation', async () => {
       version: '0.0.1',
     })
     assert.strictEqual(result.success, false)
+    const paths = result.error.issues.map(i => i.path.join('.'))
+    assert.ok(
+      paths.includes('authentication.username'),
+      `Expected error path 'authentication.username' in ${JSON.stringify(paths)}`
+    )
+  })
+
+  await it('should reject auth config when enabled with protocol-basic-auth but empty password', () => {
+    const result = uiServerConfigSchema.safeParse({
+      authentication: {
+        enabled: true,
+        password: '',
+        type: 'protocol-basic-auth',
+        username: 'admin',
+      },
+      host: 'localhost',
+      port: 8080,
+      protocol: 'ui',
+      version: '0.0.1',
+    })
+    assert.strictEqual(result.success, false)
+    const paths = result.error.issues.map(i => i.path.join('.'))
+    assert.ok(
+      paths.includes('authentication.password'),
+      `Expected error path 'authentication.password' in ${JSON.stringify(paths)}`
+    )
+  })
+
+  await it("should reject auth config when username contains ':' (RFC 7617)", () => {
+    const result = uiServerConfigSchema.safeParse({
+      authentication: {
+        enabled: true,
+        password: 'admin',
+        type: 'protocol-basic-auth',
+        username: 'a:b',
+      },
+      host: 'localhost',
+      port: 8080,
+      protocol: 'ui',
+      version: '0.0.1',
+    })
+    assert.strictEqual(result.success, false)
+    const usernameIssues = result.error.issues.filter(
+      i => i.path.join('.') === 'authentication.username'
+    )
+    assert.ok(usernameIssues.length > 0)
+    assert.ok(
+      usernameIssues.some(i => i.message.includes('RFC 7617')),
+      `Expected an issue mentioning 'RFC 7617' in ${JSON.stringify(usernameIssues)}`
+    )
+  })
+
+  await it('should reject auth config when enabled with password but no username', () => {
+    const result = uiServerConfigSchema.safeParse({
+      authentication: {
+        enabled: true,
+        password: 'admin',
+        type: 'protocol-basic-auth',
+      },
+      host: 'localhost',
+      port: 8080,
+      protocol: 'ui',
+      version: '0.0.1',
+    })
+    assert.strictEqual(result.success, false)
+    const paths = result.error.issues.map(i => i.path.join('.'))
+    assert.ok(
+      paths.includes('authentication.username'),
+      `Expected error path 'authentication.username' in ${JSON.stringify(paths)}`
+    )
+  })
+
+  await it('should reject auth config when enabled with username but no password', () => {
+    const result = uiServerConfigSchema.safeParse({
+      authentication: {
+        enabled: true,
+        type: 'protocol-basic-auth',
+        username: 'admin',
+      },
+      host: 'localhost',
+      port: 8080,
+      protocol: 'ui',
+      version: '0.0.1',
+    })
+    assert.strictEqual(result.success, false)
+    const paths = result.error.issues.map(i => i.path.join('.'))
+    assert.ok(
+      paths.includes('authentication.password'),
+      `Expected error path 'authentication.password' in ${JSON.stringify(paths)}`
+    )
   })
 
   await it('should accept auth config when enabled with protocol-basic-auth and credentials present', () => {


### PR DESCRIPTION
## Summary

Audit pass over `uiServer.*` primitives that PR #1901 left under-constrained. Five Zod constraints close concrete fail-fast gaps where the simulator currently accepts a misconfiguration at boot and bypasses Basic-Auth (or silently ignores access-policy intent) at runtime.

**Phase 0 finding**: P1 as literally described (`port: "not-a-number"` boots and crashes later) is already fixed on `main` (`19afcb28`, PR #1901). This PR ships the **audit findings** that the single-thread fix missed — surfaced by a strict 3-angle design pass with cross-validation.

---

## Consolidated design (from `/tmp/design-consolidated.md`)

### Schema changes (KEEP — all 3-of-3 unanimous or 2-of-3 + Agent C "SAFE")

| # | Field | Constraint | Angles |
|---|---|---|---|
| 1 | `uiServer.authentication.username` | `z.string().min(1).optional()` | A+B+C |
| 2 | `uiServer.authentication.password` | `z.string().min(1).optional()` | A+B+C |
| 3 | `uiServer.authentication.username` | `.refine(v => !v.includes(':'), 'RFC 7617')` (lifts runtime check at `UIServerFactory.ts:48-54` to schema) | A+B+C |
| 4 | `uiServer.authentication` (object-level) | `.refine`: `enabled === true` ⇒ `username` and `password` required | A+B (with C-mitigation) |
| 5 | `uiServer.accessPolicy` (object-level) | `.refine`: `allowLoopbackProxy === true` ⇒ `trustedProxies.length >= 1` | A+C |

### Test fixture update (Agent C mitigation R2)

`tests/utils/ConfigurationSchema.test.ts` — the unknown-key test for `uiServer.authentication` (formerly relied on `{ enabled: true, type: 'protocol-basic-auth', bogusAuthKey: 'x' }` with no creds) now includes valid `username: 'u'`, `password: 'p'` so the unknown-key intent stays unambiguous after the new object-level superRefine. Assertion strengthened to check the issue path explicitly mentions `uiServer.authentication`.

### What did NOT survive cross-validation

| Proposal | Verdict | Reason |
|---|---|---|
| `accessPolicy.requireTlsForNonLoopback=false × non-loopback host` refine | **REJECT** | Agent C: breaks `docker/config.json:18` (`host: "::"` + `requireTls: false` is intentional, loopback-only via docker-compose binding). |
| `uiServer.type × version` coupling (ws/mcp ⇒ '1.1') | **DEFER** | Coupled to in-place mutation bug at `UIServerFactory.ts:69` — needs separate cleanup PR first. |
| `uiServer.type × authentication.type` coupling (basic-auth on http/mcp) | **DEFER** | Defense-in-depth at runtime (`UIServerFactory.ts:30-79`) intentional; schema-encoding is a behavior change worth a separate PR. |
| `options.{path,readableAll,writableAll,ipv6Only}` refinements | **DEFER** | Single-angle, no shipped config or test exercises these. Low-value protective constraints. |
| `accessPolicy.*` array dedup | **DEFER** | Single-angle, low value. |
| `log.*`, `worker.*`, `performanceStorage.*`, `stationTemplateUrls.*`, `supervisionUrls` tightening | **OUT-OF-SCOPE** | Outside `uiServer.*`. Belongs in separate per-subsystem PRs. |

---

## RED → GREEN evidence

### RED — initial test run before schema changes

```
$ NODE_ENV=test node --import tsx --test --test-force-exit tests/utils/ConfigurationSchema.test.ts
✖ ConfigurationSchema (31.4505ms)
ℹ tests 114
ℹ pass 108
ℹ fail 6
✖ failing tests:
✖ should reject empty username (4.779917ms)
✖ should reject empty password (0.472709ms)
✖ should reject username containing ':' (RFC 7617) (0.243208ms)
✖ should reject authentication enabled without username and password (0.194167ms)
✖ should reject authentication enabled with username but no password (0.176209ms)
✖ should reject allowLoopbackProxy=true with empty trustedProxies (0.221792ms)
```

6/9 new tests fail; 3 acceptance-path regressions pass against the existing schema (correctly).

### GREEN — after schema changes

```
$ NODE_ENV=test node --import tsx --test --test-force-exit tests/utils/ConfigurationSchema.test.ts
✔ ConfigurationSchema (26.090875ms)
ℹ tests 114
ℹ pass 114
ℹ fail 0
ℹ duration_ms 2355.834417
```

### Boot-time fail-fast — 3 reproductions on the built simulator

Setup: `pnpm build && pnpm --filter cli build && cp dist/assets/config.json /tmp/config-backup-pr1.json`

#### Reproduction 1 (regression of #1901): `uiServer.options.port = "not-a-number"`

```shell
$ jq '.uiServer.options.port = "not-a-number"' /tmp/config-backup-pr1.json > dist/assets/config.json
$ timeout 8 node --enable-source-maps dist/start.js > /dev/null 2> /tmp/pr1-port.stderr
$ tail /tmp/pr1-port.stderr
6/15/2026, 7:33:33 PM Simulator configuration | ConfigurationValidation: Configuration validation failed [schema] for '/.../dist/assets/config.json':
  - uiServer.options.port: Invalid input: expected number, received string
node-exit=1
```

#### Reproduction 2 (NEW): `uiServer.authentication.username = ""`

```shell
$ jq '.uiServer.authentication.username = ""' /tmp/config-backup-pr1.json > dist/assets/config.json
$ timeout 8 node --enable-source-maps dist/start.js > /dev/null 2> /tmp/pr1-username.stderr
$ tail /tmp/pr1-username.stderr
6/15/2026, 7:33:35 PM Simulator configuration | ConfigurationValidation: Configuration validation failed [schema] for '/.../dist/assets/config.json':
  - uiServer.authentication.username: Too small: expected string to have >=1 characters
node-exit=1
```

#### Reproduction 3 (NEW): `uiServer.accessPolicy.allowLoopbackProxy = true` with empty `trustedProxies`

```shell
$ jq '.uiServer.accessPolicy.allowLoopbackProxy = true' /tmp/config-backup-pr1.json > dist/assets/config.json
$ timeout 8 node --enable-source-maps dist/start.js > /dev/null 2> /tmp/pr1-policy.stderr
$ tail /tmp/pr1-policy.stderr
6/15/2026, 7:33:36 PM Simulator configuration | ConfigurationValidation: Configuration validation failed [schema] for '/.../dist/assets/config.json':
  - uiServer.accessPolicy.allowLoopbackProxy: 'allowLoopbackProxy' requires at least one entry in 'trustedProxies'
node-exit=1
```

All three fail-fast at boot via `ConfigurationValidationError` (`phase: 'schema'`) routed through the existing `Configuration.ts:160-175` exit path. No production-runtime crash.

---

## Quality gates

| Command | Result |
|---|---|
| `pnpm --filter . typecheck` | exit 0 |
| `pnpm --filter . lint` | exit 0 |
| `pnpm format` | clean |
| `pnpm test` | 2747 pass / 0 fail / 6 skipped (was 2738 baseline + 9 new) |
| `pnpm circular-deps \| grep -c '^ [0-9]\+\.'` | 62 (= baseline) |
| Reproduction 1 (port) | exit 1, structured Zod path |
| Reproduction 2 (username) | exit 1, structured Zod path |
| Reproduction 3 (allowLoopbackProxy) | exit 1, structured Zod path |

---

## Master risk register (Agent C-driven, with mitigations applied)

| # | Risk | Mitigation in this PR |
|---|---|---|
| **R1** | `username`/`password` `min(1)` could break configs with empty placeholders when `enabled: false` | All 5 shipped configs (`src/assets/config-template.json:31-32`, `src/assets/config.json:28-29`, `dist/assets/config.json:28-29`, `docker/config.json:32-33`, `tests/utils/ConfigurationSchema.test.ts:188-190`) use non-empty values. Verified zero breakage. |
| **R2** | `enabled=true ⇒ creds required` superRefine masks the unknown-key test fixture | Fixture updated: `bogusAuthKey: 'x'` now sits alongside valid `username: 'u'`, `password: 'p'`. Assertion strengthened to require the issue path includes `uiServer.authentication`. |
| **R3** | Promoting `UIServerFactory.ts:30-79` runtime checks to schema is a behavior change | NOT done in this PR. Defense-in-depth runtime checks remain. The `type×version` and `type×auth` couplings are deferred until the in-place mutation bug at `Factory.ts:69` is fixed in a separate PR. |
| **R4** | Hot-reload of `uiServer.options` (port/host) does NOT take effect — `Bootstrap.ts:103,161` instantiates `uiServer` once | Documented gap, OUT-OF-SCOPE for the schema-tightening PR. Schema validation does not regress this; it only blocks bad values from reaching the running server's stale config cache. Separate wiring PR candidate. |
| **R5** | `dist/assets/config.json:29` ships with a production-shaped password | OUT-OF-SCOPE separate finding; surfacing it here for maintainer awareness. |
| **R6** | In-place mutation at `UIServerFactory.ts:69` poisons `Configuration.configurationSectionCache` | OUT-OF-SCOPE; would be addressed when the type×version schema coupling is added (R3 follow-up). |
| **R7** | `accessPolicy.requireTlsForNonLoopback=false × non-loopback host` refine would break `docker/config.json:18-25` | **REJECTED** — refine NOT added. |
| **R8** | `accessPolicy.allowLoopbackProxy=true ⇒ trustedProxies non-empty` may surprise users currently running with both | No shipped config triggers this combination (`docker/config.json:24-26` has `allowLoopbackProxy: false, trustedProxies: []`). Safe. New regression-anchor test asserts the docker shape still passes. |

---

## Open questions surfaced by the audit (no action this round)

1. `port: 0` semantics (ephemeral) — PR #1901 picked `min(0)`; confirm intent.
2. Cross-enum guard policy in `payloadBuilders.ts` (Agent A) — maintainer policy decision.
3. Missing `numberOfStation` (singular) and `performanceStorage.URI` (uppercase) migrations vs. their `@deprecated` schema descriptors — Agent B finding; separate `feat(config-migration)` PR candidate.
4. Hot-reload of `uiServer.options` not taking effect (R4) — separate wiring PR.

---

## Out of scope

- OCPP wire schema, station templates — not touched.
- `BaseError` / `OCPPError` class hierarchy — not refactored.
- Other Zod sub-schemas (LogConfigurationSchema, WorkerConfigurationSchema, StorageConfigurationSchema, StationTemplateUrlSchema, supervisionUrls) — Agent B's broader audit findings belong in separate PRs scoped to those subsystems.
- Hot-reload wiring for `uiServer.options` (R4) — separate PR.

## Severity

MAJOR — closes concrete fail-fast gaps in Basic-Auth and access-policy enforcement that the prior single-thread fix missed.