### PR TITLE
fix(ui-server): classify broadcast responses without handlers

### DIFF
--- a/src/charging-station/broadcast-channel/UIServiceWorkerBroadcastChannel.ts
+++ b/src/charging-station/broadcast-channel/UIServiceWorkerBroadcastChannel.ts
@@ -111,9 +111,12 @@ export class UIServiceWorkerBroadcastChannel extends WorkerBroadcastChannel {
     }
     const responses = this.responses.get(uuid)
     if (responses != null && responses.responsesReceived >= responses.responsesExpected) {
-      this.uiService.sendResponse(uuid, this.buildResponsePayload(uuid))
-      this.responses.delete(uuid)
-      this.uiService.deleteBroadcastChannelRequest(uuid)
+      try {
+        this.uiService.sendResponse(uuid, this.buildResponsePayload(uuid))
+      } finally {
+        this.responses.delete(uuid)
+        this.uiService.deleteBroadcastChannelRequest(uuid)
+      }
     }
   }
 }

--- a/src/charging-station/broadcast-channel/UIServiceWorkerBroadcastChannel.ts
+++ b/src/charging-station/broadcast-channel/UIServiceWorkerBroadcastChannel.ts
@@ -111,6 +111,7 @@ export class UIServiceWorkerBroadcastChannel extends WorkerBroadcastChannel {
     }
     const responses = this.responses.get(uuid)
     if (responses != null && responses.responsesReceived >= responses.responsesExpected) {
+      // Always release aggregation state, even if downstream sendResponse throws.
       try {
         this.uiService.sendResponse(uuid, this.buildResponsePayload(uuid))
       } finally {

--- a/src/charging-station/ui-server/AbstractUIServer.ts
+++ b/src/charging-station/ui-server/AbstractUIServer.ts
@@ -300,7 +300,7 @@ export abstract class AbstractUIServer {
     this.registerProtocolVersionUIService(protocolVersion)
     return await (this.uiServices
       .get(protocolVersion)
-      ?.requestHandler(request) as Promise<ProtocolResponse>)
+      ?.requestHandler(request, { origin: 'internal' }) as Promise<ProtocolResponse>)
   }
 
   public abstract sendRequest (request: ProtocolRequest): void

--- a/src/charging-station/ui-server/AbstractUIServer.ts
+++ b/src/charging-station/ui-server/AbstractUIServer.ts
@@ -22,6 +22,7 @@ import {
   ProtocolVersion,
   type RequestPayload,
   type ResponsePayload,
+  UIRequestOrigin,
   type UIServerConfiguration,
   type UUIDv4,
 } from '../../types/index.js'
@@ -300,7 +301,7 @@ export abstract class AbstractUIServer {
     this.registerProtocolVersionUIService(protocolVersion)
     return await (this.uiServices
       .get(protocolVersion)
-      ?.requestHandler(request, { origin: 'internal' }) as Promise<ProtocolResponse>)
+      ?.requestHandler(request, { origin: UIRequestOrigin.INTERNAL }) as Promise<ProtocolResponse>)
   }
 
   public abstract sendRequest (request: ProtocolRequest): void

--- a/src/charging-station/ui-server/ui-services/AbstractUIService.ts
+++ b/src/charging-station/ui-server/ui-services/AbstractUIService.ts
@@ -11,12 +11,15 @@ import {
   type JsonType,
   ProcedureName,
   type ProtocolRequest,
+  type ProtocolRequestHandler,
   type ProtocolResponse,
   type ProtocolVersion,
   type RequestPayload,
   type ResponsePayload,
   ResponseStatus,
   type StorageConfiguration,
+  type UIRequestContext,
+  UIRequestOrigin,
   type UUIDv4,
 } from '../../../types/index.js'
 import {
@@ -51,19 +54,6 @@ interface BroadcastResponseLogContext {
   readonly status: ResponseStatus
   readonly uuid: UUIDv4
 }
-
-interface UIRequestContext {
-  readonly origin: UIRequestOrigin
-}
-
-type UIRequestOrigin = 'internal' | 'transport'
-
-type UIServiceProtocolRequestHandler = (
-  uuid?: UUIDv4,
-  procedureName?: ProcedureName,
-  payload?: RequestPayload,
-  context?: UIRequestContext
-) => Promise<ResponsePayload> | Promise<undefined> | ResponsePayload | undefined
 
 export abstract class AbstractUIService {
   protected static readonly ProcedureNameToBroadCastChannelProcedureNameMapping = new Map<
@@ -124,7 +114,7 @@ export abstract class AbstractUIService {
     [ProcedureName.UNLOCK_CONNECTOR, BroadcastChannelProcedureName.UNLOCK_CONNECTOR],
   ])
 
-  protected readonly requestHandlers: Map<ProcedureName, UIServiceProtocolRequestHandler>
+  protected readonly requestHandlers: Map<ProcedureName, ProtocolRequestHandler>
   private active = true
   private readonly broadcastChannelRequests: Map<UUIDv4, BroadcastChannelRequestContext>
 
@@ -135,7 +125,7 @@ export abstract class AbstractUIService {
   constructor (uiServer: AbstractUIServer, version: ProtocolVersion) {
     this.uiServer = uiServer
     this.version = version
-    this.requestHandlers = new Map<ProcedureName, UIServiceProtocolRequestHandler>([
+    this.requestHandlers = new Map<ProcedureName, ProtocolRequestHandler>([
       [ProcedureName.ADD_CHARGING_STATIONS, this.handleAddChargingStations.bind(this)],
       [ProcedureName.LIST_CHARGING_STATIONS, this.handleListChargingStations.bind(this)],
       [ProcedureName.LIST_TEMPLATES, this.handleListTemplates.bind(this)],
@@ -162,7 +152,7 @@ export abstract class AbstractUIService {
 
   public async requestHandler (
     request: ProtocolRequest,
-    context: UIRequestContext = { origin: 'transport' }
+    context: UIRequestContext = { origin: UIRequestOrigin.TRANSPORT }
   ): Promise<ProtocolResponse | undefined> {
     let uuid: undefined | UUIDv4
     let command: ProcedureName | undefined
@@ -241,7 +231,7 @@ export abstract class AbstractUIService {
     uuid?: UUIDv4,
     procedureName?: ProcedureName,
     payload?: RequestPayload,
-    context: UIRequestContext = { origin: 'transport' }
+    context: UIRequestContext = { origin: UIRequestOrigin.TRANSPORT }
   ): undefined {
     if (uuid == null || procedureName == null || payload == null) {
       throw new BaseError('Invalid protocol request')

--- a/src/charging-station/ui-server/ui-services/AbstractUIService.ts
+++ b/src/charging-station/ui-server/ui-services/AbstractUIService.ts
@@ -115,8 +115,8 @@ export abstract class AbstractUIService {
   ])
 
   protected readonly requestHandlers: Map<ProcedureName, ProtocolRequestHandler>
-  private active = true
   private readonly broadcastChannelRequests: Map<UUIDv4, BroadcastChannelRequestContext>
+  private stopped = false
 
   private readonly uiServer: AbstractUIServer
   private readonly uiServiceWorkerBroadcastChannel: UIServiceWorkerBroadcastChannel
@@ -222,7 +222,7 @@ export abstract class AbstractUIService {
   }
 
   public stop (): void {
-    this.active = false
+    this.stopped = true
     this.broadcastChannelRequests.clear()
     this.uiServiceWorkerBroadcastChannel.close()
   }
@@ -421,14 +421,14 @@ export abstract class AbstractUIService {
     const requestContext = this.broadcastChannelRequests.get(uuid)
     const logContext = this.buildBroadcastResponseLogContext(uuid, responsePayload, requestContext)
     if (requestContext == null) {
-      if (this.active) {
-        logger.warn(
-          `${this.logPrefix(moduleName, 'sendResponse')} Dropping untracked broadcast response:`,
+      if (this.stopped) {
+        logger.debug(
+          `${this.logPrefix(moduleName, 'sendResponse')} Dropping late broadcast response after UI service stop:`,
           logContext
         )
       } else {
-        logger.debug(
-          `${this.logPrefix(moduleName, 'sendResponse')} Dropping late broadcast response after UI service stop:`,
+        logger.warn(
+          `${this.logPrefix(moduleName, 'sendResponse')} Dropping untracked broadcast response:`,
           logContext
         )
       }
@@ -484,6 +484,7 @@ export abstract class AbstractUIService {
       origin: context.origin,
       procedureName,
     })
+    // Rollback expected-response accounting if dispatch to the worker channel throws.
     try {
       this.uiServiceWorkerBroadcastChannel.sendRequest([uuid, procedureName, payload])
     } catch (error) {

--- a/src/charging-station/ui-server/ui-services/AbstractUIService.ts
+++ b/src/charging-station/ui-server/ui-services/AbstractUIService.ts
@@ -11,7 +11,6 @@ import {
   type JsonType,
   ProcedureName,
   type ProtocolRequest,
-  type ProtocolRequestHandler,
   type ProtocolResponse,
   type ProtocolVersion,
   type RequestPayload,
@@ -24,7 +23,6 @@ import {
   Configuration,
   ensureError,
   getErrorMessage,
-  isAsyncFunction,
   isNotEmptyArray,
   logger,
 } from '../../../utils/index.js'
@@ -38,6 +36,34 @@ interface AddChargingStationsRequestPayload extends RequestPayload {
   options?: ChargingStationOptions
   template: string
 }
+
+interface BroadcastChannelRequestContext {
+  readonly expectedResponses: number
+  readonly origin: UIRequestOrigin
+  readonly procedureName: BroadcastChannelProcedureName
+}
+
+interface BroadcastResponseLogContext {
+  readonly hashIdsFailed?: string[]
+  readonly hashIdsSucceeded?: string[]
+  readonly origin?: UIRequestOrigin
+  readonly procedureName?: BroadcastChannelProcedureName
+  readonly status: ResponseStatus
+  readonly uuid: UUIDv4
+}
+
+interface UIRequestContext {
+  readonly origin: UIRequestOrigin
+}
+
+type UIRequestOrigin = 'internal' | 'transport'
+
+type UIServiceProtocolRequestHandler = (
+  uuid?: UUIDv4,
+  procedureName?: ProcedureName,
+  payload?: RequestPayload,
+  context?: UIRequestContext
+) => Promise<ResponsePayload> | Promise<undefined> | ResponsePayload | undefined
 
 export abstract class AbstractUIService {
   protected static readonly ProcedureNameToBroadCastChannelProcedureNameMapping = new Map<
@@ -98,8 +124,9 @@ export abstract class AbstractUIService {
     [ProcedureName.UNLOCK_CONNECTOR, BroadcastChannelProcedureName.UNLOCK_CONNECTOR],
   ])
 
-  protected readonly requestHandlers: Map<ProcedureName, ProtocolRequestHandler>
-  private readonly broadcastChannelRequests: Map<UUIDv4, number>
+  protected readonly requestHandlers: Map<ProcedureName, UIServiceProtocolRequestHandler>
+  private active = true
+  private readonly broadcastChannelRequests: Map<UUIDv4, BroadcastChannelRequestContext>
 
   private readonly uiServer: AbstractUIServer
   private readonly uiServiceWorkerBroadcastChannel: UIServiceWorkerBroadcastChannel
@@ -108,7 +135,7 @@ export abstract class AbstractUIService {
   constructor (uiServer: AbstractUIServer, version: ProtocolVersion) {
     this.uiServer = uiServer
     this.version = version
-    this.requestHandlers = new Map<ProcedureName, ProtocolRequestHandler>([
+    this.requestHandlers = new Map<ProcedureName, UIServiceProtocolRequestHandler>([
       [ProcedureName.ADD_CHARGING_STATIONS, this.handleAddChargingStations.bind(this)],
       [ProcedureName.LIST_CHARGING_STATIONS, this.handleListChargingStations.bind(this)],
       [ProcedureName.LIST_TEMPLATES, this.handleListTemplates.bind(this)],
@@ -118,7 +145,7 @@ export abstract class AbstractUIService {
       [ProcedureName.STOP_SIMULATOR, this.handleStopSimulator.bind(this)],
     ])
     this.uiServiceWorkerBroadcastChannel = new UIServiceWorkerBroadcastChannel(this)
-    this.broadcastChannelRequests = new Map<UUIDv4, number>()
+    this.broadcastChannelRequests = new Map<UUIDv4, BroadcastChannelRequestContext>()
   }
 
   public deleteBroadcastChannelRequest (uuid: UUIDv4): void {
@@ -126,14 +153,17 @@ export abstract class AbstractUIService {
   }
 
   public getBroadcastChannelExpectedResponses (uuid: UUIDv4): number {
-    return this.broadcastChannelRequests.get(uuid) ?? 0
+    return this.broadcastChannelRequests.get(uuid)?.expectedResponses ?? 0
   }
 
   public logPrefix = (modName: string, methodName: string): string => {
     return this.uiServer.logPrefix(modName, methodName, this.version)
   }
 
-  public async requestHandler (request: ProtocolRequest): Promise<ProtocolResponse | undefined> {
+  public async requestHandler (
+    request: ProtocolRequest,
+    context: UIRequestContext = { origin: 'transport' }
+  ): Promise<ProtocolResponse | undefined> {
     let uuid: undefined | UUIDv4
     let command: ProcedureName | undefined
     let requestPayload: RequestPayload | undefined
@@ -156,17 +186,7 @@ export abstract class AbstractUIService {
       if (requestHandler == null) {
         throw new BaseError(`'${command}' request handler not found`)
       }
-      if (isAsyncFunction(requestHandler)) {
-        responsePayload = await requestHandler(uuid, command, requestPayload)
-      } else {
-        responsePayload = (
-          requestHandler as (
-            uuid?: string,
-            procedureName?: ProcedureName,
-            payload?: RequestPayload
-          ) => ResponsePayload | undefined
-        )(uuid, command, requestPayload)
-      }
+      responsePayload = await requestHandler(uuid, command, requestPayload, context)
     } catch (error) {
       // Log
       logger.error(`${this.logPrefix(moduleName, 'requestHandler')} Handle request error:`, error)
@@ -206,30 +226,54 @@ export abstract class AbstractUIService {
   public sendResponse (uuid: UUIDv4, responsePayload: ResponsePayload): void {
     if (this.uiServer.hasResponseHandler(uuid)) {
       this.uiServer.sendResponse(this.uiServer.buildProtocolResponse(uuid, responsePayload))
-    } else {
-      logger.warn(`${this.logPrefix(moduleName, 'sendResponse')} Response handler not found:`, {
-        responsePayload,
-        uuid,
-      })
+      return
     }
+    this.logBroadcastResponseWithoutHandler(uuid, responsePayload)
   }
 
   public stop (): void {
+    this.active = false
     this.broadcastChannelRequests.clear()
     this.uiServiceWorkerBroadcastChannel.close()
   }
 
   protected handleProtocolRequest (
-    uuid: UUIDv4,
-    procedureName: ProcedureName,
-    payload: RequestPayload
-  ): void {
+    uuid?: UUIDv4,
+    procedureName?: ProcedureName,
+    payload?: RequestPayload,
+    context: UIRequestContext = { origin: 'transport' }
+  ): undefined {
+    if (uuid == null || procedureName == null || payload == null) {
+      throw new BaseError('Invalid protocol request')
+    }
     const broadCastChannelProcedureName =
       AbstractUIService.ProcedureNameToBroadCastChannelProcedureNameMapping.get(procedureName)
     if (broadCastChannelProcedureName == null) {
       throw new BaseError(`No broadcast channel mapping for procedure '${procedureName}'`)
     }
-    this.sendBroadcastChannelRequest(uuid, broadCastChannelProcedureName, payload)
+    this.sendBroadcastChannelRequest(uuid, broadCastChannelProcedureName, payload, context)
+    return undefined
+  }
+
+  private buildBroadcastResponseLogContext (
+    uuid: UUIDv4,
+    responsePayload: ResponsePayload,
+    requestContext?: BroadcastChannelRequestContext
+  ): BroadcastResponseLogContext {
+    return {
+      ...(responsePayload.hashIdsFailed != null && {
+        hashIdsFailed: responsePayload.hashIdsFailed,
+      }),
+      ...(responsePayload.hashIdsSucceeded != null && {
+        hashIdsSucceeded: responsePayload.hashIdsSucceeded,
+      }),
+      ...(requestContext != null && {
+        origin: requestContext.origin,
+        procedureName: requestContext.procedureName,
+      }),
+      status: responsePayload.status,
+      uuid,
+    }
   }
 
   private async handleAddChargingStations (
@@ -386,10 +430,41 @@ export abstract class AbstractUIService {
     }
   }
 
+  private logBroadcastResponseWithoutHandler (uuid: UUIDv4, responsePayload: ResponsePayload): void {
+    const requestContext = this.broadcastChannelRequests.get(uuid)
+    const logContext = this.buildBroadcastResponseLogContext(uuid, responsePayload, requestContext)
+    if (requestContext == null) {
+      if (this.active) {
+        logger.warn(
+          `${this.logPrefix(moduleName, 'sendResponse')} Dropping untracked broadcast response:`,
+          logContext
+        )
+      } else {
+        logger.debug(
+          `${this.logPrefix(moduleName, 'sendResponse')} Dropping late broadcast response after UI service stop:`,
+          logContext
+        )
+      }
+      return
+    }
+    if (responsePayload.status === ResponseStatus.SUCCESS) {
+      logger.debug(
+        `${this.logPrefix(moduleName, 'sendResponse')} Broadcast response completed without transport handler:`,
+        logContext
+      )
+      return
+    }
+    logger.warn(
+      `${this.logPrefix(moduleName, 'sendResponse')} Failed broadcast response completed without transport handler:`,
+      logContext
+    )
+  }
+
   private sendBroadcastChannelRequest (
     uuid: UUIDv4,
     procedureName: BroadcastChannelProcedureName,
-    payload: BroadcastChannelRequestPayload
+    payload: BroadcastChannelRequestPayload,
+    context: UIRequestContext
   ): void {
     if (isNotEmptyArray(payload.hashIds)) {
       payload.hashIds = payload.hashIds
@@ -417,7 +492,16 @@ export abstract class AbstractUIService {
         'hashIds array in the request payload does not contain any valid charging station hashId'
       )
     }
-    this.uiServiceWorkerBroadcastChannel.sendRequest([uuid, procedureName, payload])
-    this.broadcastChannelRequests.set(uuid, expectedNumberOfResponses)
+    this.broadcastChannelRequests.set(uuid, {
+      expectedResponses: expectedNumberOfResponses,
+      origin: context.origin,
+      procedureName,
+    })
+    try {
+      this.uiServiceWorkerBroadcastChannel.sendRequest([uuid, procedureName, payload])
+    } catch (error) {
+      this.broadcastChannelRequests.delete(uuid)
+      throw error
+    }
   }
 }

--- a/src/charging-station/ui-server/ui-services/AbstractUIService.ts
+++ b/src/charging-station/ui-server/ui-services/AbstractUIService.ts
@@ -34,6 +34,12 @@ import { DEFAULT_MAX_STATIONS, isValidNumberOfStations } from '../UIServerSecuri
 
 const moduleName = 'AbstractUIService'
 
+/**
+ * Structured payload of the `logger.{debug,warn}` calls emitted by
+ * {@link AbstractUIService.logBroadcastResponseWithoutHandler}. Fields are
+ * optional when the corresponding context is unavailable (untracked or
+ * late responses, payload without hashIds).
+ */
 export interface BroadcastChannelResponseLogContext {
   readonly hashIdsFailed?: string[]
   readonly hashIdsSucceeded?: string[]

--- a/src/charging-station/ui-server/ui-services/AbstractUIService.ts
+++ b/src/charging-station/ui-server/ui-services/AbstractUIService.ts
@@ -34,6 +34,15 @@ import { DEFAULT_MAX_STATIONS, isValidNumberOfStations } from '../UIServerSecuri
 
 const moduleName = 'AbstractUIService'
 
+export interface BroadcastChannelResponseLogContext {
+  readonly hashIdsFailed?: string[]
+  readonly hashIdsSucceeded?: string[]
+  readonly origin?: UIRequestOrigin
+  readonly procedureName?: BroadcastChannelProcedureName
+  readonly status: ResponseStatus
+  readonly uuid: UUIDv4
+}
+
 interface AddChargingStationsRequestPayload extends RequestPayload {
   numberOfStations: number
   options?: ChargingStationOptions
@@ -44,15 +53,6 @@ interface BroadcastChannelRequestContext {
   readonly expectedResponses: number
   readonly origin: UIRequestOrigin
   readonly procedureName: BroadcastChannelProcedureName
-}
-
-interface BroadcastResponseLogContext {
-  readonly hashIdsFailed?: string[]
-  readonly hashIdsSucceeded?: string[]
-  readonly origin?: UIRequestOrigin
-  readonly procedureName?: BroadcastChannelProcedureName
-  readonly status: ResponseStatus
-  readonly uuid: UUIDv4
 }
 
 export abstract class AbstractUIService {
@@ -228,14 +228,11 @@ export abstract class AbstractUIService {
   }
 
   protected handleProtocolRequest (
-    uuid?: UUIDv4,
-    procedureName?: ProcedureName,
-    payload?: RequestPayload,
+    uuid: UUIDv4,
+    procedureName: ProcedureName,
+    payload: RequestPayload,
     context: UIRequestContext = { origin: UIRequestOrigin.TRANSPORT }
   ): undefined {
-    if (uuid == null || procedureName == null || payload == null) {
-      throw new BaseError('Invalid protocol request')
-    }
     const broadCastChannelProcedureName =
       AbstractUIService.ProcedureNameToBroadCastChannelProcedureNameMapping.get(procedureName)
     if (broadCastChannelProcedureName == null) {
@@ -249,7 +246,7 @@ export abstract class AbstractUIService {
     uuid: UUIDv4,
     responsePayload: ResponsePayload,
     requestContext?: BroadcastChannelRequestContext
-  ): BroadcastResponseLogContext {
+  ): BroadcastChannelResponseLogContext {
     return {
       ...(responsePayload.hashIdsFailed != null && {
         hashIdsFailed: responsePayload.hashIdsFailed,
@@ -439,13 +436,13 @@ export abstract class AbstractUIService {
     }
     if (responsePayload.status === ResponseStatus.SUCCESS) {
       logger.debug(
-        `${this.logPrefix(moduleName, 'sendResponse')} Broadcast response completed without transport handler:`,
+        `${this.logPrefix(moduleName, 'sendResponse')} Broadcast response completed without response handler:`,
         logContext
       )
       return
     }
     logger.warn(
-      `${this.logPrefix(moduleName, 'sendResponse')} Failed broadcast response completed without transport handler:`,
+      `${this.logPrefix(moduleName, 'sendResponse')} Failed broadcast response completed without response handler:`,
       logContext
     )
   }

--- a/src/charging-station/ui-server/ui-services/UIService001.ts
+++ b/src/charging-station/ui-server/ui-services/UIService001.ts
@@ -1,16 +1,13 @@
 import type { AbstractUIServer } from '../AbstractUIServer.js'
 
-import { type ProtocolRequestHandler, ProtocolVersion } from '../../../types/index.js'
+import { ProtocolVersion } from '../../../types/index.js'
 import { AbstractUIService } from './AbstractUIService.js'
 
 export class UIService001 extends AbstractUIService {
   constructor (uiServer: AbstractUIServer) {
     super(uiServer, ProtocolVersion['0.0.1'])
     for (const procedureName of AbstractUIService.ProcedureNameToBroadCastChannelProcedureNameMapping.keys()) {
-      this.requestHandlers.set(
-        procedureName,
-        this.handleProtocolRequest.bind(this) as ProtocolRequestHandler
-      )
+      this.requestHandlers.set(procedureName, this.handleProtocolRequest.bind(this))
     }
   }
 }

--- a/src/types/UIProtocol.ts
+++ b/src/types/UIProtocol.ts
@@ -81,11 +81,11 @@ export type ProtocolNotification = [ServerNotification]
 export type ProtocolRequest = [UUIDv4, ProcedureName, RequestPayload]
 
 export type ProtocolRequestHandler = (
-  uuid?: UUIDv4,
-  procedureName?: ProcedureName,
-  payload?: RequestPayload,
+  uuid: UUIDv4,
+  procedureName: ProcedureName,
+  payload: RequestPayload,
   context?: UIRequestContext
-) => Promise<ResponsePayload> | Promise<undefined> | ResponsePayload | undefined
+) => Promise<ResponsePayload | undefined> | ResponsePayload | undefined
 
 export type ProtocolResponse = [UUIDv4, ResponsePayload]
 

--- a/src/types/UIProtocol.ts
+++ b/src/types/UIProtocol.ts
@@ -71,6 +71,12 @@ export enum ServerNotification {
   REFRESH = 'refresh',
 }
 
+/**
+ * Origin of a UI service request. Drives broadcast-response classification:
+ * `INTERNAL` requests originate from `AbstractUIServer.sendInternalRequest`
+ * (e.g. `Bootstrap.doStop`) and have no transport-side response handler.
+ * `TRANSPORT` requests originate from a UI client (WebSocket/HTTP/MCP).
+ */
 export enum UIRequestOrigin {
   INTERNAL = 'internal',
   TRANSPORT = 'transport',
@@ -80,6 +86,11 @@ export type ProtocolNotification = [ServerNotification]
 
 export type ProtocolRequest = [UUIDv4, ProcedureName, RequestPayload]
 
+/**
+ * Signature of any UI service request handler stored in the dispatch map.
+ * Sync or async; may return a payload or nothing. The optional `context`
+ * carries the request origin so broadcast handlers can classify late responses.
+ */
 export type ProtocolRequestHandler = (
   uuid: UUIDv4,
   procedureName: ProcedureName,
@@ -101,6 +112,10 @@ export interface ResponsePayload extends JsonObject {
   status: ResponseStatus
 }
 
+/**
+ * Context carried alongside a UI protocol request. Currently records only the
+ * request origin; additive fields are non-breaking.
+ */
 export interface UIRequestContext {
   readonly origin: UIRequestOrigin
 }

--- a/src/types/UIProtocol.ts
+++ b/src/types/UIProtocol.ts
@@ -71,6 +71,11 @@ export enum ServerNotification {
   REFRESH = 'refresh',
 }
 
+export enum UIRequestOrigin {
+  INTERNAL = 'internal',
+  TRANSPORT = 'transport',
+}
+
 export type ProtocolNotification = [ServerNotification]
 
 export type ProtocolRequest = [UUIDv4, ProcedureName, RequestPayload]
@@ -78,7 +83,8 @@ export type ProtocolRequest = [UUIDv4, ProcedureName, RequestPayload]
 export type ProtocolRequestHandler = (
   uuid?: UUIDv4,
   procedureName?: ProcedureName,
-  payload?: RequestPayload
+  payload?: RequestPayload,
+  context?: UIRequestContext
 ) => Promise<ResponsePayload> | Promise<undefined> | ResponsePayload | undefined
 
 export type ProtocolResponse = [UUIDv4, ResponsePayload]
@@ -93,4 +99,8 @@ export interface ResponsePayload extends JsonObject {
   hashIdsSucceeded?: string[]
   responsesFailed?: BroadcastChannelResponsePayload[]
   status: ResponseStatus
+}
+
+export interface UIRequestContext {
+  readonly origin: UIRequestOrigin
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -458,6 +458,8 @@ export {
   type ResponsePayload,
   ResponseStatus,
   ServerNotification,
+  type UIRequestContext,
+  UIRequestOrigin,
 } from './UIProtocol.js'
 export type { UUIDv4 } from './UUID.js'
 export {

--- a/tests/charging-station/ui-server/UIServerTestUtils.ts
+++ b/tests/charging-station/ui-server/UIServerTestUtils.ts
@@ -6,9 +6,11 @@ import type { IncomingMessage } from 'node:http'
 import type { Duplex } from 'node:stream'
 import type { mock } from 'node:test'
 
+import assert from 'node:assert/strict'
 import { EventEmitter, once } from 'node:events'
 
 import type { IBootstrap } from '../../../src/charging-station/IBootstrap.js'
+import type { BroadcastChannelResponseLogContext } from '../../../src/charging-station/ui-server/ui-services/AbstractUIService.js'
 import type {
   ChargingStationData,
   ProcedureName,
@@ -529,3 +531,39 @@ export const createMockChargingStationDataWithVersion = (
       templateName: 'test-template',
     },
   })
+
+interface LogMock {
+  readonly mock: {
+    readonly calls: readonly { readonly arguments: readonly unknown[] }[]
+  }
+}
+
+/**
+ * Assert that exactly one of the two `logger` levels was invoked with a
+ * message matching `pattern` and, optionally, a structured second argument
+ * deep-equal to `contextShape`.
+ * @param mocks - Tracked `logger.debug` and `logger.warn` mocks.
+ * @param mocks.debug - Mock tracking `logger.debug` invocations.
+ * @param mocks.warn - Mock tracking `logger.warn` invocations.
+ * @param level - Expected level for the single invocation.
+ * @param pattern - Regular expression the message must match.
+ * @param contextShape - Optional deep-equal shape for the second log argument.
+ */
+export const expectSingleLog = (
+  mocks: { readonly debug: LogMock; readonly warn: LogMock },
+  level: 'debug' | 'warn',
+  pattern: RegExp,
+  contextShape?: BroadcastChannelResponseLogContext
+): void => {
+  const [hit, miss] = level === 'debug' ? [mocks.debug, mocks.warn] : [mocks.warn, mocks.debug]
+  assert.strictEqual(miss.mock.calls.length, 0)
+  assert.strictEqual(hit.mock.calls.length, 1)
+  const [message, context] = hit.mock.calls[0]?.arguments ?? []
+  if (typeof message !== 'string') {
+    assert.fail(`Expected ${level} log message to be a string`)
+  }
+  assert.match(message, pattern)
+  if (contextShape != null) {
+    assert.deepStrictEqual(context, contextShape)
+  }
+}

--- a/tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts
+++ b/tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts
@@ -8,7 +8,13 @@ import { afterEach, describe, it } from 'node:test'
 
 import type { AbstractUIService } from '../../../../src/charging-station/ui-server/ui-services/AbstractUIService.js'
 
-import { ProcedureName, ProtocolVersion, ResponseStatus } from '../../../../src/types/index.js'
+import {
+  BroadcastChannelProcedureName,
+  ProcedureName,
+  ProtocolVersion,
+  ResponseStatus,
+  UIRequestOrigin,
+} from '../../../../src/types/index.js'
 import { logger } from '../../../../src/utils/Logger.js'
 import { standardCleanup } from '../../../helpers/TestLifecycleHelpers.js'
 import { TEST_HASH_ID, TEST_UUID } from '../UIServerTestConstants.js'
@@ -16,6 +22,7 @@ import {
   createMockChargingStationData,
   createMockUIServerConfiguration,
   createProtocolRequest,
+  expectSingleLog,
   TestableUIWebSocketServer,
 } from '../UIServerTestUtils.js'
 
@@ -179,8 +186,10 @@ await describe('AbstractUIService', async () => {
   })
 
   await it('should log internal successful broadcast responses without response handler at debug', async t => {
-    const warnMock = t.mock.method(logger, 'warn', () => undefined)
-    const debugMock = t.mock.method(logger, 'debug', () => undefined)
+    const mocks = {
+      debug: t.mock.method(logger, 'debug', () => undefined),
+      warn: t.mock.method(logger, 'warn', () => undefined),
+    }
     const { server, service } = createServiceContext()
 
     try {
@@ -190,21 +199,23 @@ await describe('AbstractUIService', async () => {
         status: ResponseStatus.SUCCESS,
       })
 
-      assert.strictEqual(warnMock.mock.calls.length, 0)
-      assert.strictEqual(debugMock.mock.calls.length, 1)
-      const debugMessage = debugMock.mock.calls[0]?.arguments[0]
-      if (typeof debugMessage !== 'string') {
-        assert.fail('Expected debug log message to be a string')
-      }
-      assert.match(debugMessage, /Broadcast response completed without response handler/)
+      expectSingleLog(mocks, 'debug', /Broadcast response completed without response handler/, {
+        hashIdsSucceeded: [TEST_HASH_ID],
+        origin: UIRequestOrigin.INTERNAL,
+        procedureName: BroadcastChannelProcedureName.STOP_CHARGING_STATION,
+        status: ResponseStatus.SUCCESS,
+        uuid: TEST_UUID,
+      })
     } finally {
       service.stop()
     }
   })
 
   await it('should warn on internal failed broadcast responses without response handler', async t => {
-    const warnMock = t.mock.method(logger, 'warn', () => undefined)
-    const debugMock = t.mock.method(logger, 'debug', () => undefined)
+    const mocks = {
+      debug: t.mock.method(logger, 'debug', () => undefined),
+      warn: t.mock.method(logger, 'warn', () => undefined),
+    }
     const { server, service } = createServiceContext()
 
     try {
@@ -214,21 +225,28 @@ await describe('AbstractUIService', async () => {
         status: ResponseStatus.FAILURE,
       })
 
-      assert.strictEqual(debugMock.mock.calls.length, 0)
-      assert.strictEqual(warnMock.mock.calls.length, 1)
-      const warnMessage = warnMock.mock.calls[0]?.arguments[0]
-      if (typeof warnMessage !== 'string') {
-        assert.fail('Expected warning log message to be a string')
-      }
-      assert.match(warnMessage, /Failed broadcast response completed without response handler/)
+      expectSingleLog(
+        mocks,
+        'warn',
+        /Failed broadcast response completed without response handler/,
+        {
+          hashIdsFailed: [TEST_HASH_ID],
+          origin: UIRequestOrigin.INTERNAL,
+          procedureName: BroadcastChannelProcedureName.STOP_CHARGING_STATION,
+          status: ResponseStatus.FAILURE,
+          uuid: TEST_UUID,
+        }
+      )
     } finally {
       service.stop()
     }
   })
 
   await it('should log transport successful broadcast responses without response handler at debug', async t => {
-    const warnMock = t.mock.method(logger, 'warn', () => undefined)
-    const debugMock = t.mock.method(logger, 'debug', () => undefined)
+    const mocks = {
+      debug: t.mock.method(logger, 'debug', () => undefined),
+      warn: t.mock.method(logger, 'warn', () => undefined),
+    }
     const { service } = createServiceContext()
 
     try {
@@ -238,21 +256,23 @@ await describe('AbstractUIService', async () => {
         status: ResponseStatus.SUCCESS,
       })
 
-      assert.strictEqual(warnMock.mock.calls.length, 0)
-      assert.strictEqual(debugMock.mock.calls.length, 1)
-      const debugMessage = debugMock.mock.calls[0]?.arguments[0]
-      if (typeof debugMessage !== 'string') {
-        assert.fail('Expected debug log message to be a string')
-      }
-      assert.match(debugMessage, /Broadcast response completed without response handler/)
+      expectSingleLog(mocks, 'debug', /Broadcast response completed without response handler/, {
+        hashIdsSucceeded: [TEST_HASH_ID],
+        origin: UIRequestOrigin.TRANSPORT,
+        procedureName: BroadcastChannelProcedureName.STOP_CHARGING_STATION,
+        status: ResponseStatus.SUCCESS,
+        uuid: TEST_UUID,
+      })
     } finally {
       service.stop()
     }
   })
 
   await it('should warn on transport failed broadcast responses without response handler', async t => {
-    const warnMock = t.mock.method(logger, 'warn', () => undefined)
-    const debugMock = t.mock.method(logger, 'debug', () => undefined)
+    const mocks = {
+      debug: t.mock.method(logger, 'debug', () => undefined),
+      warn: t.mock.method(logger, 'warn', () => undefined),
+    }
     const { service } = createServiceContext()
 
     try {
@@ -262,41 +282,47 @@ await describe('AbstractUIService', async () => {
         status: ResponseStatus.FAILURE,
       })
 
-      assert.strictEqual(debugMock.mock.calls.length, 0)
-      assert.strictEqual(warnMock.mock.calls.length, 1)
-      const warnMessage = warnMock.mock.calls[0]?.arguments[0]
-      if (typeof warnMessage !== 'string') {
-        assert.fail('Expected warning log message to be a string')
-      }
-      assert.match(warnMessage, /Failed broadcast response completed without response handler/)
+      expectSingleLog(
+        mocks,
+        'warn',
+        /Failed broadcast response completed without response handler/,
+        {
+          hashIdsFailed: [TEST_HASH_ID],
+          origin: UIRequestOrigin.TRANSPORT,
+          procedureName: BroadcastChannelProcedureName.STOP_CHARGING_STATION,
+          status: ResponseStatus.FAILURE,
+          uuid: TEST_UUID,
+        }
+      )
     } finally {
       service.stop()
     }
   })
 
   await it('should warn on untracked broadcast responses while service is active', t => {
-    const warnMock = t.mock.method(logger, 'warn', () => undefined)
-    const debugMock = t.mock.method(logger, 'debug', () => undefined)
+    const mocks = {
+      debug: t.mock.method(logger, 'debug', () => undefined),
+      warn: t.mock.method(logger, 'warn', () => undefined),
+    }
     const { service } = createServiceContext()
 
     try {
       service.sendResponse(TEST_UUID, { status: ResponseStatus.SUCCESS })
 
-      assert.strictEqual(debugMock.mock.calls.length, 0)
-      assert.strictEqual(warnMock.mock.calls.length, 1)
-      const warnMessage = warnMock.mock.calls[0]?.arguments[0]
-      if (typeof warnMessage !== 'string') {
-        assert.fail('Expected warning log message to be a string')
-      }
-      assert.match(warnMessage, /Dropping untracked broadcast response/)
+      expectSingleLog(mocks, 'warn', /Dropping untracked broadcast response/, {
+        status: ResponseStatus.SUCCESS,
+        uuid: TEST_UUID,
+      })
     } finally {
       service.stop()
     }
   })
 
   await it('should log late broadcast responses after service stop at debug', async t => {
-    const warnMock = t.mock.method(logger, 'warn', () => undefined)
-    const debugMock = t.mock.method(logger, 'debug', () => undefined)
+    const mocks = {
+      debug: t.mock.method(logger, 'debug', () => undefined),
+      warn: t.mock.method(logger, 'warn', () => undefined),
+    }
     const { service } = createServiceContext()
 
     try {
@@ -307,13 +333,33 @@ await describe('AbstractUIService', async () => {
         status: ResponseStatus.SUCCESS,
       })
 
-      assert.strictEqual(warnMock.mock.calls.length, 0)
-      assert.strictEqual(debugMock.mock.calls.length, 1)
-      const debugMessage = debugMock.mock.calls[0]?.arguments[0]
-      if (typeof debugMessage !== 'string') {
-        assert.fail('Expected debug log message to be a string')
+      expectSingleLog(mocks, 'debug', /Dropping late broadcast response/, {
+        hashIdsSucceeded: [TEST_HASH_ID],
+        status: ResponseStatus.SUCCESS,
+        uuid: TEST_UUID,
+      })
+    } finally {
+      service.stop()
+    }
+  })
+
+  await it('should rollback expected responses when broadcast dispatch throws', async t => {
+    const { service } = createServiceContext()
+    const channel = Reflect.get(service, 'uiServiceWorkerBroadcastChannel') as object
+    t.mock.method(channel as never, 'sendRequest' as never, (): never => {
+      throw new Error('dispatch failed')
+    })
+
+    try {
+      const response = await service.requestHandler(
+        createProtocolRequest(TEST_UUID, ProcedureName.STOP_CHARGING_STATION, {})
+      )
+
+      assert.notStrictEqual(response, undefined)
+      if (response != null) {
+        assert.strictEqual(response[1].status, ResponseStatus.FAILURE)
       }
-      assert.match(debugMessage, /Dropping late broadcast response/)
+      assert.strictEqual(service.getBroadcastChannelExpectedResponses(TEST_UUID), 0)
     } finally {
       service.stop()
     }

--- a/tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts
+++ b/tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts
@@ -6,6 +6,7 @@
 import assert from 'node:assert/strict'
 import { afterEach, describe, it } from 'node:test'
 
+import type { UIServiceWorkerBroadcastChannel } from '../../../../src/charging-station/broadcast-channel/UIServiceWorkerBroadcastChannel.js'
 import type { AbstractUIService } from '../../../../src/charging-station/ui-server/ui-services/AbstractUIService.js'
 
 import {
@@ -299,7 +300,7 @@ await describe('AbstractUIService', async () => {
     }
   })
 
-  await it('should warn on untracked broadcast responses while service is active', t => {
+  await it('should warn on untracked broadcast responses before service stop', t => {
     const mocks = {
       debug: t.mock.method(logger, 'debug', () => undefined),
       warn: t.mock.method(logger, 'warn', () => undefined),
@@ -345,8 +346,11 @@ await describe('AbstractUIService', async () => {
 
   await it('should rollback expected responses when broadcast dispatch throws', async t => {
     const { service } = createServiceContext()
-    const channel = Reflect.get(service, 'uiServiceWorkerBroadcastChannel') as object
-    t.mock.method(channel as never, 'sendRequest' as never, (): never => {
+    const channel = Reflect.get(
+      service,
+      'uiServiceWorkerBroadcastChannel'
+    ) as UIServiceWorkerBroadcastChannel
+    t.mock.method(channel, 'sendRequest', () => {
       throw new Error('dispatch failed')
     })
 

--- a/tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts
+++ b/tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts
@@ -299,20 +299,24 @@ await describe('AbstractUIService', async () => {
     const debugMock = t.mock.method(logger, 'debug', () => undefined)
     const { service } = createServiceContext()
 
-    await registerTransportStopRequest(service)
-    service.stop()
-    service.sendResponse(TEST_UUID, {
-      hashIdsSucceeded: [TEST_HASH_ID],
-      status: ResponseStatus.SUCCESS,
-    })
+    try {
+      await registerTransportStopRequest(service)
+      service.stop()
+      service.sendResponse(TEST_UUID, {
+        hashIdsSucceeded: [TEST_HASH_ID],
+        status: ResponseStatus.SUCCESS,
+      })
 
-    assert.strictEqual(warnMock.mock.calls.length, 0)
-    assert.strictEqual(debugMock.mock.calls.length, 1)
-    const debugMessage = debugMock.mock.calls[0]?.arguments[0]
-    if (typeof debugMessage !== 'string') {
-      assert.fail('Expected debug log message to be a string')
+      assert.strictEqual(warnMock.mock.calls.length, 0)
+      assert.strictEqual(debugMock.mock.calls.length, 1)
+      const debugMessage = debugMock.mock.calls[0]?.arguments[0]
+      if (typeof debugMessage !== 'string') {
+        assert.fail('Expected debug log message to be a string')
+      }
+      assert.match(debugMessage, /Dropping late broadcast response/)
+    } finally {
+      service.stop()
     }
-    assert.match(debugMessage, /Dropping late broadcast response/)
   })
 
   await it('should return failure response when request handler throws', async () => {

--- a/tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts
+++ b/tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts
@@ -6,7 +6,10 @@
 import assert from 'node:assert/strict'
 import { afterEach, describe, it } from 'node:test'
 
+import type { AbstractUIService } from '../../../../src/charging-station/ui-server/ui-services/AbstractUIService.js'
+
 import { ProcedureName, ProtocolVersion, ResponseStatus } from '../../../../src/types/index.js'
+import { logger } from '../../../../src/utils/Logger.js'
 import { standardCleanup } from '../../../helpers/TestLifecycleHelpers.js'
 import { TEST_HASH_ID, TEST_UUID } from '../UIServerTestConstants.js'
 import {
@@ -15,6 +18,33 @@ import {
   createProtocolRequest,
   TestableUIWebSocketServer,
 } from '../UIServerTestUtils.js'
+
+const createServiceContext = (): {
+  readonly server: TestableUIWebSocketServer
+  readonly service: AbstractUIService
+} => {
+  const config = createMockUIServerConfiguration()
+  const server = new TestableUIWebSocketServer(config)
+  server.testRegisterProtocolVersionUIService(ProtocolVersion['0.0.1'])
+  server.setChargingStationData(TEST_HASH_ID, createMockChargingStationData(TEST_HASH_ID))
+  const service = server.getUIService(ProtocolVersion['0.0.1'])
+  if (service == null) {
+    assert.fail('Expected UI service to be registered')
+  }
+  return { server, service }
+}
+
+const registerInternalStopRequest = async (server: TestableUIWebSocketServer): Promise<void> => {
+  await server.sendInternalRequest(
+    server.buildProtocolRequest(TEST_UUID, ProcedureName.STOP_CHARGING_STATION, {})
+  )
+}
+
+const registerTransportStopRequest = async (service: AbstractUIService): Promise<void> => {
+  await service.requestHandler(
+    createProtocolRequest(TEST_UUID, ProcedureName.STOP_CHARGING_STATION, {})
+  )
+}
 
 await describe('AbstractUIService', async () => {
   afterEach(() => {
@@ -146,6 +176,143 @@ await describe('AbstractUIService', async () => {
       service.stop()
       assert.strictEqual(service.getBroadcastChannelExpectedResponses(TEST_UUID), 0)
     }
+  })
+
+  await it('should log internal successful broadcast responses without transport handler at debug', async t => {
+    const warnMock = t.mock.method(logger, 'warn', () => undefined)
+    const debugMock = t.mock.method(logger, 'debug', () => undefined)
+    const { server, service } = createServiceContext()
+
+    try {
+      await registerInternalStopRequest(server)
+      service.sendResponse(TEST_UUID, {
+        hashIdsSucceeded: [TEST_HASH_ID],
+        status: ResponseStatus.SUCCESS,
+      })
+
+      assert.strictEqual(warnMock.mock.calls.length, 0)
+      assert.strictEqual(debugMock.mock.calls.length, 1)
+      const debugMessage = debugMock.mock.calls[0]?.arguments[0]
+      if (typeof debugMessage !== 'string') {
+        assert.fail('Expected debug log message to be a string')
+      }
+      assert.match(debugMessage, /Broadcast response completed without transport handler/)
+    } finally {
+      service.stop()
+    }
+  })
+
+  await it('should warn on internal failed broadcast responses without transport handler', async t => {
+    const warnMock = t.mock.method(logger, 'warn', () => undefined)
+    const debugMock = t.mock.method(logger, 'debug', () => undefined)
+    const { server, service } = createServiceContext()
+
+    try {
+      await registerInternalStopRequest(server)
+      service.sendResponse(TEST_UUID, {
+        hashIdsFailed: [TEST_HASH_ID],
+        status: ResponseStatus.FAILURE,
+      })
+
+      assert.strictEqual(debugMock.mock.calls.length, 0)
+      assert.strictEqual(warnMock.mock.calls.length, 1)
+      const warnMessage = warnMock.mock.calls[0]?.arguments[0]
+      if (typeof warnMessage !== 'string') {
+        assert.fail('Expected warning log message to be a string')
+      }
+      assert.match(warnMessage, /Failed broadcast response completed without transport handler/)
+    } finally {
+      service.stop()
+    }
+  })
+
+  await it('should log transport successful broadcast responses without transport handler at debug', async t => {
+    const warnMock = t.mock.method(logger, 'warn', () => undefined)
+    const debugMock = t.mock.method(logger, 'debug', () => undefined)
+    const { service } = createServiceContext()
+
+    try {
+      await registerTransportStopRequest(service)
+      service.sendResponse(TEST_UUID, {
+        hashIdsSucceeded: [TEST_HASH_ID],
+        status: ResponseStatus.SUCCESS,
+      })
+
+      assert.strictEqual(warnMock.mock.calls.length, 0)
+      assert.strictEqual(debugMock.mock.calls.length, 1)
+      const debugMessage = debugMock.mock.calls[0]?.arguments[0]
+      if (typeof debugMessage !== 'string') {
+        assert.fail('Expected debug log message to be a string')
+      }
+      assert.match(debugMessage, /Broadcast response completed without transport handler/)
+    } finally {
+      service.stop()
+    }
+  })
+
+  await it('should warn on transport failed broadcast responses without transport handler', async t => {
+    const warnMock = t.mock.method(logger, 'warn', () => undefined)
+    const debugMock = t.mock.method(logger, 'debug', () => undefined)
+    const { service } = createServiceContext()
+
+    try {
+      await registerTransportStopRequest(service)
+      service.sendResponse(TEST_UUID, {
+        hashIdsFailed: [TEST_HASH_ID],
+        status: ResponseStatus.FAILURE,
+      })
+
+      assert.strictEqual(debugMock.mock.calls.length, 0)
+      assert.strictEqual(warnMock.mock.calls.length, 1)
+      const warnMessage = warnMock.mock.calls[0]?.arguments[0]
+      if (typeof warnMessage !== 'string') {
+        assert.fail('Expected warning log message to be a string')
+      }
+      assert.match(warnMessage, /Failed broadcast response completed without transport handler/)
+    } finally {
+      service.stop()
+    }
+  })
+
+  await it('should warn on untracked broadcast responses while service is active', t => {
+    const warnMock = t.mock.method(logger, 'warn', () => undefined)
+    const debugMock = t.mock.method(logger, 'debug', () => undefined)
+    const { service } = createServiceContext()
+
+    try {
+      service.sendResponse(TEST_UUID, { status: ResponseStatus.SUCCESS })
+
+      assert.strictEqual(debugMock.mock.calls.length, 0)
+      assert.strictEqual(warnMock.mock.calls.length, 1)
+      const warnMessage = warnMock.mock.calls[0]?.arguments[0]
+      if (typeof warnMessage !== 'string') {
+        assert.fail('Expected warning log message to be a string')
+      }
+      assert.match(warnMessage, /Dropping untracked broadcast response/)
+    } finally {
+      service.stop()
+    }
+  })
+
+  await it('should log late broadcast responses after service stop at debug', async t => {
+    const warnMock = t.mock.method(logger, 'warn', () => undefined)
+    const debugMock = t.mock.method(logger, 'debug', () => undefined)
+    const { service } = createServiceContext()
+
+    await registerTransportStopRequest(service)
+    service.stop()
+    service.sendResponse(TEST_UUID, {
+      hashIdsSucceeded: [TEST_HASH_ID],
+      status: ResponseStatus.SUCCESS,
+    })
+
+    assert.strictEqual(warnMock.mock.calls.length, 0)
+    assert.strictEqual(debugMock.mock.calls.length, 1)
+    const debugMessage = debugMock.mock.calls[0]?.arguments[0]
+    if (typeof debugMessage !== 'string') {
+      assert.fail('Expected debug log message to be a string')
+    }
+    assert.match(debugMessage, /Dropping late broadcast response/)
   })
 
   await it('should return failure response when request handler throws', async () => {

--- a/tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts
+++ b/tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts
@@ -178,7 +178,7 @@ await describe('AbstractUIService', async () => {
     }
   })
 
-  await it('should log internal successful broadcast responses without transport handler at debug', async t => {
+  await it('should log internal successful broadcast responses without response handler at debug', async t => {
     const warnMock = t.mock.method(logger, 'warn', () => undefined)
     const debugMock = t.mock.method(logger, 'debug', () => undefined)
     const { server, service } = createServiceContext()
@@ -196,13 +196,13 @@ await describe('AbstractUIService', async () => {
       if (typeof debugMessage !== 'string') {
         assert.fail('Expected debug log message to be a string')
       }
-      assert.match(debugMessage, /Broadcast response completed without transport handler/)
+      assert.match(debugMessage, /Broadcast response completed without response handler/)
     } finally {
       service.stop()
     }
   })
 
-  await it('should warn on internal failed broadcast responses without transport handler', async t => {
+  await it('should warn on internal failed broadcast responses without response handler', async t => {
     const warnMock = t.mock.method(logger, 'warn', () => undefined)
     const debugMock = t.mock.method(logger, 'debug', () => undefined)
     const { server, service } = createServiceContext()
@@ -220,13 +220,13 @@ await describe('AbstractUIService', async () => {
       if (typeof warnMessage !== 'string') {
         assert.fail('Expected warning log message to be a string')
       }
-      assert.match(warnMessage, /Failed broadcast response completed without transport handler/)
+      assert.match(warnMessage, /Failed broadcast response completed without response handler/)
     } finally {
       service.stop()
     }
   })
 
-  await it('should log transport successful broadcast responses without transport handler at debug', async t => {
+  await it('should log transport successful broadcast responses without response handler at debug', async t => {
     const warnMock = t.mock.method(logger, 'warn', () => undefined)
     const debugMock = t.mock.method(logger, 'debug', () => undefined)
     const { service } = createServiceContext()
@@ -244,13 +244,13 @@ await describe('AbstractUIService', async () => {
       if (typeof debugMessage !== 'string') {
         assert.fail('Expected debug log message to be a string')
       }
-      assert.match(debugMessage, /Broadcast response completed without transport handler/)
+      assert.match(debugMessage, /Broadcast response completed without response handler/)
     } finally {
       service.stop()
     }
   })
 
-  await it('should warn on transport failed broadcast responses without transport handler', async t => {
+  await it('should warn on transport failed broadcast responses without response handler', async t => {
     const warnMock = t.mock.method(logger, 'warn', () => undefined)
     const debugMock = t.mock.method(logger, 'debug', () => undefined)
     const { service } = createServiceContext()
@@ -268,7 +268,7 @@ await describe('AbstractUIService', async () => {
       if (typeof warnMessage !== 'string') {
         assert.fail('Expected warning log message to be a string')
       }
-      assert.match(warnMessage, /Failed broadcast response completed without transport handler/)
+      assert.match(warnMessage, /Failed broadcast response completed without response handler/)
     } finally {
       service.stop()
     }


### PR DESCRIPTION
## Summary
- Track broadcast request context (origin, procedure, expected responses) before dispatching worker broadcast requests.
- Classify completed broadcast responses without response handlers by context and status instead of emitting the generic `Response handler not found` warning.
- Preserve internal request origin for server-initiated broadcasts and clean broadcast aggregation state reliably.

## Context
This follows the broadcast-response behavior established around #1642/#1643 while keeping broadcast requests asynchronous by design. It addresses the general no-response-handler path, including internal shutdown-origin broadcasts, without changing `ProtocolRequest` or `ProtocolResponse` tuple shapes.

## Operator-facing notes
- **Log level**: successful broadcast responses without a registered response handler are now logged at `debug` (was `warn`). `warn` is reserved for the failure path and the untracked-while-active path. The pre-PR `Response handler not found` string is gone; new message strings are `Broadcast response completed without response handler` (debug, success) / `Failed broadcast response completed without response handler` (warn, failure) / `Dropping untracked broadcast response` (warn) / `Dropping late broadcast response after UI service stop` (debug).
- **Signature**: `AbstractUIService.requestHandler(request, context?)` accepts an optional second arg `{ origin: UIRequestOrigin }` (default `UIRequestOrigin.TRANSPORT`). `AbstractUIServer.sendInternalRequest` passes `UIRequestOrigin.INTERNAL`. Backwards-compatible by default.
- **Public types**: `UIRequestOrigin` enum and `UIRequestContext` interface added to `src/types/UIProtocol.ts` (re-exported via `src/types/index.ts`). Canonical `ProtocolRequestHandler` widens to accept an optional 4th `context?: UIRequestContext` parameter.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec tsx --test tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts` (16 pass)
- `pnpm exec tsx --test tests/charging-station/ui-server/UIWebSocketServer.test.ts tests/charging-station/ui-server/UIHttpServer.test.ts tests/charging-station/ui-server/UIMCPServer.test.ts` (106 pass)
- `pnpm build`
- `GIT_MASTER=1 git diff --check 2f2dc35dcdecf0f8af93c2100eb865565fb1ff59..HEAD`

## Review
Post-implementation review passed across goal/constraint verification, hands-on QA, code quality, security, and context mining. A follow-up cross-validated design pass (4 oracles) addressed the previously-noted structured log context assertions and surfaced 11 NIT items now landed as 4 follow-up commits on this branch (`refactor(types)`, `refactor(ui-server)`, `style(ui-server)`, `test(ui-server)`).
