### PR TITLE
test: use shared response test helpers

### DIFF
--- a/src/charging-station/ocpp/2.0/__testable__/OCPP20ResponseServiceTestable.ts
+++ b/src/charging-station/ocpp/2.0/__testable__/OCPP20ResponseServiceTestable.ts
@@ -1,0 +1,63 @@
+/**
+ * Testable wrapper for OCPP 2.0 ResponseService
+ *
+ * This module provides type-safe access to private handler methods of
+ * OCPP20ResponseService for testing purposes. It replaces ad hoc
+ * `as unknown as` casts at test sites with a properly typed interface,
+ * enabling:
+ * - Type-safe method invocations in tests
+ * - IntelliSense and autocompletion for handler parameters and returns
+ * - Compile-time checking for test code
+ * @example
+ * ```typescript
+ * import { createTestableResponseService } from './__testable__/index.js'
+ *
+ * const testable = createTestableResponseService(new OCPP20ResponseService())
+ * await testable.handleResponseTransactionEvent(station, payload, requestPayload)
+ * ```
+ */
+
+import type {
+  OCPP20TransactionEventRequest,
+  OCPP20TransactionEventResponse,
+} from '../../../../types/index.js'
+import type { ChargingStation } from '../../../index.js'
+import type { OCPP20ResponseService } from '../OCPP20ResponseService.js'
+
+/**
+ * Interface exposing private handler methods of OCPP20ResponseService for testing.
+ * Each method signature matches the corresponding private method in the service class.
+ */
+export interface TestableOCPP20ResponseService {
+  handleResponseTransactionEvent: (
+    chargingStation: ChargingStation,
+    payload: OCPP20TransactionEventResponse,
+    requestPayload: OCPP20TransactionEventRequest
+  ) => Promise<void>
+}
+
+/**
+ * Creates a testable wrapper around OCPP20ResponseService.
+ * Provides type-safe access to private handler methods without `as any` casts.
+ * @param service - The OCPP20ResponseService instance to wrap
+ * @returns A typed interface exposing private handler methods
+ * @example
+ * ```typescript
+ * // Before (with as any cast):
+ * await (service as any).handleResponseTransactionEvent(station, payload, requestPayload)
+ *
+ * // After (with testable interface):
+ * const testable = createTestableResponseService(service)
+ * await testable.handleResponseTransactionEvent(station, payload, requestPayload)
+ * ```
+ */
+export function createTestableResponseService (
+  service: OCPP20ResponseService
+): TestableOCPP20ResponseService {
+  // Cast to unknown first to satisfy TypeScript while preserving runtime behavior
+  const serviceImpl = service as unknown as TestableOCPP20ResponseService
+
+  return {
+    handleResponseTransactionEvent: serviceImpl.handleResponseTransactionEvent.bind(service),
+  }
+}

--- a/src/charging-station/ocpp/2.0/__testable__/index.ts
+++ b/src/charging-station/ocpp/2.0/__testable__/index.ts
@@ -321,6 +321,11 @@ export {
 } from './OCPP20RequestServiceTestable.js'
 
 export {
+  createTestableResponseService,
+  type TestableOCPP20ResponseService,
+} from './OCPP20ResponseServiceTestable.js'
+
+export {
   createTestableVariableManager,
   type TestableOCPP20VariableManager,
 } from './OCPP20VariableManagerTestable.js'

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-ClearCache.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-ClearCache.test.ts
@@ -16,9 +16,33 @@ import { Constants } from '../../../../src/utils/index.js'
 import { standardCleanup } from '../../../helpers/TestLifecycleHelpers.js'
 import { TEST_CHARGING_STATION_BASE_NAME } from '../../ChargingStationTestConstants.js'
 import { createMockChargingStation } from '../../helpers/StationHelpers.js'
+import { createMockAuthService, createTestAuthConfig } from '../auth/helpers/MockFactories.js'
+
+/**
+ * Inject a mock auth service for the current station.
+ * @param station - Charging station under test
+ * @param authorizationCacheEnabled - Whether the mock auth cache is enabled
+ * @param clearCache - Mock cache clearing implementation
+ */
+function setupMockAuthService (
+  station: ChargingStation,
+  authorizationCacheEnabled: boolean,
+  clearCache: () => void = () => {
+    /* empty */
+  }
+): void {
+  OCPPAuthServiceFactory.setInstanceForTesting(
+    station.stationInfo?.chargingStationId ?? 'unknown',
+    createMockAuthService({
+      clearCache,
+      getConfiguration: () => createTestAuthConfig({ authorizationCacheEnabled }),
+    })
+  )
+}
 
 await describe('C11 - Clear Authorization Data in Authorization Cache', async () => {
   afterEach(() => {
+    OCPPAuthServiceFactory.clearAllInstances()
     standardCleanup()
   })
 
@@ -66,30 +90,13 @@ await describe('C11 - Clear Authorization Data in Authorization Cache', async ()
   // CLR-001: Verify Authorization Cache is cleared (not IdTagsCache)
   await describe('CLR-001 - ClearCache clears Authorization Cache', async () => {
     await it('should call authService.clearCache() on ClearCache request', async () => {
-      // Create a mock auth service to verify clearCache is called
       const clearCacheMock = mock.fn()
-      const mockAuthService = {
-        clearCache: clearCacheMock,
-        getConfiguration: () => ({
-          authorizationCacheEnabled: true,
-        }),
-      }
+      setupMockAuthService(station, true, clearCacheMock)
 
-      // Mock the factory to return our mock auth service
-      const originalGetInstance = OCPPAuthServiceFactory.getInstance.bind(OCPPAuthServiceFactory)
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      const response = await testableService.handleRequestClearCache(station)
 
-      try {
-        const response = await testableService.handleRequestClearCache(station)
-
-        assert.strictEqual(clearCacheMock.mock.callCount(), 1)
-        assert.strictEqual(response.status, GenericStatus.Accepted)
-      } finally {
-        // Restore original factory method
-        Object.assign(OCPPAuthServiceFactory, { getInstance: originalGetInstance })
-      }
+      assert.strictEqual(clearCacheMock.mock.callCount(), 1)
+      assert.strictEqual(response.status, GenericStatus.Accepted)
     })
 
     await it('should not call idTagsCache.deleteIdTags() on ClearCache request', async () => {
@@ -114,110 +121,40 @@ await describe('C11 - Clear Authorization Data in Authorization Cache', async ()
   // CLR-002: Verify AuthCacheEnabled check per C11.FR.04
   await describe('CLR-002 - AuthCacheEnabled Check (C11.FR.04)', async () => {
     await it('should return Rejected when AuthCacheEnabled is false', async () => {
-      // Create a mock auth service with cache disabled
-      const mockAuthService = {
-        clearCache: (): void => {
-          throw new Error('clearCache should not be called when cache is disabled')
-        },
-        getConfiguration: () => ({
-          authorizationCacheEnabled: false,
-        }),
-      }
-
-      // Mock the factory to return our mock auth service
-      const originalGetInstance = OCPPAuthServiceFactory.getInstance.bind(OCPPAuthServiceFactory)
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
+      setupMockAuthService(station, false, () => {
+        throw new Error('clearCache should not be called when cache is disabled')
       })
 
-      try {
-        const response = await testableService.handleRequestClearCache(station)
+      const response = await testableService.handleRequestClearCache(station)
 
-        assert.strictEqual(response.status, GenericStatus.Rejected)
-      } finally {
-        // Restore original factory method
-        Object.assign(OCPPAuthServiceFactory, { getInstance: originalGetInstance })
-      }
+      assert.strictEqual(response.status, GenericStatus.Rejected)
     })
 
     await it('should return Accepted when AuthCacheEnabled is true and clear succeeds', async () => {
-      // Create a mock auth service with cache enabled
-      const mockAuthService = {
-        clearCache: (): void => {
-          /* empty */
-        },
-        getConfiguration: () => ({
-          authorizationCacheEnabled: true,
-        }),
-      }
+      setupMockAuthService(station, true)
 
-      // Mock the factory to return our mock auth service
-      const originalGetInstance = OCPPAuthServiceFactory.getInstance.bind(OCPPAuthServiceFactory)
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      const response = await testableService.handleRequestClearCache(station)
 
-      try {
-        const response = await testableService.handleRequestClearCache(station)
-
-        assert.strictEqual(response.status, GenericStatus.Accepted)
-      } finally {
-        // Restore original factory method
-        Object.assign(OCPPAuthServiceFactory, { getInstance: originalGetInstance })
-      }
+      assert.strictEqual(response.status, GenericStatus.Accepted)
     })
 
     await it('should return Rejected when clearCache throws an error', async () => {
-      // Create a mock auth service that throws on clearCache
-      const mockAuthService = {
-        clearCache: (): void => {
-          throw new Error('Cache clear failed')
-        },
-        getConfiguration: () => ({
-          authorizationCacheEnabled: true,
-        }),
-      }
-
-      // Mock the factory to return our mock auth service
-      const originalGetInstance = OCPPAuthServiceFactory.getInstance.bind(OCPPAuthServiceFactory)
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
+      setupMockAuthService(station, true, () => {
+        throw new Error('Cache clear failed')
       })
 
-      try {
-        const response = await testableService.handleRequestClearCache(station)
+      const response = await testableService.handleRequestClearCache(station)
 
-        assert.strictEqual(response.status, GenericStatus.Rejected)
-      } finally {
-        // Restore original factory method
-        Object.assign(OCPPAuthServiceFactory, { getInstance: originalGetInstance })
-      }
+      assert.strictEqual(response.status, GenericStatus.Rejected)
     })
 
     await it('should not attempt to clear cache when AuthCacheEnabled is false', async () => {
       const clearCacheMock = mock.fn()
-      const mockAuthService = {
-        clearCache: clearCacheMock,
-        getConfiguration: () => ({
-          authorizationCacheEnabled: false,
-        }),
-      }
+      setupMockAuthService(station, false, clearCacheMock)
 
-      // Mock the factory to return our mock auth service
-      const originalGetInstance = OCPPAuthServiceFactory.getInstance.bind(OCPPAuthServiceFactory)
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      await testableService.handleRequestClearCache(station)
 
-      try {
-        await testableService.handleRequestClearCache(station)
-
-        // clearCache should NOT be called when cache is disabled
-        assert.strictEqual(clearCacheMock.mock.callCount(), 0)
-      } finally {
-        // Restore original factory method
-        Object.assign(OCPPAuthServiceFactory, { getInstance: originalGetInstance })
-      }
+      assert.strictEqual(clearCacheMock.mock.callCount(), 0)
     })
   })
 

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-ClearCache.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-ClearCache.test.ts
@@ -46,11 +46,6 @@ function setupMockAuthService (
 }
 
 await describe('C11 - Clear Authorization Data in Authorization Cache', async () => {
-  afterEach(() => {
-    OCPPAuthServiceFactory.clearAllInstances()
-    standardCleanup()
-  })
-
   let station: ChargingStation
   let incomingRequestService: OCPP20IncomingRequestService
   let testableService: ReturnType<typeof createTestableIncomingRequestService>
@@ -69,6 +64,11 @@ await describe('C11 - Clear Authorization Data in Authorization Cache', async ()
     station = mockStation
     incomingRequestService = new OCPP20IncomingRequestService()
     testableService = createTestableIncomingRequestService(incomingRequestService)
+  })
+
+  afterEach(() => {
+    OCPPAuthServiceFactory.clearAllInstances()
+    standardCleanup()
   })
 
   // FR: C11.FR.01 - CS SHALL attempt to clear its Authorization Cache

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-ClearCache.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-ClearCache.test.ts
@@ -16,7 +16,12 @@ import { Constants } from '../../../../src/utils/index.js'
 import { standardCleanup } from '../../../helpers/TestLifecycleHelpers.js'
 import { TEST_CHARGING_STATION_BASE_NAME } from '../../ChargingStationTestConstants.js'
 import { createMockChargingStation } from '../../helpers/StationHelpers.js'
-import { createMockAuthService, createTestAuthConfig } from '../auth/helpers/MockFactories.js'
+import {
+  createMockAuthService,
+  createTestAuthConfig,
+  injectMockAuthService,
+  withThrowingAuthServiceFactory,
+} from '../auth/helpers/MockFactories.js'
 
 /**
  * Inject a mock auth service for the current station.
@@ -31,8 +36,8 @@ function setupMockAuthService (
     /* empty */
   }
 ): void {
-  OCPPAuthServiceFactory.setInstanceForTesting(
-    station.stationInfo?.chargingStationId ?? 'unknown',
+  injectMockAuthService(
+    station,
     createMockAuthService({
       clearCache,
       getConfiguration: () => createTestAuthConfig({ authorizationCacheEnabled }),
@@ -161,23 +166,13 @@ await describe('C11 - Clear Authorization Data in Authorization Cache', async ()
   // C11.FR.05: IF the CS does not support an Authorization Cache → Rejected
   await describe('C11.FR.05 - No Authorization Cache Support', async () => {
     await it('should return Rejected when authService factory fails (no cache support)', async () => {
-      // Mock factory to throw error (simulates no Authorization Cache support)
-      const originalGetInstance = OCPPAuthServiceFactory.getInstance.bind(OCPPAuthServiceFactory)
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): never => {
-          throw new Error('Authorization Cache not supported')
-        },
-      })
+      const response = await withThrowingAuthServiceFactory(
+        'Authorization Cache not supported',
+        () => testableService.handleRequestClearCache(station)
+      )
 
-      try {
-        const response = await testableService.handleRequestClearCache(station)
-
-        // Per C11.FR.05: SHALL return Rejected if CS does not support Authorization Cache
-        assert.strictEqual(response.status, GenericStatus.Rejected)
-      } finally {
-        // Restore original factory method
-        Object.assign(OCPPAuthServiceFactory, { getInstance: originalGetInstance })
-      }
+      // Per C11.FR.05: SHALL return Rejected if CS does not support Authorization Cache
+      assert.strictEqual(response.status, GenericStatus.Rejected)
     })
   })
 })

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-ClearCache.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-ClearCache.test.ts
@@ -24,7 +24,7 @@ import {
 } from '../auth/helpers/MockFactories.js'
 
 /**
- * Inject a mock auth service for the current station.
+ * Configure and inject a mock auth service for the current station.
  * @param station - Charging station under test
  * @param authorizationCacheEnabled - Whether the mock auth cache is enabled
  * @param clearCache - Mock cache clearing implementation

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-LocalAuthList.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-LocalAuthList.test.ts
@@ -7,10 +7,7 @@ import assert from 'node:assert/strict'
 import { afterEach, beforeEach, describe, it } from 'node:test'
 
 import type { ChargingStation } from '../../../../src/charging-station/index.js'
-import type {
-  LocalAuthListManager,
-  OCPPAuthService,
-} from '../../../../src/charging-station/ocpp/auth/interfaces/OCPPAuthService.js'
+import type { LocalAuthListManager } from '../../../../src/charging-station/ocpp/auth/interfaces/OCPPAuthService.js'
 
 import { buildConfigKey } from '../../../../src/charging-station/index.js'
 import { createTestableIncomingRequestService } from '../../../../src/charging-station/ocpp/2.0/__testable__/index.js'
@@ -42,18 +39,17 @@ import {
 import { upsertConfigurationKey } from './OCPP20TestUtils.js'
 
 /**
- * Inject a mock auth service for LocalAuthList request handling tests.
+ * Configure and inject a mock auth service for LocalAuthList request handling tests.
  * @param station - Charging station under test
  * @param manager - Local auth list manager exposed by the mock service
  * @param localAuthListEnabled - Whether LocalAuthList is enabled in auth configuration
- * @returns Mock auth service instance cached for the station
  */
 function setupMockAuthService (
   station: ChargingStation,
   manager: LocalAuthListManager | undefined,
   localAuthListEnabled = true
-): OCPPAuthService {
-  return injectMockAuthService(
+): void {
+  injectMockAuthService(
     station,
     createMockAuthService({
       getConfiguration: () => createTestAuthConfig({ localAuthListEnabled }),

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-LocalAuthList.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-LocalAuthList.test.ts
@@ -33,7 +33,12 @@ import { Constants } from '../../../../src/utils/index.js'
 import { standardCleanup } from '../../../helpers/TestLifecycleHelpers.js'
 import { TEST_CHARGING_STATION_BASE_NAME } from '../../ChargingStationTestConstants.js'
 import { createMockChargingStation } from '../../helpers/StationHelpers.js'
-import { createMockAuthService, createTestAuthConfig } from '../auth/helpers/MockFactories.js'
+import {
+  createMockAuthService,
+  createTestAuthConfig,
+  injectMockAuthService,
+  withThrowingAuthServiceFactory,
+} from '../auth/helpers/MockFactories.js'
 import { upsertConfigurationKey } from './OCPP20TestUtils.js'
 
 /**
@@ -48,21 +53,18 @@ function setupMockAuthService (
   manager: LocalAuthListManager | undefined,
   localAuthListEnabled = true
 ): OCPPAuthService {
-  const authService = createMockAuthService({
-    getConfiguration: () => createTestAuthConfig({ localAuthListEnabled }),
-    getLocalAuthListManager: () => manager,
-  })
-  OCPPAuthServiceFactory.setInstanceForTesting(
-    station.stationInfo?.chargingStationId ?? 'unknown',
-    authService
+  return injectMockAuthService(
+    station,
+    createMockAuthService({
+      getConfiguration: () => createTestAuthConfig({ localAuthListEnabled }),
+      getLocalAuthListManager: () => manager,
+    })
   )
-  return authService
 }
 
 await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
   let station: ChargingStation
   let testableService: ReturnType<typeof createTestableIncomingRequestService>
-  let originalGetInstance: typeof OCPPAuthServiceFactory.getInstance
 
   /**
    * Toggle the LocalAuthListCtrlr.Enabled configuration key on the mock station.
@@ -90,12 +92,10 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
     station = mockStation
     const incomingRequestService = new OCPP20IncomingRequestService()
     testableService = createTestableIncomingRequestService(incomingRequestService)
-    originalGetInstance = OCPPAuthServiceFactory.getInstance.bind(OCPPAuthServiceFactory)
     setLocalAuthListEnabled(true)
   })
 
   afterEach(() => {
-    Object.assign(OCPPAuthServiceFactory, { getInstance: originalGetInstance })
     OCPPAuthServiceFactory.clearAllInstances()
     standardCleanup()
   })
@@ -141,14 +141,10 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
       assert.strictEqual(response.versionNumber, 5)
     })
 
-    await it('should return version 0 when auth service throws', () => {
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): never => {
-          throw new Error('Auth service unavailable')
-        },
-      })
-
-      const response = testableService.handleRequestGetLocalListVersion(station)
+    await it('should return version 0 when auth service throws', async () => {
+      const response = await withThrowingAuthServiceFactory('Auth service unavailable', () =>
+        testableService.handleRequestGetLocalListVersion(station)
+      )
 
       assert.strictEqual(response.versionNumber, 0)
     })
@@ -266,18 +262,14 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
       assert.strictEqual(version, 2)
     })
 
-    await it('should return Failed when auth service throws', () => {
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): never => {
-          throw new Error('Auth service unavailable')
-        },
-      })
-
-      const response = testableService.handleRequestSendLocalList(station, {
-        localAuthorizationList: [],
-        updateType: OCPP20UpdateEnumType.Full,
-        versionNumber: 1,
-      })
+    await it('should return Failed when auth service throws', async () => {
+      const response = await withThrowingAuthServiceFactory('Auth service unavailable', () =>
+        testableService.handleRequestSendLocalList(station, {
+          localAuthorizationList: [],
+          updateType: OCPP20UpdateEnumType.Full,
+          versionNumber: 1,
+        })
+      )
 
       assert.strictEqual(response.status, OCPP20SendLocalListStatusEnumType.Failed)
     })

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-LocalAuthList.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-LocalAuthList.test.ts
@@ -7,6 +7,10 @@ import assert from 'node:assert/strict'
 import { afterEach, beforeEach, describe, it } from 'node:test'
 
 import type { ChargingStation } from '../../../../src/charging-station/index.js'
+import type {
+  LocalAuthListManager,
+  OCPPAuthService,
+} from '../../../../src/charging-station/ocpp/auth/interfaces/OCPPAuthService.js'
 
 import { buildConfigKey } from '../../../../src/charging-station/index.js'
 import { createTestableIncomingRequestService } from '../../../../src/charging-station/ocpp/2.0/__testable__/index.js'
@@ -29,7 +33,31 @@ import { Constants } from '../../../../src/utils/index.js'
 import { standardCleanup } from '../../../helpers/TestLifecycleHelpers.js'
 import { TEST_CHARGING_STATION_BASE_NAME } from '../../ChargingStationTestConstants.js'
 import { createMockChargingStation } from '../../helpers/StationHelpers.js'
+import { createMockAuthService, createTestAuthConfig } from '../auth/helpers/MockFactories.js'
 import { upsertConfigurationKey } from './OCPP20TestUtils.js'
+
+/**
+ * Inject a mock auth service for LocalAuthList request handling tests.
+ * @param station - Charging station under test
+ * @param manager - Local auth list manager exposed by the mock service
+ * @param localAuthListEnabled - Whether LocalAuthList is enabled in auth configuration
+ * @returns Mock auth service instance cached for the station
+ */
+function setupMockAuthService (
+  station: ChargingStation,
+  manager: LocalAuthListManager | undefined,
+  localAuthListEnabled = true
+): OCPPAuthService {
+  const authService = createMockAuthService({
+    getConfiguration: () => createTestAuthConfig({ localAuthListEnabled }),
+    getLocalAuthListManager: () => manager,
+  })
+  OCPPAuthServiceFactory.setInstanceForTesting(
+    station.stationInfo?.chargingStationId ?? 'unknown',
+    authService
+  )
+  return authService
+}
 
 await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
   let station: ChargingStation
@@ -68,6 +96,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
 
   afterEach(() => {
     Object.assign(OCPPAuthServiceFactory, { getInstance: originalGetInstance })
+    OCPPAuthServiceFactory.clearAllInstances()
     standardCleanup()
   })
 
@@ -78,13 +107,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
   await describe('GetLocalListVersion', async () => {
     await it('should return version 0 for empty list', () => {
       const manager = new InMemoryLocalAuthListManager()
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: true }),
-        getLocalAuthListManager: () => manager,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, manager)
 
       const response = testableService.handleRequestGetLocalListVersion(station)
 
@@ -93,13 +116,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
 
     await it('should return version 0 when local auth list disabled', () => {
       setLocalAuthListEnabled(false)
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: false }),
-        getLocalAuthListManager: () => undefined,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, undefined, false)
 
       const response = testableService.handleRequestGetLocalListVersion(station)
 
@@ -107,13 +124,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
     })
 
     await it('should return version 0 when manager is undefined', () => {
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: true }),
-        getLocalAuthListManager: () => undefined,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, undefined)
 
       const response = testableService.handleRequestGetLocalListVersion(station)
 
@@ -123,13 +134,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
     await it('should return correct version after SendLocalList', () => {
       const manager = new InMemoryLocalAuthListManager()
       manager.setEntries([{ identifier: 'TOKEN_001', status: 'Accepted' }], 5)
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: true }),
-        getLocalAuthListManager: () => manager,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, manager)
 
       const response = testableService.handleRequestGetLocalListVersion(station)
 
@@ -156,13 +161,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
   await describe('SendLocalList', async () => {
     await it('should accept Full update and replace list', () => {
       const manager = new InMemoryLocalAuthListManager()
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: true }),
-        getLocalAuthListManager: () => manager,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, manager)
 
       const response = testableService.handleRequestSendLocalList(station, {
         localAuthorizationList: [
@@ -191,13 +190,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
     await it('should accept Differential update with complex IdToken types', () => {
       const manager = new InMemoryLocalAuthListManager()
       manager.setEntries([{ identifier: 'EXISTING_001', status: 'Accepted' }], 1)
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: true }),
-        getLocalAuthListManager: () => manager,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, manager)
 
       const response = testableService.handleRequestSendLocalList(station, {
         localAuthorizationList: [
@@ -221,13 +214,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
 
     await it('should return Failed when disabled (with statusInfo)', () => {
       setLocalAuthListEnabled(false)
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: false }),
-        getLocalAuthListManager: () => undefined,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, undefined, false)
 
       const response = testableService.handleRequestSendLocalList(station, {
         localAuthorizationList: [],
@@ -241,13 +228,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
     })
 
     await it('should return Failed when manager is undefined', () => {
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: true }),
-        getLocalAuthListManager: () => undefined,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, undefined)
 
       const response = testableService.handleRequestSendLocalList(station, {
         localAuthorizationList: [],
@@ -268,13 +249,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
         ],
         1
       )
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: true }),
-        getLocalAuthListManager: () => manager,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, manager)
 
       const response = testableService.handleRequestSendLocalList(station, {
         localAuthorizationList: [],
@@ -316,13 +291,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
         ],
         1
       )
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: true }),
-        getLocalAuthListManager: () => manager,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, manager)
 
       const response = testableService.handleRequestSendLocalList(station, {
         localAuthorizationList: [
@@ -347,13 +316,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
 
     await it('should preserve idTokenType metadata in entries', () => {
       const manager = new InMemoryLocalAuthListManager()
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: true }),
-        getLocalAuthListManager: () => manager,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, manager)
 
       testableService.handleRequestSendLocalList(station, {
         localAuthorizationList: [
@@ -375,13 +338,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
     await it('should handle Full update with undefined localAuthorizationList', () => {
       const manager = new InMemoryLocalAuthListManager()
       manager.setEntries([{ identifier: 'OLD_TOKEN', status: 'Accepted' }], 1)
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: true }),
-        getLocalAuthListManager: () => manager,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, manager)
 
       const response = testableService.handleRequestSendLocalList(station, {
         updateType: OCPP20UpdateEnumType.Full,
@@ -399,13 +356,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
 
     await it('should convert cacheExpiryDateTime to Date', () => {
       const manager = new InMemoryLocalAuthListManager()
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: true }),
-        getLocalAuthListManager: () => manager,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, manager)
 
       const expiryDate = new Date('2027-01-01T00:00:00.000Z')
 
@@ -431,13 +382,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
     await it('should return VersionMismatch for differential update with version < current', () => {
       const manager = new InMemoryLocalAuthListManager()
       manager.setEntries([{ identifier: 'TOKEN_001', status: 'Accepted' }], 5)
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: true }),
-        getLocalAuthListManager: () => manager,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, manager)
 
       const response = testableService.handleRequestSendLocalList(station, {
         localAuthorizationList: [
@@ -456,13 +401,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
     await it('should return VersionMismatch for differential update with version equal to current', () => {
       const manager = new InMemoryLocalAuthListManager()
       manager.setEntries([{ identifier: 'TOKEN_001', status: 'Accepted' }], 5)
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: true }),
-        getLocalAuthListManager: () => manager,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, manager)
 
       const response = testableService.handleRequestSendLocalList(station, {
         localAuthorizationList: [
@@ -480,13 +419,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
 
     await it('should return Failed with versionNumber <= 0', () => {
       const manager = new InMemoryLocalAuthListManager()
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: true }),
-        getLocalAuthListManager: () => manager,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, manager)
 
       const response = testableService.handleRequestSendLocalList(station, {
         localAuthorizationList: [],
@@ -499,13 +432,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
 
     await it('should return Failed with negative versionNumber', () => {
       const manager = new InMemoryLocalAuthListManager()
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: true }),
-        getLocalAuthListManager: () => manager,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, manager)
 
       const response = testableService.handleRequestSendLocalList(station, {
         localAuthorizationList: [],
@@ -519,13 +446,7 @@ await describe('OCPP20IncomingRequestService — LocalAuthList', async () => {
     await it('should accept Full update regardless of version (no VersionMismatch)', () => {
       const manager = new InMemoryLocalAuthListManager()
       manager.setEntries([{ identifier: 'TOKEN_001', status: 'Accepted' }], 5)
-      const mockAuthService = {
-        getConfiguration: () => ({ localAuthListEnabled: true }),
-        getLocalAuthListManager: () => manager,
-      }
-      Object.assign(OCPPAuthServiceFactory, {
-        getInstance: (): typeof mockAuthService => mockAuthService,
-      })
+      setupMockAuthService(station, manager)
 
       const response = testableService.handleRequestSendLocalList(station, {
         localAuthorizationList: [

--- a/tests/charging-station/ocpp/2.0/OCPP20ResponseService-ForceTxOnInvalid.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20ResponseService-ForceTxOnInvalid.test.ts
@@ -22,11 +22,7 @@ import assert from 'node:assert/strict'
 import { afterEach, beforeEach, describe, it, mock } from 'node:test'
 
 import type { ChargingStation } from '../../../../src/charging-station/index.js'
-import type {
-  OCPP20TransactionEventRequest,
-  OCPP20TransactionEventResponse,
-  UUIDv4,
-} from '../../../../src/types/index.js'
+import type { OCPP20TransactionEventResponse } from '../../../../src/types/index.js'
 
 import { OCPP20ResponseService } from '../../../../src/charging-station/ocpp/2.0/OCPP20ResponseService.js'
 import { OCPP20ServiceUtils } from '../../../../src/charging-station/ocpp/2.0/OCPP20ServiceUtils.js'
@@ -34,7 +30,6 @@ import {
   OCPP20AuthorizationStatusEnumType,
   OCPP20IdTokenEnumType,
   OCPP20TransactionEventEnumType,
-  OCPP20TriggerReasonEnumType,
   OCPPVersion,
 } from '../../../../src/types/index.js'
 import { Constants, logger } from '../../../../src/utils/index.js'
@@ -48,59 +43,11 @@ import {
   TEST_TRANSACTION_UUID,
 } from '../../ChargingStationTestConstants.js'
 import { createMockChargingStation } from '../../helpers/StationHelpers.js'
-
-interface TestableOCPP20ResponseService {
-  handleResponseTransactionEvent: (
-    chargingStation: ChargingStation,
-    payload: OCPP20TransactionEventResponse,
-    requestPayload: OCPP20TransactionEventRequest
-  ) => Promise<void>
-}
-
-/**
- * Builds a minimal OCPP20TransactionEventRequest with the given event type and
- * transaction id. Used as the request-payload twin in handler dispatch.
- * @param transactionId - The transaction UUID embedded in transactionInfo
- * @param eventType - The TransactionEvent type (Started/Updated/Ended)
- * @param idToken - Optional idToken to attach; required to exercise the auth-cache
- *   update path at OCPP20ResponseService.ts (C10.FR.01/04/05)
- * @param idToken.idToken - OCPP IdToken value (e.g. an RFID tag string)
- * @param idToken.type - OCPP 2.0.1 IdToken type (e.g. `ISO14443`, `ISO15693`, `Central`)
- * @returns A minimal OCPP20TransactionEventRequest
- */
-function buildTransactionEventRequest (
-  transactionId: UUIDv4,
-  eventType: OCPP20TransactionEventEnumType,
-  idToken?: { idToken: string; type: OCPP20IdTokenEnumType }
-): OCPP20TransactionEventRequest {
-  return {
-    eventType,
-    ...(idToken != null ? { idToken } : {}),
-    meterValue: [],
-    seqNo: 0,
-    timestamp: new Date(),
-    transactionInfo: {
-      transactionId,
-    },
-    triggerReason: OCPP20TriggerReasonEnumType.Authorized,
-  }
-}
-
-/**
- * Wraps an OCPP20ResponseService instance so its private
- * `handleResponseTransactionEvent` is reachable by tests via a typed cast.
- * Mirrors the helper in `OCPP20ResponseService-TransactionEvent.test.ts`.
- * @param service - The OCPP20ResponseService instance to wrap
- * @returns A typed interface exposing the private handler
- */
-function createTestableResponseService (
-  service: OCPP20ResponseService
-): TestableOCPP20ResponseService {
-  const serviceImpl = service as unknown as TestableOCPP20ResponseService
-  return {
-    handleResponseTransactionEvent: serviceImpl.handleResponseTransactionEvent.bind(service),
-  }
-}
+import {
+  buildTransactionEventRequest,
+  createTestableOCPP20ResponseService,
+  type TestableOCPP20ResponseService,
+} from './OCPP20ResponseServiceTestUtils.js'
 
 await describe('OCPP20ResponseService — forceTransactionOnInvalidIdToken (issue #1826)', async () => {
   let station: ChargingStation
@@ -125,7 +72,7 @@ await describe('OCPP20ResponseService — forceTransactionOnInvalidIdToken (issu
       connectorStatus.transactionId = TEST_TRANSACTION_UUID
     }
     const responseService = new OCPP20ResponseService()
-    testable = createTestableResponseService(responseService)
+    testable = createTestableOCPP20ResponseService(responseService)
   })
 
   afterEach(() => {
@@ -226,7 +173,7 @@ await describe('OCPP20ResponseService — forceTransactionOnInvalidIdToken (issu
     if (endedConnector != null) {
       endedConnector.transactionId = TEST_TRANSACTION_UUID
     }
-    const endedTestable = createTestableResponseService(new OCPP20ResponseService())
+    const endedTestable = createTestableOCPP20ResponseService(new OCPP20ResponseService())
     const mockDeauthEnded = mock.method(
       OCPP20ServiceUtils,
       'requestDeauthorizeTransaction',
@@ -352,7 +299,7 @@ await describe('OCPP20ResponseService — forceTransactionOnInvalidIdToken (issu
     mock.method(OCPP20ServiceUtils, 'startUpdatedMeterValues', () => undefined)
     mock.method(OCPP20ServiceUtils, 'startEndedMeterValues', () => undefined)
     const warnMockOff = mock.method(logger, 'warn', () => undefined)
-    const flagOffTestable = createTestableResponseService(new OCPP20ResponseService())
+    const flagOffTestable = createTestableOCPP20ResponseService(new OCPP20ResponseService())
 
     const payload: OCPP20TransactionEventResponse = {}
     const requestPayload = buildTransactionEventRequest(
@@ -439,7 +386,7 @@ await describe('OCPP20ResponseService — forceTransactionOnInvalidIdToken (issu
       if (cacheConnector != null) {
         cacheConnector.transactionId = TEST_TRANSACTION_UUID
       }
-      const cacheTestable = createTestableResponseService(new OCPP20ResponseService())
+      const cacheTestable = createTestableOCPP20ResponseService(new OCPP20ResponseService())
       mock.method(OCPP20ServiceUtils, 'requestDeauthorizeTransaction', async () =>
         Promise.resolve({} as OCPP20TransactionEventResponse)
       )

--- a/tests/charging-station/ocpp/2.0/OCPP20ResponseService-ForceTxOnInvalid.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20ResponseService-ForceTxOnInvalid.test.ts
@@ -24,6 +24,10 @@ import { afterEach, beforeEach, describe, it, mock } from 'node:test'
 import type { ChargingStation } from '../../../../src/charging-station/index.js'
 import type { OCPP20TransactionEventResponse } from '../../../../src/types/index.js'
 
+import {
+  createTestableResponseService,
+  type TestableOCPP20ResponseService,
+} from '../../../../src/charging-station/ocpp/2.0/__testable__/index.js'
 import { OCPP20ResponseService } from '../../../../src/charging-station/ocpp/2.0/OCPP20ResponseService.js'
 import { OCPP20ServiceUtils } from '../../../../src/charging-station/ocpp/2.0/OCPP20ServiceUtils.js'
 import {
@@ -43,11 +47,7 @@ import {
   TEST_TRANSACTION_UUID,
 } from '../../ChargingStationTestConstants.js'
 import { createMockChargingStation } from '../../helpers/StationHelpers.js'
-import {
-  buildTransactionEventRequest,
-  createTestableOCPP20ResponseService,
-  type TestableOCPP20ResponseService,
-} from './OCPP20ResponseServiceTestUtils.js'
+import { buildTransactionEventRequest } from './OCPP20ResponseServiceTestUtils.js'
 
 await describe('OCPP20ResponseService — forceTransactionOnInvalidIdToken (issue #1826)', async () => {
   let station: ChargingStation
@@ -72,7 +72,7 @@ await describe('OCPP20ResponseService — forceTransactionOnInvalidIdToken (issu
       connectorStatus.transactionId = TEST_TRANSACTION_UUID
     }
     const responseService = new OCPP20ResponseService()
-    testable = createTestableOCPP20ResponseService(responseService)
+    testable = createTestableResponseService(responseService)
   })
 
   afterEach(() => {
@@ -173,7 +173,7 @@ await describe('OCPP20ResponseService — forceTransactionOnInvalidIdToken (issu
     if (endedConnector != null) {
       endedConnector.transactionId = TEST_TRANSACTION_UUID
     }
-    const endedTestable = createTestableOCPP20ResponseService(new OCPP20ResponseService())
+    const endedTestable = createTestableResponseService(new OCPP20ResponseService())
     const mockDeauthEnded = mock.method(
       OCPP20ServiceUtils,
       'requestDeauthorizeTransaction',
@@ -299,7 +299,7 @@ await describe('OCPP20ResponseService — forceTransactionOnInvalidIdToken (issu
     mock.method(OCPP20ServiceUtils, 'startUpdatedMeterValues', () => undefined)
     mock.method(OCPP20ServiceUtils, 'startEndedMeterValues', () => undefined)
     const warnMockOff = mock.method(logger, 'warn', () => undefined)
-    const flagOffTestable = createTestableOCPP20ResponseService(new OCPP20ResponseService())
+    const flagOffTestable = createTestableResponseService(new OCPP20ResponseService())
 
     const payload: OCPP20TransactionEventResponse = {}
     const requestPayload = buildTransactionEventRequest(
@@ -386,7 +386,7 @@ await describe('OCPP20ResponseService — forceTransactionOnInvalidIdToken (issu
       if (cacheConnector != null) {
         cacheConnector.transactionId = TEST_TRANSACTION_UUID
       }
-      const cacheTestable = createTestableOCPP20ResponseService(new OCPP20ResponseService())
+      const cacheTestable = createTestableResponseService(new OCPP20ResponseService())
       mock.method(OCPP20ServiceUtils, 'requestDeauthorizeTransaction', async () =>
         Promise.resolve({} as OCPP20TransactionEventResponse)
       )

--- a/tests/charging-station/ocpp/2.0/OCPP20ResponseService-TransactionEvent.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20ResponseService-TransactionEvent.test.ts
@@ -8,19 +8,13 @@ import assert from 'node:assert/strict'
 import { afterEach, beforeEach, describe, it, mock } from 'node:test'
 
 import type { ChargingStation } from '../../../../src/charging-station/index.js'
-import type {
-  OCPP20TransactionEventRequest,
-  OCPP20TransactionEventResponse,
-  UUIDv4,
-} from '../../../../src/types/index.js'
+import type { OCPP20TransactionEventResponse, UUIDv4 } from '../../../../src/types/index.js'
 
 import { OCPP20ResponseService } from '../../../../src/charging-station/ocpp/2.0/OCPP20ResponseService.js'
 import { OCPP20ServiceUtils } from '../../../../src/charging-station/ocpp/2.0/OCPP20ServiceUtils.js'
 import {
   OCPP20AuthorizationStatusEnumType,
   OCPP20MessageFormatEnumType,
-  OCPP20TransactionEventEnumType,
-  OCPP20TriggerReasonEnumType,
   OCPPVersion,
 } from '../../../../src/types/index.js'
 import { Constants } from '../../../../src/utils/index.js'
@@ -33,46 +27,11 @@ import {
   TEST_TRANSACTION_UUID,
 } from '../../ChargingStationTestConstants.js'
 import { createMockChargingStation } from '../../helpers/StationHelpers.js'
-
-interface TestableOCPP20ResponseService {
-  handleResponseTransactionEvent: (
-    chargingStation: ChargingStation,
-    payload: OCPP20TransactionEventResponse,
-    requestPayload: OCPP20TransactionEventRequest
-  ) => Promise<void>
-}
-
-/**
- * Builds a minimal OCPP20TransactionEventRequest for use as requestPayload in tests.
- * @param transactionId - The transaction UUID to embed in transactionInfo
- * @returns A minimal OCPP20TransactionEventRequest
- */
-function buildTransactionEventRequest (transactionId: UUIDv4): OCPP20TransactionEventRequest {
-  return {
-    eventType: OCPP20TransactionEventEnumType.Updated,
-    meterValue: [],
-    seqNo: 0,
-    timestamp: new Date(),
-    transactionInfo: {
-      transactionId,
-    },
-    triggerReason: OCPP20TriggerReasonEnumType.Authorized,
-  }
-}
-
-/**
- * Creates a testable wrapper around OCPP20ResponseService.
- * @param service - The OCPP20ResponseService instance to wrap
- * @returns A typed interface exposing private handler methods
- */
-function createTestableResponseService (
-  service: OCPP20ResponseService
-): TestableOCPP20ResponseService {
-  const serviceImpl = service as unknown as TestableOCPP20ResponseService
-  return {
-    handleResponseTransactionEvent: serviceImpl.handleResponseTransactionEvent.bind(service),
-  }
-}
+import {
+  buildTransactionEventRequest,
+  createTestableOCPP20ResponseService,
+  type TestableOCPP20ResponseService,
+} from './OCPP20ResponseServiceTestUtils.js'
 
 await describe('D01 - TransactionEvent Response', async () => {
   let station: ChargingStation
@@ -98,7 +57,7 @@ await describe('D01 - TransactionEvent Response', async () => {
       connectorStatus.transactionId = TEST_TRANSACTION_UUID
     }
     const responseService = new OCPP20ResponseService()
-    testable = createTestableResponseService(responseService)
+    testable = createTestableOCPP20ResponseService(responseService)
   })
 
   afterEach(() => {
@@ -308,7 +267,7 @@ await describe('D01 - TransactionEvent Response', async () => {
         status: OCPP20AuthorizationStatusEnumType.Invalid,
       },
     }
-    const multiTestable = createTestableResponseService(new OCPP20ResponseService())
+    const multiTestable = createTestableOCPP20ResponseService(new OCPP20ResponseService())
 
     // Act — reject EVSE 1's transaction only
     await multiTestable.handleResponseTransactionEvent(

--- a/tests/charging-station/ocpp/2.0/OCPP20ResponseService-TransactionEvent.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20ResponseService-TransactionEvent.test.ts
@@ -10,6 +10,10 @@ import { afterEach, beforeEach, describe, it, mock } from 'node:test'
 import type { ChargingStation } from '../../../../src/charging-station/index.js'
 import type { OCPP20TransactionEventResponse, UUIDv4 } from '../../../../src/types/index.js'
 
+import {
+  createTestableResponseService,
+  type TestableOCPP20ResponseService,
+} from '../../../../src/charging-station/ocpp/2.0/__testable__/index.js'
 import { OCPP20ResponseService } from '../../../../src/charging-station/ocpp/2.0/OCPP20ResponseService.js'
 import { OCPP20ServiceUtils } from '../../../../src/charging-station/ocpp/2.0/OCPP20ServiceUtils.js'
 import {
@@ -27,11 +31,7 @@ import {
   TEST_TRANSACTION_UUID,
 } from '../../ChargingStationTestConstants.js'
 import { createMockChargingStation } from '../../helpers/StationHelpers.js'
-import {
-  buildTransactionEventRequest,
-  createTestableOCPP20ResponseService,
-  type TestableOCPP20ResponseService,
-} from './OCPP20ResponseServiceTestUtils.js'
+import { buildTransactionEventRequest } from './OCPP20ResponseServiceTestUtils.js'
 
 await describe('D01 - TransactionEvent Response', async () => {
   let station: ChargingStation
@@ -57,7 +57,7 @@ await describe('D01 - TransactionEvent Response', async () => {
       connectorStatus.transactionId = TEST_TRANSACTION_UUID
     }
     const responseService = new OCPP20ResponseService()
-    testable = createTestableOCPP20ResponseService(responseService)
+    testable = createTestableResponseService(responseService)
   })
 
   afterEach(() => {
@@ -267,7 +267,7 @@ await describe('D01 - TransactionEvent Response', async () => {
         status: OCPP20AuthorizationStatusEnumType.Invalid,
       },
     }
-    const multiTestable = createTestableOCPP20ResponseService(new OCPP20ResponseService())
+    const multiTestable = createTestableResponseService(new OCPP20ResponseService())
 
     // Act — reject EVSE 1's transaction only
     await multiTestable.handleResponseTransactionEvent(

--- a/tests/charging-station/ocpp/2.0/OCPP20ResponseServiceTestUtils.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20ResponseServiceTestUtils.ts
@@ -1,9 +1,10 @@
-import type { ChargingStation } from '../../../../src/charging-station/index.js'
-import type { OCPP20ResponseService } from '../../../../src/charging-station/ocpp/2.0/OCPP20ResponseService.js'
+/**
+ * @file OCPP20ResponseServiceTestUtils
+ * @description Test-only payload builders for OCPP 2.0 response-service tests
+ */
 import type {
   OCPP20IdTokenType,
   OCPP20TransactionEventRequest,
-  OCPP20TransactionEventResponse,
   UUIDv4,
 } from '../../../../src/types/index.js'
 
@@ -12,49 +13,26 @@ import {
   OCPP20TriggerReasonEnumType,
 } from '../../../../src/types/index.js'
 
-export interface TestableOCPP20ResponseService {
-  handleResponseTransactionEvent: (
-    chargingStation: ChargingStation,
-    payload: OCPP20TransactionEventResponse,
-    requestPayload: OCPP20TransactionEventRequest
-  ) => Promise<void>
-}
-
 /**
  * Build a minimal TransactionEvent request payload for response-service tests.
  * @param transactionId - Transaction id to embed in the request payload.
  * @param eventType - TransactionEvent type to use; defaults to Updated.
- * @param idToken - Optional idToken used by authorization-cache test cases.
+ * @param idToken - Optional idToken used by authorization-cache test cases
+ *   (see `OCPP20IdTokenType` for field semantics).
  * @returns Minimal TransactionEvent request payload.
  */
-export function buildTransactionEventRequest (
+export const buildTransactionEventRequest = (
   transactionId: UUIDv4,
   eventType: OCPP20TransactionEventEnumType = OCPP20TransactionEventEnumType.Updated,
   idToken?: OCPP20IdTokenType
-): OCPP20TransactionEventRequest {
-  return {
-    eventType,
-    ...(idToken != null ? { idToken } : {}),
-    meterValue: [],
-    seqNo: 0,
-    timestamp: new Date(),
-    transactionInfo: {
-      transactionId,
-    },
-    triggerReason: OCPP20TriggerReasonEnumType.Authorized,
-  }
-}
-
-/**
- * Expose OCPP20ResponseService private handlers through a typed test wrapper.
- * @param service - Response service instance to wrap.
- * @returns Test wrapper exposing private handler methods.
- */
-export function createTestableOCPP20ResponseService (
-  service: OCPP20ResponseService
-): TestableOCPP20ResponseService {
-  const serviceImpl = service as unknown as TestableOCPP20ResponseService
-  return {
-    handleResponseTransactionEvent: serviceImpl.handleResponseTransactionEvent.bind(service),
-  }
-}
+): OCPP20TransactionEventRequest => ({
+  eventType,
+  ...(idToken != null ? { idToken } : {}),
+  meterValue: [],
+  seqNo: 0,
+  timestamp: new Date(),
+  transactionInfo: {
+    transactionId,
+  },
+  triggerReason: OCPP20TriggerReasonEnumType.Authorized,
+})

--- a/tests/charging-station/ocpp/2.0/OCPP20ResponseServiceTestUtils.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20ResponseServiceTestUtils.ts
@@ -1,0 +1,60 @@
+import type { ChargingStation } from '../../../../src/charging-station/index.js'
+import type { OCPP20ResponseService } from '../../../../src/charging-station/ocpp/2.0/OCPP20ResponseService.js'
+import type {
+  OCPP20IdTokenType,
+  OCPP20TransactionEventRequest,
+  OCPP20TransactionEventResponse,
+  UUIDv4,
+} from '../../../../src/types/index.js'
+
+import {
+  OCPP20TransactionEventEnumType,
+  OCPP20TriggerReasonEnumType,
+} from '../../../../src/types/index.js'
+
+export interface TestableOCPP20ResponseService {
+  handleResponseTransactionEvent: (
+    chargingStation: ChargingStation,
+    payload: OCPP20TransactionEventResponse,
+    requestPayload: OCPP20TransactionEventRequest
+  ) => Promise<void>
+}
+
+/**
+ * Build a minimal TransactionEvent request payload for response-service tests.
+ * @param transactionId - Transaction id to embed in the request payload.
+ * @param eventType - TransactionEvent type to use; defaults to Updated.
+ * @param idToken - Optional idToken used by authorization-cache test cases.
+ * @returns Minimal TransactionEvent request payload.
+ */
+export function buildTransactionEventRequest (
+  transactionId: UUIDv4,
+  eventType: OCPP20TransactionEventEnumType = OCPP20TransactionEventEnumType.Updated,
+  idToken?: OCPP20IdTokenType
+): OCPP20TransactionEventRequest {
+  return {
+    eventType,
+    ...(idToken != null ? { idToken } : {}),
+    meterValue: [],
+    seqNo: 0,
+    timestamp: new Date(),
+    transactionInfo: {
+      transactionId,
+    },
+    triggerReason: OCPP20TriggerReasonEnumType.Authorized,
+  }
+}
+
+/**
+ * Expose OCPP20ResponseService private handlers through a typed test wrapper.
+ * @param service - Response service instance to wrap.
+ * @returns Test wrapper exposing private handler methods.
+ */
+export function createTestableOCPP20ResponseService (
+  service: OCPP20ResponseService
+): TestableOCPP20ResponseService {
+  const serviceImpl = service as unknown as TestableOCPP20ResponseService
+  return {
+    handleResponseTransactionEvent: serviceImpl.handleResponseTransactionEvent.bind(service),
+  }
+}

--- a/tests/charging-station/ocpp/auth/helpers/MockFactories.ts
+++ b/tests/charging-station/ocpp/auth/helpers/MockFactories.ts
@@ -14,6 +14,7 @@ import type {
 import type { OCPPAuthServiceImpl } from '../../../../../src/charging-station/ocpp/auth/services/OCPPAuthServiceImpl.js'
 import type { LocalAuthStrategy } from '../../../../../src/charging-station/ocpp/auth/strategies/LocalAuthStrategy.js'
 
+import { OCPPAuthServiceFactory } from '../../../../../src/charging-station/ocpp/auth/services/OCPPAuthServiceFactory.js'
 import {
   type AuthConfiguration,
   AuthContext,
@@ -356,4 +357,54 @@ export const getTestAuthCache = (authService: OCPPAuthService): AuthCache => {
   const cache = localStrategy?.getAuthCache()
   assert.ok(cache != null, 'Auth cache must be available for test')
   return cache
+}
+
+// ============================================================================
+// Factory Injection Helpers
+// ============================================================================
+
+/**
+ * Register a mock OCPPAuthService in the factory cache for the given station.
+ * Centralizes the station-id lookup and `setInstanceForTesting` plumbing used
+ * by OCPP 2.0 IncomingRequest tests (ClearCache, LocalAuthList, ...).
+ * @param station - Charging station under test (station-id read from stationInfo).
+ * @param service - Mock auth service to register.
+ * @returns The injected service for chaining.
+ */
+export const injectMockAuthService = (
+  station: ChargingStation,
+  service: OCPPAuthService
+): OCPPAuthService => {
+  OCPPAuthServiceFactory.setInstanceForTesting(
+    station.stationInfo?.chargingStationId ?? 'unknown',
+    service
+  )
+  return service
+}
+
+/**
+ * Replace `OCPPAuthServiceFactory.getInstance` with a throwing function for the
+ * duration of `fn`, then restore the original. Used by tests that must exercise
+ * handler code paths surviving a factory failure (factory unavailable, no
+ * Authorization Cache support, ...). Required because `setInstanceForTesting`
+ * only injects a returned instance — it cannot make `getInstance` itself throw.
+ * @param errorMessage - Error message thrown by the patched `getInstance`.
+ * @param fn - Synchronous or asynchronous function executed while patched.
+ * @returns The value returned by `fn`.
+ */
+export const withThrowingAuthServiceFactory = async <T>(
+  errorMessage: string,
+  fn: () => Promise<T> | T
+): Promise<T> => {
+  const original = OCPPAuthServiceFactory.getInstance.bind(OCPPAuthServiceFactory)
+  Object.assign(OCPPAuthServiceFactory, {
+    getInstance: (): never => {
+      throw new Error(errorMessage)
+    },
+  })
+  try {
+    return await fn()
+  } finally {
+    Object.assign(OCPPAuthServiceFactory, { getInstance: original })
+  }
 }

--- a/tests/charging-station/ocpp/auth/helpers/MockFactories.ts
+++ b/tests/charging-station/ocpp/auth/helpers/MockFactories.ts
@@ -364,11 +364,11 @@ export const getTestAuthCache = (authService: OCPPAuthService): AuthCache => {
 // ============================================================================
 
 /**
- * Register a mock OCPPAuthService in the factory cache for the given station.
+ * Inject a mock OCPPAuthService into the factory cache for the given station.
  * Centralizes the station-id lookup and `setInstanceForTesting` plumbing used
  * by OCPP 2.0 IncomingRequest tests (ClearCache, LocalAuthList, ...).
  * @param station - Charging station under test (station-id read from stationInfo).
- * @param service - Mock auth service to register.
+ * @param service - Mock auth service to inject.
  * @returns The injected service for chaining.
  */
 export const injectMockAuthService = (

--- a/tests/charging-station/ui-server/UIHttpServer.test.ts
+++ b/tests/charging-station/ui-server/UIHttpServer.test.ts
@@ -6,7 +6,6 @@
 import type { IncomingMessage } from 'node:http'
 
 import assert from 'node:assert/strict'
-import { once } from 'node:events'
 import { afterEach, beforeEach, describe, it } from 'node:test'
 import { gunzipSync } from 'node:zlib'
 
@@ -18,6 +17,7 @@ import { ApplicationProtocol, ResponseStatus } from '../../../src/types/index.js
 import { standardCleanup } from '../../helpers/TestLifecycleHelpers.js'
 import { TEST_UUID } from './UIServerTestConstants.js'
 import {
+  awaitFinish,
   createMockBootstrap,
   createMockIncomingMessage,
   createMockUIServerConfiguration,
@@ -33,6 +33,13 @@ class TestableUIHttpServer extends UIHttpServer {
 
   public addResponseHandler (uuid: UUIDv4, res: MockServerResponse): void {
     this.responseHandlers.set(uuid, res as never)
+  }
+
+  public emitRequest (req: IncomingMessage, res: MockServerResponse): void {
+    const httpServer = Reflect.get(this, 'httpServer') as {
+      emit: (eventName: string, req: IncomingMessage, res: MockServerResponse) => boolean
+    }
+    httpServer.emit('request', req, res)
   }
 
   public getAcceptsGzip (): Map<UUIDv4, boolean> {
@@ -225,7 +232,7 @@ await describe('UIHttpServer', async () => {
 
     try {
       gatedServer.start()
-      httpServer.emit('request', req, res)
+      gatedServer.emitRequest(req, res)
     } finally {
       httpServer.removeAllListeners()
       gatedServer.stop()
@@ -269,7 +276,7 @@ await describe('UIHttpServer', async () => {
 
     try {
       gatedServer.start()
-      httpServer.emit('request', denyingReq, res)
+      gatedServer.emitRequest(denyingReq, res)
     } finally {
       httpServer.removeAllListeners()
       gatedServer.stop()
@@ -330,7 +337,7 @@ await describe('UIHttpServer', async () => {
       gzipServer.setAcceptsGzip(TEST_UUID, true)
       gzipServer.sendResponse([TEST_UUID, createLargePayload()])
 
-      await once(res, 'finish')
+      await awaitFinish(res)
 
       assert.strictEqual(res.headers['Content-Encoding'], 'gzip')
       assert.strictEqual(res.headers['Content-Type'], 'application/json')
@@ -345,7 +352,7 @@ await describe('UIHttpServer', async () => {
       gzipServer.setAcceptsGzip(TEST_UUID, true)
       gzipServer.sendResponse([TEST_UUID, payload])
 
-      await once(res, 'finish')
+      await awaitFinish(res)
 
       assert.notStrictEqual(res.bodyBuffer, undefined)
       if (res.bodyBuffer == null) {
@@ -376,7 +383,7 @@ await describe('UIHttpServer', async () => {
 
       gzipServer.sendResponse([TEST_UUID, createLargePayload()])
 
-      await once(res, 'finish')
+      await awaitFinish(res)
 
       assert.strictEqual(gzipServer.getAcceptsGzip().has(TEST_UUID), false)
     })

--- a/tests/charging-station/ui-server/UIMetricsEndpoint.test.ts
+++ b/tests/charging-station/ui-server/UIMetricsEndpoint.test.ts
@@ -8,7 +8,6 @@ import type { mock } from 'node:test'
 import type { Registry } from 'prom-client'
 
 import assert from 'node:assert/strict'
-import { once } from 'node:events'
 import { afterEach, beforeEach, describe, it } from 'node:test'
 
 import type {
@@ -37,9 +36,11 @@ import {
 import { logger } from '../../../src/utils/index.js'
 import { standardCleanup } from '../../helpers/TestLifecycleHelpers.js'
 import {
+  awaitFinish,
   createMockBootstrap,
   createMockIncomingMessage,
   createMockUIServerConfiguration,
+  drainResponses,
   MockServerResponse,
 } from './UIServerTestUtils.js'
 
@@ -184,7 +185,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
     server.start()
     const res = new MockServerResponse()
     server.emitRequest(buildMetricsRequest(), res)
-    await once(res, 'finish')
+    await awaitFinish(res)
     assert.strictEqual(res.statusCode, 200)
     assert.match(res.headers['Content-Type'] ?? '', /^text\/plain;\s*version=0\.0\.4/)
     assert.match(res.body ?? '', /^# HELP /m)
@@ -232,7 +233,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
     server.start()
     const res = new MockServerResponse()
     server.emitRequest(buildMetricsRequest(), res)
-    await once(res, 'finish')
+    await awaitFinish(res)
     const body = res.body ?? ''
     assert.match(body, /^simulator_charging_stations_configured_total\s+5$/m)
     assert.match(body, /^simulator_charging_stations_provisioned_total\s+2$/m)
@@ -248,7 +249,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
     server.start()
     const res = new MockServerResponse()
     server.emitRequest(buildMetricsRequest(), res)
-    await once(res, 'finish')
+    await awaitFinish(res)
     const body = res.body ?? ''
     assert.match(body, /simulator_station_started\{[^}]*hash_id="station-T5"[^}]*\}\s+1/)
     assert.match(body, /simulator_station_ws_state\{[^}]*hash_id="station-T5"[^}]*\}\s+1/)
@@ -262,7 +263,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
     server.start()
     const res = new MockServerResponse()
     server.emitRequest(buildMetricsRequest(), res)
-    await once(res, 'finish')
+    await awaitFinish(res)
     const body = res.body ?? ''
     const line = body
       .split('\n')
@@ -375,7 +376,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
         }),
         res
       )
-      await once(res, 'finish')
+      await awaitFinish(res)
       assert.strictEqual(res.statusCode, 200)
     } finally {
       authServer.stop()
@@ -422,7 +423,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
     server.start()
     const res = new MockServerResponse()
     server.emitRequest(buildMetricsRequest(), res)
-    await once(res, 'finish')
+    await awaitFinish(res)
     const body = res.body ?? ''
     for (const secret of [
       'SECRET-IDTAG-12345',
@@ -462,7 +463,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
     server.start()
     const res = new MockServerResponse()
     server.emitRequest(buildMetricsRequest(), res)
-    await once(res, 'finish')
+    await awaitFinish(res)
     const body = res.body ?? ''
     assert.ok(
       !/^fake_metric\b/m.test(body),
@@ -505,7 +506,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
     server.start()
     const res = new MockServerResponse()
     server.emitRequest(buildMetricsRequest(), res)
-    await once(res, 'finish')
+    await awaitFinish(res)
     assert.strictEqual(res.statusCode, 200)
     const matchingCalls = warnSpy.mock.calls.filter(call => {
       const message: unknown = call.arguments[0]
@@ -524,7 +525,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
     server.start()
     const res = new MockServerResponse()
     server.emitRequest(buildMetricsRequest(), res)
-    await once(res, 'finish')
+    await awaitFinish(res)
     const body = res.body ?? ''
     assert.ok(
       !/simulator_station_ws_state\{[^}]*hash_id="station-Mws"[^}]*\}/.test(body),
@@ -563,7 +564,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
     server.start()
     const res = new MockServerResponse()
     server.emitRequest(buildMetricsRequest(), res)
-    await once(res, 'finish')
+    await awaitFinish(res)
     const body = res.body ?? ''
     assert.match(body, /simulator_station_connectors_total\{[^}]*hash_id="station-T18"[^}]*\}\s+1/)
     const statusLine = body
@@ -595,7 +596,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
     probeServer.start()
     const probeRes = new MockServerResponse()
     probeServer.emitRequest(buildMetricsRequest(), probeRes)
-    await once(probeRes, 'finish')
+    await awaitFinish(probeRes)
     const probedSampleCount = (probeRes.body ?? '')
       .split('\n')
       .filter(line => line.length > 0 && !line.startsWith('#')).length
@@ -616,7 +617,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
     exactServer.start()
     const exactRes = new MockServerResponse()
     exactServer.emitRequest(buildMetricsRequest(), exactRes)
-    await once(exactRes, 'finish')
+    await awaitFinish(exactRes)
     const exactSoftCapCalls = warnSpy.mock.calls.filter(call => {
       const message: unknown = call.arguments[0]
       return typeof message === 'string' && message.includes(METRICS_SOFT_CAP_WARN_PREFIX)
@@ -644,7 +645,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
     belowServer.start()
     const belowRes = new MockServerResponse()
     belowServer.emitRequest(buildMetricsRequest(), belowRes)
-    await once(belowRes, 'finish')
+    await awaitFinish(belowRes)
     const belowSoftCapCalls = warnSpy.mock.calls.filter(call => {
       const message: unknown = call.arguments[0]
       return typeof message === 'string' && message.includes(METRICS_SOFT_CAP_WARN_PREFIX)
@@ -676,7 +677,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
     probeServer.start()
     const probeRes = new MockServerResponse()
     probeServer.emitRequest(buildMetricsRequest(), probeRes)
-    await once(probeRes, 'finish')
+    await awaitFinish(probeRes)
     const probedSampleCount = (probeRes.body ?? '')
       .split('\n')
       .filter(line => line.length > 0 && !line.startsWith('#')).length
@@ -699,7 +700,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
     const resB = new MockServerResponse()
     concurrentServer.emitRequest(buildMetricsRequest(), resA)
     concurrentServer.emitRequest(buildMetricsRequest(), resB)
-    await Promise.all([once(resA, 'finish'), once(resB, 'finish')])
+    await drainResponses([resA, resB])
     concurrentServer.stop()
 
     assert.strictEqual(resA.statusCode, 200)
@@ -842,7 +843,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
       server.start()
       const res = new MockServerResponse()
       server.emitRequest(buildMetricsRequest(), res)
-      await once(res, 'finish')
+      await awaitFinish(res)
       const body = res.body ?? ''
       assert.ok(body.includes('1.0.0-✓'), 'non-ASCII version must propagate into exposition body')
       const checkMarkOccurrences = (body.match(/✓/gu) ?? []).length
@@ -1345,7 +1346,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
       const chain0 = getChain()
       const r1 = new MockServerResponse()
       server.emitRequest(buildMetricsRequest(), r1)
-      await once(r1, 'finish')
+      await awaitFinish(r1)
       const chainAfterScrape1 = getChain()
       assert.notStrictEqual(
         chainAfterScrape1,
@@ -1368,7 +1369,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
       )
       const r2 = new MockServerResponse()
       server.emitRequest(buildMetricsRequest(), r2)
-      await once(r2, 'finish')
+      await awaitFinish(r2)
       const chainAfterScrape2 = getChain()
       const all = [chain0, chainAfterScrape1, chainAfterStop, chain1, chainAfterScrape2]
       assert.strictEqual(
@@ -1390,7 +1391,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
       localServer.start()
       const r1 = new MockServerResponse()
       localServer.emitRequest(buildMetricsRequest(), r1)
-      await once(r1, 'finish')
+      await awaitFinish(r1)
       const registry = localServer.getMetricsRegistry()
       assert.ok(registry !== undefined, 'precondition: registry present before stop()')
       let clearCalls = 0
@@ -1441,7 +1442,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
       }
       const res = new MockServerResponse()
       localServer.emitRequest(buildMetricsRequest(), res)
-      await once(res, 'finish')
+      await awaitFinish(res)
       const rejectedChain = Reflect.get(localServer, 'metricsScrapeChain') as Promise<void>
       let rejected = false
       await rejectedChain.catch(() => {
@@ -1495,7 +1496,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
         setImmediate(resolve)
       })
       releaseGate()
-      await once(res, 'finish')
+      await awaitFinish(res)
       const scrapeWarns = warnSpy.mock.calls.filter(
         c =>
           typeof c.arguments[0] === 'string' &&
@@ -1524,7 +1525,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
       localServer.start()
       const res = new MockServerResponse()
       localServer.emitRequest(buildMetricsRequest(), res)
-      await once(res, 'finish')
+      await awaitFinish(res)
       assert.strictEqual(res.statusCode, 200)
       const sampleCount = (res.body ?? '')
         .split('\n')
@@ -1568,7 +1569,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
       localServer.start()
       const res = new MockServerResponse()
       localServer.emitRequest(buildMetricsRequest(), res)
-      await once(res, 'finish')
+      await awaitFinish(res)
       assert.strictEqual(res.statusCode, 200)
       const scrapeWarns = warnSpy.mock.calls.filter(
         c =>
@@ -1616,7 +1617,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
         'precondition: stop() nulled this.metricsRegistry mid-flight'
       )
       releaseGate()
-      await once(res, 'finish')
+      await awaitFinish(res)
       assert.strictEqual(
         res.statusCode,
         200,


### PR DESCRIPTION
## PR Checklist

- [x] Please add a description of your changes.
- [x] Please ensure title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] We need your changes to come with unit tests in order to keep this project in quality and easy to maintain.
- [x] If your changes contain any new feature please be sure to document it. Not applicable: test cleanup only.
- [x] Please add a link to the open issue or task that this pull request will resolve. Closes #1929.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

---

## Description

This PR cleans up test helpers and removes test-side monkey-patching of internal factories:

- UI server response tests: replace ad hoc `await once(res, 'finish')` waits with the existing
  `awaitFinish()` / `drainResponses()` helpers; add a local `emitRequest()` wrapper in
  `UIHttpServer.test.ts` for access-gate request emission.
- OCPP 2.0 ResponseService tests: extract the duplicated `buildTransactionEventRequest` payload
  builder into `OCPP20ResponseServiceTestUtils.ts`, and move the `createTestableResponseService`
  wrapper into the standard `src/charging-station/ocpp/2.0/__testable__/` location to match the
  `OCPP20RequestService` / `OCPP20VariableManager` precedent.
- OCPP 2.0 IncomingRequest tests (ClearCache, LocalAuthList): migrate from monkey-patched
  `Object.assign(OCPPAuthServiceFactory, …)` to the proper `setInstanceForTesting` /
  `clearAllInstances` injection API, plus two shared helpers `injectMockAuthService` and
  `withThrowingAuthServiceFactory` in `MockFactories.ts`.

No production behavior is changed.

## Validation

- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `GIT_MASTER=1 git diff --check origin/main..HEAD`
- `pnpm exec cross-env NODE_ENV=test node --import tsx --test --test-force-exit tests/charging-station/ui-server/UIHttpServer.test.ts tests/charging-station/ui-server/UIMetricsEndpoint.test.ts tests/charging-station/ui-server/UIMCPServer.test.ts tests/charging-station/ui-server/UIWebSocketServer.test.ts`
- `pnpm exec cross-env NODE_ENV=test node --import tsx --test --test-force-exit tests/charging-station/ocpp/2.0/OCPP20ResponseService-TransactionEvent.test.ts tests/charging-station/ocpp/2.0/OCPP20ResponseService-ForceTxOnInvalid.test.ts tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-ClearCache.test.ts tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-LocalAuthList.test.ts`
