### PR TITLE
refactor(meter-values): extract CoherentMeterValuesManager, shrink ICoherentContext, split OCPP16 begin helper (issue #1936 items a, b, e)

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -28,6 +28,7 @@ words:
   - unpushed
   - logform
   - mnemonist
+  - multiton
   - poolifier
   - measurand
   - measurands

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -9,6 +9,8 @@ import { URL } from 'node:url'
 import { parentPort } from 'node:worker_threads'
 import { type RawData, WebSocket } from 'ws'
 
+import type { CoherentSession } from './meter-values/index.js'
+
 import { BaseError, OCPPError } from '../exception/index.js'
 import { PerformanceStatistics } from '../performance/index.js'
 import {
@@ -110,6 +112,7 @@ import {
 } from '../utils/index.js'
 import { AutomaticTransactionGenerator } from './AutomaticTransactionGenerator.js'
 import { ChargingStationWorkerBroadcastChannel } from './broadcast-channel/ChargingStationWorkerBroadcastChannel.js'
+import { CoherentMeterValuesManager } from './CoherentMeterValuesManager.js'
 import {
   addConfigurationKey,
   deleteConfigurationKey,
@@ -132,7 +135,6 @@ import {
   getConnectorChargingProfilesLimit,
   getDefaultConnectorMaximumPower,
   getDefaultVoltageOut,
-  getEvProfilesFile,
   getHashId,
   getIdTagsFile,
   getMaxNumberOfConnectors,
@@ -148,14 +150,6 @@ import {
   validateStationInfo,
 } from './Helpers.js'
 import { IdTagsCache } from './IdTagsCache.js'
-import { disposeCoherentSessionRuntime } from './meter-values/CoherentMeterValuesGenerator.js'
-import {
-  type CoherentSession,
-  createCoherentSession,
-  type EvProfilesFile,
-  loadEvProfilesFile,
-  resolveRootSeed,
-} from './meter-values/index.js'
 import {
   buildBootNotificationRequest,
   createOCPPServices,
@@ -215,8 +209,6 @@ export class ChargingStation extends EventEmitter {
 
   private automaticTransactionGeneratorConfiguration?: AutomaticTransactionGeneratorConfiguration
   private readonly chargingStationWorkerBroadcastChannel: ChargingStationWorkerBroadcastChannel
-  private coherentEvProfiles?: EvProfilesFile
-  private readonly coherentSessions: Map<number | string, CoherentSession>
   private configurationFile!: string
   private configurationFileHash!: string
   private configuredSupervisionUrl!: URL
@@ -252,7 +244,6 @@ export class ChargingStation extends EventEmitter {
     this.sharedLRUCache = SharedLRUCache.getInstance()
     this.idTagsCache = IdTagsCache.getInstance()
     this.chargingStationWorkerBroadcastChannel = new ChargingStationWorkerBroadcastChannel(this)
-    this.coherentSessions = new Map<number | string, CoherentSession>()
 
     this.on(ChargingStationEvents.added, () => {
       parentPort?.postMessage(buildAddedMessage(this))
@@ -316,20 +307,15 @@ export class ChargingStation extends EventEmitter {
 
   /**
    * Injects a pre-built coherent session directly into the session store.
-   * **Test seam only** — never call from production code; enforced at
-   * runtime by a `NODE_ENV === 'production'` guard that throws
-   * {@link BaseError}.
+   * **Test seam only** — delegates to
+   * {@link CoherentMeterValuesManager.injectSession}, which enforces the
+   * `NODE_ENV === 'production'` guard.
    * @param transactionId - Transaction identifier.
    * @param session - Pre-built session.
    * @throws {BaseError} When invoked in a production build.
    */
   public __injectCoherentSession (transactionId: number | string, session: CoherentSession): void {
-    if (process.env.NODE_ENV === 'production') {
-      throw new BaseError(
-        `${this.logPrefix()} ${moduleName}.__injectCoherentSession: test-only seam called in production build`
-      )
-    }
-    this.coherentSessions.set(transactionId, session)
+    CoherentMeterValuesManager.getInstance(this)?.injectSession(transactionId, session)
   }
 
   /**
@@ -377,8 +363,9 @@ export class ChargingStation extends EventEmitter {
 
   /**
    * Creates or returns the coherent MeterValues session for a transaction.
-   * Idempotent. Returns `undefined` when coherent mode is disabled or no
-   * valid EV profile file is loaded.
+   * Idempotent. Delegates to
+   * {@link CoherentMeterValuesManager.createSession}; returns `undefined`
+   * when coherent mode is disabled or no valid EV profile file is loaded.
    * @param transactionId - Transaction identifier from the CSMS.
    * @param connectorId - Connector on which the transaction is running.
    * @returns The active or newly-created session, or `undefined` when
@@ -388,27 +375,7 @@ export class ChargingStation extends EventEmitter {
     transactionId: number | string,
     connectorId: number
   ): CoherentSession | undefined {
-    const existing = this.coherentSessions.get(transactionId)
-    if (existing != null) {
-      return existing
-    }
-    if (this.stationInfo?.coherentMeterValues !== true) {
-      return undefined
-    }
-    if (this.coherentEvProfiles == null || this.coherentEvProfiles.profiles.length === 0) {
-      return undefined
-    }
-    const rootSeed = resolveRootSeed(this.stationInfo)
-    const session = createCoherentSession(this, {
-      connectorId,
-      profiles: this.coherentEvProfiles.profiles,
-      rootSeed,
-      transactionId,
-    })
-    if (session != null) {
-      this.coherentSessions.set(transactionId, session)
-    }
-    return session
+    return CoherentMeterValuesManager.getInstance(this)?.createSession(transactionId, connectorId)
   }
 
   /**
@@ -428,6 +395,7 @@ export class ChargingStation extends EventEmitter {
       }
     }
     AutomaticTransactionGenerator.deleteInstance(this)
+    CoherentMeterValuesManager.deleteInstance(this)
     PerformanceStatistics.deleteInstance(this.stationInfo?.hashId)
     OCPPAuthServiceFactory.clearInstance(this)
     if (this.stationInfo != null) {
@@ -467,17 +435,14 @@ export class ChargingStation extends EventEmitter {
 
   /**
    * Removes the coherent session for a transaction. Idempotent — safe to
-   * call from every reset/stop/disconnect path. Also disposes the module-scope
-   * per-session runtime state (voltage-noise PRNG closure).
+   * call from every reset/stop/disconnect path. Delegates to
+   * {@link CoherentMeterValuesManager.destroySession}, which disposes the
+   * module-scope per-session runtime state (voltage-noise PRNG closure).
    * @param transactionId - Transaction identifier.
    * @returns `true` when a session was removed, `false` otherwise.
    */
   public destroyCoherentSession (transactionId: number | string | undefined): boolean {
-    if (transactionId == null) {
-      return false
-    }
-    disposeCoherentSessionRuntime(this.coherentSessions.get(transactionId))
-    return this.coherentSessions.delete(transactionId)
+    return CoherentMeterValuesManager.getInstance(this)?.destroySession(transactionId) ?? false
   }
 
   /**
@@ -540,12 +505,13 @@ export class ChargingStation extends EventEmitter {
   }
 
   /**
-   * Retrieves the coherent session for a transaction, if any.
+   * Retrieves the coherent session for a transaction, if any. Delegates
+   * to {@link CoherentMeterValuesManager.getSession}.
    * @param transactionId - Transaction identifier.
    * @returns The session or `undefined` when none exists.
    */
   public getCoherentSession (transactionId: number | string): CoherentSession | undefined {
-    return this.coherentSessions.get(transactionId)
+    return CoherentMeterValuesManager.getInstance(this)?.getSession(transactionId)
   }
 
   public getConnectionTimeout (): number {
@@ -1314,10 +1280,7 @@ export class ChargingStation extends EventEmitter {
           // Drop any coherent sessions still tracked at shutdown so a
           // subsequent restart cannot resurrect stale state or leak
           // module-scope runtime PRNG closures.
-          for (const session of this.coherentSessions.values()) {
-            disposeCoherentSessionRuntime(session)
-          }
-          this.coherentSessions.clear()
+          CoherentMeterValuesManager.getInstance(this)?.dispose()
           this.stopping = false
         }
       } else {
@@ -1911,7 +1874,12 @@ export class ChargingStation extends EventEmitter {
       }
     }
     this.saveStationInfo()
-    this.initializeCoherentEvProfiles()
+    // Trigger eager creation of the coherent MeterValues manager when
+    // opt-in is set, so EV-profile-file warnings surface at startup
+    // rather than at first transaction.
+    if (this.stationInfo.coherentMeterValues === true) {
+      CoherentMeterValuesManager.getInstance(this)
+    }
     this.configuredSupervisionUrl = this.getConfiguredSupervisionUrl()
     if (this.stationInfo.enableStatistics === true) {
       this.performanceStatistics = PerformanceStatistics.getInstance(
@@ -1940,33 +1908,6 @@ export class ChargingStation extends EventEmitter {
         status: RegistrationStatusEnumType.ACCEPTED,
       }
     }
-  }
-
-  /**
-   * Loads and validates the EV profile file when coherent MeterValues are
-   * enabled. Fail-soft: any error disables coherent mode for this station
-   * (createCoherentSession then becomes a no-op).
-   */
-  private initializeCoherentEvProfiles (): void {
-    this.coherentEvProfiles = undefined
-    if (this.stationInfo?.coherentMeterValues !== true) {
-      return
-    }
-    const evProfilesFile = getEvProfilesFile(this.stationInfo)
-    if (evProfilesFile == null) {
-      logger.warn(
-        `${this.logPrefix()} ${moduleName}.initializeCoherentEvProfiles: coherentMeterValues=true but no evProfilesFile is configured, coherent MeterValues disabled`
-      )
-      return
-    }
-    const loaded = loadEvProfilesFile(evProfilesFile, this.logPrefix())
-    if (loaded == null) {
-      logger.warn(
-        `${this.logPrefix()} ${moduleName}.initializeCoherentEvProfiles: EV profiles could not be loaded, coherent MeterValues disabled`
-      )
-      return
-    }
-    this.coherentEvProfiles = loaded
   }
 
   private initializeConnectorsFromTemplate (stationTemplate: ChargingStationTemplate): void {

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -1885,11 +1885,16 @@ export class ChargingStation extends EventEmitter {
       }
     }
     this.saveStationInfo()
-    // Trigger eager creation of the coherent MeterValues manager when
-    // opt-in is set, so EV-profile-file warnings surface at startup
-    // rather than at first transaction.
+    // Warm up the coherent MeterValues manager on opt-in so
+    // EV-profile-file warnings surface at startup, and reload profiles
+    // on every subsequent `initialize()` (reset, template file change)
+    // to propagate template mutations. When the opt-in flag flips
+    // `true → false` at runtime, drop the manager so cached sessions
+    // and stale profiles do not leak across the config change.
     if (this.stationInfo.coherentMeterValues === true) {
-      CoherentMeterValuesManager.getInstance(this)
+      CoherentMeterValuesManager.getInstance(this)?.reloadEvProfiles()
+    } else {
+      CoherentMeterValuesManager.deleteInstance(this)
     }
     this.configuredSupervisionUrl = this.getConfiguredSupervisionUrl()
     if (this.stationInfo.enableStatistics === true) {

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -1888,13 +1888,14 @@ export class ChargingStation extends EventEmitter {
     // Warm up the coherent MeterValues manager on opt-in so
     // EV-profile-file warnings surface at startup, and reload profiles
     // on every subsequent `initialize()` (reset, template file change)
-    // to propagate template mutations. When the opt-in flag flips
-    // `true → false` at runtime, drop the manager so cached sessions
-    // and stale profiles do not leak across the config change.
+    // to propagate template mutations. On opt-out we deliberately
+    // leave any pre-existing manager in place: new sessions are
+    // already blocked by the `coherentMeterValues` gate in
+    // `createSession`, and in-flight sessions drain via
+    // `destroyCoherentSession` on transaction end — preserving
+    // provenance of transactions started before the flag flip.
     if (this.stationInfo.coherentMeterValues === true) {
       CoherentMeterValuesManager.getInstance(this)?.reloadEvProfiles()
-    } else {
-      CoherentMeterValuesManager.deleteInstance(this)
     }
     this.configuredSupervisionUrl = this.getConfiguredSupervisionUrl()
     if (this.stationInfo.enableStatistics === true) {

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -366,6 +366,11 @@ export class ChargingStation extends EventEmitter {
    * Idempotent. Delegates to
    * {@link CoherentMeterValuesManager.createSession}; returns `undefined`
    * when coherent mode is disabled or no valid EV profile file is loaded.
+   *
+   * Uses `peekInstance` (lookup-only): opt-in stations warm up the
+   * manager at initialize, so subsequent calls find it in the cache;
+   * non-opt-in stations never allocate a manager because
+   * `manager.createSession` would return `undefined` anyway.
    * @param transactionId - Transaction identifier from the CSMS.
    * @param connectorId - Connector on which the transaction is running.
    * @returns The active or newly-created session, or `undefined` when
@@ -375,7 +380,7 @@ export class ChargingStation extends EventEmitter {
     transactionId: number | string,
     connectorId: number
   ): CoherentSession | undefined {
-    return CoherentMeterValuesManager.getInstance(this)?.createSession(transactionId, connectorId)
+    return CoherentMeterValuesManager.peekInstance(this)?.createSession(transactionId, connectorId)
   }
 
   /**
@@ -438,11 +443,13 @@ export class ChargingStation extends EventEmitter {
    * call from every reset/stop/disconnect path. Delegates to
    * {@link CoherentMeterValuesManager.destroySession}, which disposes the
    * module-scope per-session runtime state (voltage-noise PRNG closure).
+   * Uses `peekInstance` so non-opt-in stations never allocate a manager
+   * on a transaction-end tear-down.
    * @param transactionId - Transaction identifier.
    * @returns `true` when a session was removed, `false` otherwise.
    */
   public destroyCoherentSession (transactionId: number | string | undefined): boolean {
-    return CoherentMeterValuesManager.getInstance(this)?.destroySession(transactionId) ?? false
+    return CoherentMeterValuesManager.peekInstance(this)?.destroySession(transactionId) ?? false
   }
 
   /**
@@ -506,12 +513,16 @@ export class ChargingStation extends EventEmitter {
 
   /**
    * Retrieves the coherent session for a transaction, if any. Delegates
-   * to {@link CoherentMeterValuesManager.getSession}.
+   * to {@link CoherentMeterValuesManager.getSession}. Uses `peekInstance`
+   * because this method is reached from the unconditional strategy gate
+   * in `OCPPServiceUtils.buildMeterValue` on every MeterValue tick — a
+   * `getInstance` here would allocate a manager for every station that
+   * ever emits a MeterValue, opt-in or not.
    * @param transactionId - Transaction identifier.
    * @returns The session or `undefined` when none exists.
    */
   public getCoherentSession (transactionId: number | string): CoherentSession | undefined {
-    return CoherentMeterValuesManager.getInstance(this)?.getSession(transactionId)
+    return CoherentMeterValuesManager.peekInstance(this)?.getSession(transactionId)
   }
 
   public getConnectionTimeout (): number {
@@ -1280,7 +1291,7 @@ export class ChargingStation extends EventEmitter {
           // Drop any coherent sessions still tracked at shutdown so a
           // subsequent restart cannot resurrect stale state or leak
           // module-scope runtime PRNG closures.
-          CoherentMeterValuesManager.getInstance(this)?.dispose()
+          CoherentMeterValuesManager.peekInstance(this)?.dispose()
           this.stopping = false
         }
       } else {

--- a/src/charging-station/CoherentMeterValuesManager.ts
+++ b/src/charging-station/CoherentMeterValuesManager.ts
@@ -1,0 +1,218 @@
+// Copyright Jerome Benoit. 2021-2026. All Rights Reserved.
+
+/**
+ * @file Per-station coherent MeterValues lifecycle owner.
+ * @description Holds the EV profile file, the active-session Map, and the
+ *   create/destroy/inject lifecycle for physics-based coherent
+ *   MeterValues. Extracted from {@link ChargingStation} to keep the
+ *   strictly opt-in coherent surface off the main class body. Follows the
+ *   per-station multiton pattern of `AutomaticTransactionGenerator` /
+ *   `IdTagsCache` / `SharedLRUCache`: one instance per `stationInfo.hashId`.
+ */
+
+import type { ChargingStation } from './ChargingStation.js'
+
+import { BaseError } from '../exception/index.js'
+import { logger } from '../utils/index.js'
+import { getEvProfilesFile } from './Helpers.js'
+import { disposeCoherentSessionRuntime } from './meter-values/CoherentMeterValuesGenerator.js'
+import {
+  type CoherentSession,
+  createCoherentSession,
+  type EvProfilesFile,
+  loadEvProfilesFile,
+  resolveRootSeed,
+} from './meter-values/index.js'
+
+const moduleName = 'CoherentMeterValuesManager'
+
+/**
+ * Per-station owner of coherent MeterValues state. Instances are keyed by
+ * `stationInfo.hashId` and shared across every OCPP handler and service
+ * util that touches a station's transactions.
+ *
+ * The manager is created eagerly at station initialization when
+ * `coherentMeterValues=true`; stations with the option off never allocate
+ * a manager.
+ */
+export class CoherentMeterValuesManager {
+  private static readonly instances: Map<string, CoherentMeterValuesManager> = new Map<
+    string,
+    CoherentMeterValuesManager
+  >()
+
+  private readonly chargingStation: ChargingStation
+  private evProfiles?: EvProfilesFile
+  private readonly sessions: Map<number | string, CoherentSession>
+
+  private constructor (chargingStation: ChargingStation) {
+    this.chargingStation = chargingStation
+    this.sessions = new Map<number | string, CoherentSession>()
+    this.reloadEvProfiles()
+  }
+
+  /**
+   * Drops the manager instance for the station after disposing every
+   * in-flight session runtime. Idempotent — safe to call from every
+   * shutdown path.
+   * @param chargingStation - Owning station.
+   * @returns `true` when an instance was removed, `false` otherwise.
+   */
+  public static deleteInstance (chargingStation: ChargingStation): boolean {
+    const hashId = chargingStation.stationInfo?.hashId
+    if (hashId == null) {
+      return false
+    }
+    const manager = CoherentMeterValuesManager.instances.get(hashId)
+    if (manager == null) {
+      return false
+    }
+    manager.dispose()
+    return CoherentMeterValuesManager.instances.delete(hashId)
+  }
+
+  /**
+   * Returns the manager for the station, constructing on first call. The
+   * constructor eagerly loads the EV profile file (fail-soft: warnings
+   * logged, coherent session creation silently disabled on error).
+   * @param chargingStation - Owning station. Requires `stationInfo.hashId`
+   *   to be resolved; returns `undefined` when called during early
+   *   bootstrap.
+   * @returns The station's manager, or `undefined` when `stationInfo` is
+   *   not yet resolved.
+   */
+  public static getInstance (
+    chargingStation: ChargingStation
+  ): CoherentMeterValuesManager | undefined {
+    const hashId = chargingStation.stationInfo?.hashId
+    if (hashId == null) {
+      return undefined
+    }
+    let manager = CoherentMeterValuesManager.instances.get(hashId)
+    if (manager == null) {
+      manager = new CoherentMeterValuesManager(chargingStation)
+      CoherentMeterValuesManager.instances.set(hashId, manager)
+    }
+    return manager
+  }
+
+  /**
+   * Creates or returns the coherent MeterValues session for a
+   * transaction. Idempotent. Returns `undefined` when coherent mode is
+   * disabled or no valid EV profile file is loaded.
+   * @param transactionId - Transaction identifier from the CSMS.
+   * @param connectorId - Connector on which the transaction is running.
+   * @returns The active or newly-created session, or `undefined` when
+   *   coherent mode is not usable.
+   */
+  public createSession (
+    transactionId: number | string,
+    connectorId: number
+  ): CoherentSession | undefined {
+    const existing = this.sessions.get(transactionId)
+    if (existing != null) {
+      return existing
+    }
+    if (this.chargingStation.stationInfo?.coherentMeterValues !== true) {
+      return undefined
+    }
+    if (this.evProfiles == null || this.evProfiles.profiles.length === 0) {
+      return undefined
+    }
+    const session = createCoherentSession(this.chargingStation, {
+      connectorId,
+      profiles: this.evProfiles.profiles,
+      rootSeed: resolveRootSeed(this.chargingStation.stationInfo),
+      transactionId,
+    })
+    if (session != null) {
+      this.sessions.set(transactionId, session)
+    }
+    return session
+  }
+
+  /**
+   * Removes the coherent session for a transaction and disposes its
+   * module-scope runtime state (voltage-noise PRNG closure). Idempotent
+   * — safe to call from every reset/stop/disconnect path.
+   * @param transactionId - Transaction identifier.
+   * @returns `true` when a session was removed, `false` otherwise.
+   */
+  public destroySession (transactionId: number | string | undefined): boolean {
+    if (transactionId == null) {
+      return false
+    }
+    disposeCoherentSessionRuntime(this.sessions.get(transactionId))
+    return this.sessions.delete(transactionId)
+  }
+
+  /**
+   * Disposes every in-flight session runtime and empties the store.
+   * Called by `ChargingStation.stop()` finalization so a subsequent
+   * restart cannot resurrect stale state or leak module-scope runtime
+   * PRNG closures.
+   */
+  public dispose (): void {
+    for (const session of this.sessions.values()) {
+      disposeCoherentSessionRuntime(session)
+    }
+    this.sessions.clear()
+  }
+
+  /**
+   * Retrieves the coherent session for a transaction, if any.
+   * @param transactionId - Transaction identifier.
+   * @returns The session or `undefined` when none exists.
+   */
+  public getSession (transactionId: number | string): CoherentSession | undefined {
+    return this.sessions.get(transactionId)
+  }
+
+  /**
+   * Injects a pre-built session directly into the store. **Test seam
+   * only** — never call from production code; enforced at runtime by a
+   * `NODE_ENV === 'production'` guard that throws {@link BaseError},
+   * mirroring the seam previously exposed on {@link ChargingStation}.
+   * @param transactionId - Transaction identifier.
+   * @param session - Pre-built session.
+   * @throws {BaseError} When invoked in a production build.
+   */
+  public injectSession (transactionId: number | string, session: CoherentSession): void {
+    if (process.env.NODE_ENV === 'production') {
+      throw new BaseError(
+        `${this.chargingStation.logPrefix()} ${moduleName}.injectSession: test-only seam called in production build`
+      )
+    }
+    this.sessions.set(transactionId, session)
+  }
+
+  /**
+   * Loads (or reloads) the EV profile file referenced by the station
+   * template. Fail-soft: any error leaves `evProfiles` as `undefined`,
+   * which turns {@link createSession} into a no-op for this station.
+   * Called eagerly by the constructor so operators see profile-file
+   * warnings at startup rather than at first transaction.
+   */
+  public reloadEvProfiles (): void {
+    this.evProfiles = undefined
+    const stationInfo = this.chargingStation.stationInfo
+    if (stationInfo?.coherentMeterValues !== true) {
+      return
+    }
+    const evProfilesFile = getEvProfilesFile(stationInfo)
+    if (evProfilesFile == null) {
+      logger.warn(
+        `${this.chargingStation.logPrefix()} ${moduleName}.reloadEvProfiles: coherentMeterValues=true but no evProfilesFile is configured, coherent MeterValues disabled`
+      )
+      return
+    }
+    const loaded = loadEvProfilesFile(evProfilesFile, this.chargingStation.logPrefix())
+    if (loaded == null) {
+      logger.warn(
+        `${this.chargingStation.logPrefix()} ${moduleName}.reloadEvProfiles: EV profiles could not be loaded, coherent MeterValues disabled`
+      )
+      return
+    }
+    this.evProfiles = loaded
+  }
+}

--- a/src/charging-station/CoherentMeterValuesManager.ts
+++ b/src/charging-station/CoherentMeterValuesManager.ts
@@ -75,11 +75,18 @@ export class CoherentMeterValuesManager {
    * Returns the manager for the station, constructing on first call. The
    * constructor eagerly loads the EV profile file (fail-soft: warnings
    * logged, coherent session creation silently disabled on error).
-   * @param chargingStation - Owning station. Requires `stationInfo.hashId`
-   *   to be resolved; returns `undefined` when called during early
-   *   bootstrap.
-   * @returns The station's manager, or `undefined` when `stationInfo` is
-   *   not yet resolved.
+   *
+   * Use this at write paths (`createSession`, `injectSession`) and the
+   * opt-in eager warm-up in `ChargingStation.initialize`. Read-only paths
+   * (`getSession`, `destroySession`, shutdown dispose) MUST use
+   * {@link peekInstance} to avoid allocating a manager for stations
+   * where `coherentMeterValues !== true` — the strategy gate in
+   * `OCPPServiceUtils.buildMeterValue` reaches this code path
+   * unconditionally on every MeterValue tick.
+   * @param chargingStation - Owning station.
+   * @returns The station's manager, or `undefined` iff
+   *   `stationInfo.hashId` is not yet resolved (early-bootstrap failure
+   *   mode — the sole path that returns `undefined`).
    */
   public static getInstance (
     chargingStation: ChargingStation
@@ -94,6 +101,26 @@ export class CoherentMeterValuesManager {
       CoherentMeterValuesManager.instances.set(hashId, manager)
     }
     return manager
+  }
+
+  /**
+   * Lookup-only sibling of {@link getInstance}. Returns the existing
+   * manager for the station or `undefined` — never constructs. Use at
+   * read-only paths reached from stations that may not have opted into
+   * coherent MeterValues, so non-opt-in stations never allocate.
+   * @param chargingStation - Owning station.
+   * @returns The station's existing manager, or `undefined` when no
+   *   manager has been created (station is not opted in, or
+   *   `stationInfo.hashId` is not yet resolved).
+   */
+  public static peekInstance (
+    chargingStation: ChargingStation
+  ): CoherentMeterValuesManager | undefined {
+    const hashId = chargingStation.stationInfo?.hashId
+    if (hashId == null) {
+      return undefined
+    }
+    return CoherentMeterValuesManager.instances.get(hashId)
   }
 
   /**

--- a/src/charging-station/CoherentMeterValuesManager.ts
+++ b/src/charging-station/CoherentMeterValuesManager.ts
@@ -76,13 +76,14 @@ export class CoherentMeterValuesManager {
    * constructor eagerly loads the EV profile file (fail-soft: warnings
    * logged, coherent session creation silently disabled on error).
    *
-   * Use this at write paths (`createSession`, `injectSession`) and the
-   * opt-in eager warm-up in `ChargingStation.initialize`. Read-only paths
-   * (`getSession`, `destroySession`, shutdown dispose) MUST use
-   * {@link peekInstance} to avoid allocating a manager for stations
-   * where `coherentMeterValues !== true` — the strategy gate in
-   * `OCPPServiceUtils.buildMeterValue` reaches this code path
-   * unconditionally on every MeterValue tick.
+   * Use this only at the opt-in eager warm-up in
+   * `ChargingStation.initialize` and at the `injectSession` test seam
+   * (where the production-guard `BaseError` throw must remain
+   * reachable). Every other read/write path — including `createSession`
+   * — MUST use {@link peekInstance}: the eager warm-up guarantees
+   * opt-in stations already have a cached manager, and non-opt-in
+   * stations must not allocate on paths reached from the unconditional
+   * strategy gate in `OCPPServiceUtils.buildMeterValue`.
    * @param chargingStation - Owning station.
    * @returns The station's manager, or `undefined` iff
    *   `stationInfo.hashId` is not yet resolved (early-bootstrap failure
@@ -105,9 +106,17 @@ export class CoherentMeterValuesManager {
 
   /**
    * Lookup-only sibling of {@link getInstance}. Returns the existing
-   * manager for the station or `undefined` — never constructs. Use at
-   * read-only paths reached from stations that may not have opted into
-   * coherent MeterValues, so non-opt-in stations never allocate.
+   * manager for the station or `undefined` — never constructs. Use on
+   * every path that must not allocate a manager on behalf of non-opt-in
+   * stations, including both reads (`getSession`) and idempotent
+   * teardown (`destroySession`, `stop()` dispose) — the strategy gate
+   * in `OCPPServiceUtils.buildMeterValue` reaches these paths
+   * unconditionally on every MeterValue tick.
+   *
+   * Load-bearing invariant: `ChargingStation.initialize` MUST call
+   * {@link getInstance} for opt-in stations before any subsequent write
+   * path is reached; otherwise `createCoherentSession` on an opt-in
+   * station silently no-ops because the cache miss returns `undefined`.
    * @param chargingStation - Owning station.
    * @returns The station's existing manager, or `undefined` when no
    *   manager has been created (station is not opted in, or

--- a/src/charging-station/CoherentMeterValuesManager.ts
+++ b/src/charging-station/CoherentMeterValuesManager.ts
@@ -213,10 +213,13 @@ export class CoherentMeterValuesManager {
    * mirroring the seam previously exposed on {@link ChargingStation}.
    *
    * Silently no-ops on non-opt-in stations
-   * (`stationInfo.coherentMeterValues !== true`) so the type guard
-   * `isCoherentModeActive(session)` — which now trusts session
-   * existence — cannot be tricked into activating the coherent wire
-   * path by injecting on a station that never opted in.
+   * (`stationInfo.coherentMeterValues !== true`) so on the
+   * production-backed injection path the type guard
+   * `isCoherentModeActive(session)` cannot activate the coherent wire
+   * path by injecting on a station that never opted in. Tests that
+   * mock `ChargingStation` may write to their own session store
+   * bypassing this seam; the mock is responsible for enforcing its own
+   * opt-in invariant where relevant.
    * @param transactionId - Transaction identifier.
    * @param session - Pre-built session.
    * @throws {BaseError} When invoked in a production build.

--- a/src/charging-station/CoherentMeterValuesManager.ts
+++ b/src/charging-station/CoherentMeterValuesManager.ts
@@ -1,4 +1,4 @@
-// Copyright Jerome Benoit. 2021-2026. All Rights Reserved.
+// Partial Copyright Jerome Benoit. 2021-2025. All Rights Reserved.
 
 /**
  * @file Per-station coherent MeterValues lifecycle owner.
@@ -81,7 +81,7 @@ export class CoherentMeterValuesManager {
    * (where the production-guard `BaseError` throw must remain
    * reachable). Every other read/write path — including `createSession`
    * — MUST use {@link peekInstance}: the eager warm-up guarantees
-   * opt-in stations already have a cached manager, and non-opt-in
+   * opt-in stations already have their instance entry, and non-opt-in
    * stations must not allocate on paths reached from the unconditional
    * strategy gate in `OCPPServiceUtils.buildMeterValue`.
    * @param chargingStation - Owning station.
@@ -107,16 +107,18 @@ export class CoherentMeterValuesManager {
   /**
    * Lookup-only sibling of {@link getInstance}. Returns the existing
    * manager for the station or `undefined` — never constructs. Use on
-   * every path that must not allocate a manager on behalf of non-opt-in
-   * stations, including both reads (`getSession`) and idempotent
-   * teardown (`destroySession`, `stop()` dispose) — the strategy gate
-   * in `OCPPServiceUtils.buildMeterValue` reaches these paths
+   * every non-warm-up path that must not allocate a manager on behalf
+   * of non-opt-in stations, including `createSession`, reads
+   * (`getSession`), and idempotent teardown (`destroySession`,
+   * `stop()` dispose) — the strategy gate in
+   * `OCPPServiceUtils.buildMeterValue` reaches these paths
    * unconditionally on every MeterValue tick.
    *
    * Load-bearing invariant: `ChargingStation.initialize` MUST call
    * {@link getInstance} for opt-in stations before any subsequent write
    * path is reached; otherwise `createCoherentSession` on an opt-in
-   * station silently no-ops because the cache miss returns `undefined`.
+   * station silently no-ops because the instances-map miss returns
+   * `undefined`.
    * @param chargingStation - Owning station.
    * @returns The station's existing manager, or `undefined` when no
    *   manager has been created (station is not opted in, or
@@ -209,6 +211,12 @@ export class CoherentMeterValuesManager {
    * only** — never call from production code; enforced at runtime by a
    * `NODE_ENV === 'production'` guard that throws {@link BaseError},
    * mirroring the seam previously exposed on {@link ChargingStation}.
+   *
+   * Silently no-ops on non-opt-in stations
+   * (`stationInfo.coherentMeterValues !== true`) so the type guard
+   * `isCoherentModeActive(session)` — which now trusts session
+   * existence — cannot be tricked into activating the coherent wire
+   * path by injecting on a station that never opted in.
    * @param transactionId - Transaction identifier.
    * @param session - Pre-built session.
    * @throws {BaseError} When invoked in a production build.
@@ -219,15 +227,21 @@ export class CoherentMeterValuesManager {
         `${this.chargingStation.logPrefix()} ${moduleName}.injectSession: test-only seam called in production build`
       )
     }
+    if (this.chargingStation.stationInfo?.coherentMeterValues !== true) {
+      return
+    }
     this.sessions.set(transactionId, session)
   }
 
   /**
    * Loads (or reloads) the EV profile file referenced by the station
-   * template. Fail-soft: any error leaves `evProfiles` as `undefined`,
-   * which turns {@link createSession} into a no-op for this station.
-   * Called eagerly by the constructor so operators see profile-file
-   * warnings at startup rather than at first transaction.
+   * template. Fail-soft: non-opt-in stations and any error leave
+   * `evProfiles` as `undefined`, which turns {@link createSession}
+   * into a no-op for this station. Called eagerly by the constructor
+   * so operators see profile-file warnings at startup rather than at
+   * first transaction, and re-invoked by `ChargingStation.initialize`
+   * on every reload so runtime mutations of `evProfilesFile` or the
+   * file contents propagate without a process restart.
    */
   public reloadEvProfiles (): void {
     this.evProfiles = undefined

--- a/src/charging-station/meter-values/CoherentMeterValuesGenerator.ts
+++ b/src/charging-station/meter-values/CoherentMeterValuesGenerator.ts
@@ -160,22 +160,20 @@ const fluctuate = (base: number, percent: number, prng: () => number): number =>
 }
 
 /**
- * Determines whether coherent mode is enabled on the given context and a
- * session exists for the transaction. Returned by the strategy gate to
- * decide dispatch.
- * @param context - Charging-station context (subset of `ChargingStation`).
- * @param transactionId - Transaction identifier.
- * @returns `true` if coherent mode should own MeterValue construction.
+ * Type guard indicating that the coherent strategy owns MeterValue
+ * construction for a transaction. Callers look up the session via the
+ * per-station manager and pass the result to this predicate; a non-null
+ * session implies coherent mode is active (sessions are only created
+ * when the opt-in `coherentMeterValues=true` template flag is set and a
+ * valid EV profile file is loaded).
+ * @param session - Session looked up from
+ *   {@link ../../CoherentMeterValuesManager.CoherentMeterValuesManager.getSession}.
+ * @returns `true` when the coherent path should own MeterValue
+ *   construction, narrowing `session` to `CoherentSession`.
  */
 export const isCoherentModeActive = (
-  context: ICoherentContext,
-  transactionId: number | string
-): boolean => {
-  if (context.stationInfo?.coherentMeterValues !== true) {
-    return false
-  }
-  return context.getCoherentSession(transactionId) != null
-}
+  session: CoherentSession | undefined
+): session is CoherentSession => session != null
 
 /**
  * Unconditionally advances the connector energy registers by `deltaEnergyWh`.
@@ -649,7 +647,11 @@ const resolveTemplates = (
  * {@link advanceEnergyRegister} independent of whether the Energy
  * measurand is emitted.
  * @param context - Charging-station context.
- * @param transactionId - Active transaction identifier.
+ * @param session - Active coherent session for the transaction. Callers
+ *   look this up via
+ *   {@link ../../CoherentMeterValuesManager.CoherentMeterValuesManager.getSession}
+ *   at the strategy gate and thread it through — the port no longer
+ *   exposes session lookup.
  * @param buildVersionedSampledValue - Versioned SampledValue builder from
  *   the OCPP dispatcher in `OCPPServiceUtils.buildMeterValue`.
  * @param options - Per-sample parameters (interval, seed material, timestamp).
@@ -663,18 +665,16 @@ const resolveTemplates = (
  */
 export const buildCoherentMeterValue = (
   context: ICoherentContext,
-  transactionId: number | string,
+  session: CoherentSession,
   buildVersionedSampledValue: BuildVersionedSampledValue,
   options: ComputeSampleOptions,
   mvContext?: MeterValueContext,
   enabledMeasurands?: ReadonlySet<MeterValueMeasurand>
 ): MeterValue => {
-  const session = context.getCoherentSession(transactionId)
-  const connectorStatus =
-    session != null ? context.getConnectorStatus(session.connectorId) : undefined
-  if (session == null || connectorStatus == null) {
+  const connectorStatus = context.getConnectorStatus(session.connectorId)
+  if (connectorStatus == null) {
     logger.warn(
-      `${context.logPrefix()} ${moduleName}.buildCoherentMeterValue: missing session or connector for transaction ${String(transactionId)}`
+      `${context.logPrefix()} ${moduleName}.buildCoherentMeterValue: missing connector ${session.connectorId.toString()} for transaction ${String(session.transactionId)}`
     )
     return { sampledValue: [], timestamp: new Date() }
   }

--- a/src/charging-station/meter-values/types.ts
+++ b/src/charging-station/meter-values/types.ts
@@ -111,10 +111,12 @@ export interface CoherentSession {
 /**
  * Minimal structural interface consumed by the coherent generator. Only
  * fields/methods actually used are declared to break any potential type
- * cycle back to `ChargingStation`.
+ * cycle back to `ChargingStation`. Per-transaction session lookup is
+ * intentionally NOT exposed here: sessions are threaded to the generator
+ * by the caller (the strategy gate), so this port describes only what
+ * the physics chain needs to query about the station itself.
  */
 export interface ICoherentContext {
-  getCoherentSession: (transactionId: number | string) => CoherentSession | undefined
   getConnectorMaximumAvailablePower: (connectorId: number) => number
   getConnectorStatus: (connectorId: number) => ConnectorStatus | undefined
   getNumberOfPhases: () => number

--- a/src/charging-station/ocpp/1.6/OCPP16ServiceUtils.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16ServiceUtils.ts
@@ -149,31 +149,15 @@ export class OCPP16ServiceUtils {
     connectorId: number,
     meterStart: number | undefined
   ): OCPP16MeterValue {
-    // Coherent path: when an active coherent session exists for this
-    // transaction, route through `buildMeterValue` so the begin MeterValue
-    // is drawn from the same physics chain as subsequent samples (SoC in
-    // the profile's initial band, energy=0, V=nominal, P=I=0). Vendor
-    // parameter `StartTxnSampledData` (per OCPP 1.6 Signed Meter Values
-    // whitepaper) overrides `MeterValuesSampledData` for this MeterValue
-    // when configured; `resolveEnabledMeasurands` falls back to
-    // `MeterValuesSampledData` when the vendor key is absent.
     const connectorStatus = chargingStation.getConnectorStatus(connectorId)
     const transactionId = connectorStatus?.transactionId
     const coherentSession =
       transactionId != null ? chargingStation.getCoherentSession(transactionId) : undefined
     if (transactionId != null && isCoherentModeActive(coherentSession)) {
-      const startTxnSampledDataKey = OCPP16VendorParametersKey.StartTxnSampledData
-      const measurandsKey =
-        getConfigurationKey(chargingStation, startTxnSampledDataKey)?.value != null
-          ? startTxnSampledDataKey
-          : undefined
-      return buildMeterValue(
+      return OCPP16ServiceUtils.buildCoherentTransactionBeginMeterValue(
         chargingStation,
-        transactionId,
-        0,
-        measurandsKey,
-        OCPP16MeterValueContext.TRANSACTION_BEGIN
-      ) as OCPP16MeterValue
+        transactionId
+      )
     }
     const meterValue = buildEmptyMeterValue() as OCPP16MeterValue
     // Energy.Active.Import.Register measurand (default)
@@ -981,6 +965,37 @@ export class OCPP16ServiceUtils {
         error
       )
     }
+  }
+
+  /**
+   * Coherent-path builder for the OCPP 1.6 transaction-begin MeterValue.
+   * Routes through `buildMeterValue` so the begin MeterValue is drawn
+   * from the same physics chain as subsequent samples (SoC in the
+   * profile's initial band, energy=0, V=nominal, P=I=0). Vendor
+   * parameter `StartTxnSampledData` (per the OCPP 1.6 Signed Meter
+   * Values whitepaper) overrides `MeterValuesSampledData` for this
+   * MeterValue when configured; `resolveEnabledMeasurands` falls back to
+   * `MeterValuesSampledData` when the vendor key is absent.
+   * @param chargingStation - Target charging station.
+   * @param transactionId - Active transaction identifier.
+   * @returns OCPP 1.6 MeterValue produced by the coherent physics chain.
+   */
+  private static buildCoherentTransactionBeginMeterValue (
+    chargingStation: ChargingStation,
+    transactionId: number | string
+  ): OCPP16MeterValue {
+    const startTxnSampledDataKey = OCPP16VendorParametersKey.StartTxnSampledData
+    const measurandsKey =
+      getConfigurationKey(chargingStation, startTxnSampledDataKey)?.value != null
+        ? startTxnSampledDataKey
+        : undefined
+    return buildMeterValue(
+      chargingStation,
+      transactionId,
+      0,
+      measurandsKey,
+      OCPP16MeterValueContext.TRANSACTION_BEGIN
+    ) as OCPP16MeterValue
   }
 
   private static buildSignedSampledValue (

--- a/src/charging-station/ocpp/1.6/OCPP16ServiceUtils.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16ServiceUtils.ts
@@ -159,7 +159,9 @@ export class OCPP16ServiceUtils {
     // `MeterValuesSampledData` when the vendor key is absent.
     const connectorStatus = chargingStation.getConnectorStatus(connectorId)
     const transactionId = connectorStatus?.transactionId
-    if (transactionId != null && isCoherentModeActive(chargingStation, transactionId)) {
+    const coherentSession =
+      transactionId != null ? chargingStation.getCoherentSession(transactionId) : undefined
+    if (transactionId != null && isCoherentModeActive(coherentSession)) {
       const startTxnSampledDataKey = OCPP16VendorParametersKey.StartTxnSampledData
       const measurandsKey =
         getConfigurationKey(chargingStation, startTxnSampledDataKey)?.value != null

--- a/src/charging-station/ocpp/OCPPServiceUtils.ts
+++ b/src/charging-station/ocpp/OCPPServiceUtils.ts
@@ -1160,16 +1160,16 @@ export const buildMeterValue = (
   // BEFORE the random/fixed measurand generation runs. When coherent mode
   // is not active for this station or no session exists for the transaction,
   // this is a no-op and the random/fixed code path is unchanged.
-  if (isCoherentModeActive(chargingStation, transactionId)) {
-    const rootSeed = resolveRootSeed(chargingStation.stationInfo)
+  const coherentSession = chargingStation.getCoherentSession(transactionId)
+  if (isCoherentModeActive(coherentSession)) {
     return buildCoherentMeterValue(
       chargingStation,
-      transactionId,
+      coherentSession,
       buildVersionedSampledValue,
       {
         intervalMs: interval,
         nowMs: Date.now(),
-        rootSeed,
+        rootSeed: resolveRootSeed(chargingStation.stationInfo),
       },
       context,
       resolveEnabledMeasurands(chargingStation, measurandsKey)

--- a/tests/charging-station/meter-values/CoherentMeterValuesGenerator.test.ts
+++ b/tests/charging-station/meter-values/CoherentMeterValuesGenerator.test.ts
@@ -106,7 +106,6 @@ const buildContext = (
   const sessions = new Map<number | string, CoherentSession>()
 
   const context: ICoherentContext = {
-    getCoherentSession: (id: number | string) => sessions.get(id),
     getConnectorMaximumAvailablePower: () => evseMax,
     getConnectorStatus: () => connectorStatus,
     getNumberOfPhases: () => numberOfPhases,
@@ -382,7 +381,7 @@ await describe('CoherentMeterValuesGenerator', async () => {
         MeterValueMeasurand.VOLTAGE,
       ])
       const before = connectorStatus.energyActiveImportRegisterValue ?? 0
-      buildCoherentMeterValue(context, 1, passThroughBuilder, {
+      buildCoherentMeterValue(context, session, passThroughBuilder, {
         intervalMs: TEST_METER_VALUES_INTERVAL_MS,
         nowMs: TEST_METER_VALUES_INTERVAL_MS,
         rootSeed: 42,
@@ -409,7 +408,7 @@ await describe('CoherentMeterValuesGenerator', async () => {
         [MeterValueMeasurand.ENERGY_ACTIVE_IMPORT_REGISTER],
         MeterValueUnit.WATT_HOUR
       )
-      const meterValue = buildCoherentMeterValue(context, 1, passThroughBuilder, {
+      const meterValue = buildCoherentMeterValue(context, session, passThroughBuilder, {
         intervalMs: 3_600_000, // 1 h → 1 Wh per 1 W
         nowMs: 3_600_000,
         rootSeed: 42,
@@ -439,7 +438,7 @@ await describe('CoherentMeterValuesGenerator', async () => {
         [MeterValueMeasurand.ENERGY_ACTIVE_IMPORT_REGISTER],
         MeterValueUnit.KILO_WATT_HOUR
       )
-      const meterValue = buildCoherentMeterValue(context, 1, passThroughBuilder, {
+      const meterValue = buildCoherentMeterValue(context, session, passThroughBuilder, {
         intervalMs: 3_600_000,
         nowMs: 3_600_000,
         rootSeed: 42,
@@ -885,7 +884,7 @@ await describe('CoherentMeterValuesGenerator', async () => {
         { measurand: MeterValueMeasurand.CURRENT_IMPORT, phase: MeterValuePhase.L1 },
         { measurand: MeterValueMeasurand.CURRENT_IMPORT, phase: MeterValuePhase.N },
       ] as unknown as SampledValueTemplate[]
-      const mv = buildCoherentMeterValue(context, 1, phaseBuilder, {
+      const mv = buildCoherentMeterValue(context, session, phaseBuilder, {
         intervalMs: TEST_METER_VALUES_INTERVAL_MS,
         nowMs: TEST_METER_VALUES_INTERVAL_MS,
         rootSeed: 42,
@@ -944,7 +943,7 @@ await describe('CoherentMeterValuesGenerator', async () => {
         { measurand: MeterValueMeasurand.VOLTAGE, phase: MeterValuePhase.L1_L2 },
         { measurand: MeterValueMeasurand.VOLTAGE, phase: MeterValuePhase.L1_N },
       ] as unknown as SampledValueTemplate[]
-      const mv = buildCoherentMeterValue(context, 1, passThroughBuilder, {
+      const mv = buildCoherentMeterValue(context, session, passThroughBuilder, {
         intervalMs: TEST_METER_VALUES_INTERVAL_MS,
         nowMs: TEST_METER_VALUES_INTERVAL_MS,
         rootSeed: 42,
@@ -981,7 +980,7 @@ await describe('CoherentMeterValuesGenerator', async () => {
           unit: MeterValueUnit.WATT_HOUR,
         },
       ] as unknown as SampledValueTemplate[]
-      const mv = buildCoherentMeterValue(context, 1, passThroughBuilder, {
+      const mv = buildCoherentMeterValue(context, session, passThroughBuilder, {
         intervalMs: 3_600_000,
         nowMs: 3_600_000,
         rootSeed: 42,


### PR DESCRIPTION
## Context

Addresses items **(a)**, **(b)**, **(e)** from issue #1936 (follow-ups deferred from PR #1935 / issue #40).

PR #1935 introduced a strategy gate in `OCPPServiceUtils.buildMeterValue` that dispatches between two peer simulation modes: **coherent** (physics chain V→P→I→ΔE→SoC with INV-1/2/3 by construction, seeded PRNG) and **random/fixed** (default; per-measurand random fluctuation on template values, independent draws). This PR is a pure refactor of the coherent-mode surface — the physics chain, seed discipline, register update semantics, and OCPP wire behavior are all **unchanged by inspection**.

## Item (a) — Extract `CoherentMeterValuesManager`

`ChargingStation` had accumulated 4 public methods (`createCoherentSession`, `destroyCoherentSession`, `getCoherentSession`, `__injectCoherentSession`), 1 private init (`initializeCoherentEvProfiles`), and 2 private fields (`coherentSessions`, `coherentEvProfiles`) for a strictly opt-in feature.

Extract to `src/charging-station/CoherentMeterValuesManager.ts` — a per-station multiton keyed by `stationInfo.hashId`, mirroring `AutomaticTransactionGenerator.getInstance(chargingStation)` / `IdTagsCache.getInstance()` / `SharedLRUCache.getInstance()`.

- **Public API preserved**: the 4 delegator methods on `ChargingStation` remain (1-line thin delegators), so all OCPP handler call sites (`OCPP16ResponseService`, `OCPP20ResponseService`, `OCPP20ServiceUtils`, `OCPP20IncomingRequestService`) and the test-helper mock (`tests/charging-station/helpers/StationHelpers.ts`) work unchanged.
- **NODE_ENV guard preserved**: `__injectCoherentSession` still throws `BaseError` in production builds; the guard now lives on `manager.injectSession`. `injectSession` additionally honors the `coherentMeterValues` opt-in gate on the production-backed injection path.
- **Lifecycle**: `deleteInstance(station)` called from `ChargingStation.delete()` (adjacent to `AutomaticTransactionGenerator.deleteInstance`); `dispose()` called from `ChargingStation.stop()` finally block. `initialize()` reloads EV profiles on every invocation so template mutations of `evProfilesFile` propagate across `reset()` and the template file watcher. When the `coherentMeterValues` flag flips `true → false` at runtime, the manager stays in place: new sessions are blocked by the opt-in gate in `createSession`, and in-flight sessions drain via `destroyCoherentSession` on transaction end — preserving provenance of transactions started before the flag flip.
- **Eager warm-up**: `ChargingStation.initialize` calls `CoherentMeterValuesManager.getInstance(this)` when `coherentMeterValues === true` so EV-profile-file warnings surface at startup rather than at first transaction.

## Item (b) — Drop `getCoherentSession` from `ICoherentContext`

Session lookup is now the caller's responsibility. `ICoherentContext` shrinks to what the physics chain actually needs to query about the station itself.

- `isCoherentModeActive(session): session is CoherentSession` — pure type guard replacing the two-tier (stationInfo + session-lookup) predicate. The `stationInfo.coherentMeterValues !== true` gate is implied by session existence on production-backed paths (sessions are only created via the manager when the flag is set; `injectSession` also honors the gate).
- `buildCoherentMeterValue(context, session, ...)` — takes the session directly. Internal `context.getCoherentSession` lookup and the "missing session" warning branch collapse to a single connector-lookup guard.
- Strategy gates in `OCPPServiceUtils.buildMeterValue` and `OCPP16ServiceUtils.buildTransactionBeginMeterValue` are threaded via `chargingStation.getCoherentSession(txId)` (the A1 delegator) — routes through the manager in production and through the test mock's own Map in tests.

## Item (e) — Extract `buildCoherentTransactionBeginMeterValue`

Split `OCPP16ServiceUtils.buildTransactionBeginMeterValue`'s dual responsibility. The coherent short-circuit (route through `buildMeterValue` with the vendor `StartTxnSampledData` override per the OCPP 1.6 Signed Meter Values whitepaper §3.3.4) moves to a named private static helper; the outer function keeps only the random/fixed default path plus the strategy gate.

The OCPP 1.6 strategy gate now lives at a single well-labeled boundary in this file, mirroring the pattern established by `OCPPServiceUtils.buildMeterValue`.

## Additional fix — `peekInstance` for lookup-only paths

Multi-lane review (Lanes A + D converged, MAJOR finding): the strategy gate reaches `ChargingStation.getCoherentSession` unconditionally on every MeterValue tick. Routing through `CoherentMeterValuesManager.getInstance` (a lazy-create factory) would allocate a manager + Map for every station that ever emits a MeterValue, regardless of opt-in — directly contradicting the file-header design contract that "stations with the option off never allocate a manager".

Fix: add `CoherentMeterValuesManager.peekInstance(cs)` — a lookup-only sibling of `getInstance` that never constructs. Route the four non-warm-up sites (create / read / destroy / dispose) through `peekInstance`; keep `getInstance` (create-if-missing) only at the opt-in eager warm-up in `initialize` and at `__injectCoherentSession` (so the production-guard `BaseError` throw remains reachable).

## Additional fix — template reload wire-up

Fresh 4-lane pass round 1 (Lanes 1 + 3 converged, MAJOR finding): the template file watcher and `reset()` path flushed `sharedLRUCache`, `idTagsCache`, and `OCPPAuthServiceFactory` before calling `initialize()` — but `initialize()` reached `CoherentMeterValuesManager.getInstance(this)` which returned the **cached** manager for the unchanged `hashId`. Its `evProfiles` were snapshotted at first-construction; `reloadEvProfiles` was defined public but never invoked externally. Result: runtime mutations of `evProfilesFile` or its file contents were a no-op for opt-in stations until process restart — a regression vs the reload semantics of every sibling cache on the same path.

Fix: `initialize()` now calls `CoherentMeterValuesManager.getInstance(this)?.reloadEvProfiles()` on opt-in so `evProfilesFile` mutations propagate across `reset()` / template reload without a process restart.

## Additional fix — preserve in-flight sessions across flag flip

Fresh 4-lane pass round 2 (Lane 2 MINOR): round-1's initial fix also included an `else { deleteInstance(this) }` branch to drop cached state on `coherentMeterValues: true → false` flip. Because the template file watcher orders `initialize()` BEFORE `stopAutomaticTransactionGenerator()`, the `deleteInstance` disposed every in-flight coherent session the moment the flag flipped — producing mixed-provenance `TransactionEvent(Ended)` frames on OCPP 2.0.x (coherent Begin + random Update/End frames after the flip). OCPP 1.6 masked the discontinuity because `buildTransactionEndMeterValue` emits register-only (the register scalar is coherent-consistent via `transactionEnergyActiveImportRegisterValue`), but 2.0.x routes the End frame through `buildMeterValue` and therefore through the strategy gate.

Fix: remove the `else` branch. New sessions on `coherentMeterValues=false` are already blocked by the opt-in gate in `createSession`; existing in-flight sessions drain naturally via `destroyCoherentSession` on transaction end. Provenance is preserved for transactions started before the flag flip; the `reloadEvProfiles` propagation on the `true` branch (the round-1 MAJOR fix) is unaffected.

## Commits

- `e318bb85f` — extract `CoherentMeterValuesManager` (item a)
- `98995539b` — thread coherent session, shrink `ICoherentContext` (item b)
- `3ee4979fb` — extract `buildCoherentTransactionBeginMeterValue` (item e)
- `3f52faf43` — add `peekInstance` (multi-lane review — phantom-allocation MAJOR)
- `563366e45` — tighten `getInstance` / `peekInstance` JSDoc (multi-lane review — MINOR)
- `13c9b95fb` — propagate template reload to coherent manager (fresh 4-lane pass R1 — MAJOR)
- `bc1efce99` — gate `injectSession`, harmonize banner and JSDoc (fresh 4-lane pass R1 — MINOR + NITs)
- `458362ad9` — preserve in-flight coherent sessions across opt-in flag flip (fresh 4-lane pass R2 — MINOR)
- `47870cc28` — calibrate `injectSession` JSDoc for mock-helper reality (fresh 4-lane pass R2 — NIT)

## Review method

Post-implementation review used the same multi-agent cross-validation loop that converged PR #1935, iterated to convergence (3 clean rounds), followed by a fresh multi-round pass with criteria adapted to the refactor scope (no physics changed → no math/physics lane).

| Round | Lane A elegance/TS | Lane B math/physics | Lane C OCPP spec | Lane D harmonization | Lane E terminology | Outcome |
|-------|-------------------|--------------------|-----------------|----------------------|-------------------|---------|
| 1 | MAJOR (phantom alloc) | SUB-THRESH | SUB-THRESH | MINOR (same root) | CLEAN | Cross-validated Lane A+D → `peekInstance` fix |
| 2 | MINOR (JSDoc stale) | NIT (JSDoc mislabel) | SUB-THRESH | CLEAN | (not re-run) | Cross-validated Lane A+B → JSDoc tighten |
| 3 | SUB-THRESH | SUB-THRESH | SUB-THRESH | SUB-THRESH | CLEAN | All 5 lanes clean → stop |

**Fresh multi-round pass** (adapted criteria — algorithmic/lifecycle + OCPP spec + harmonization + terminology; physics/math intentionally skipped as no physics surface changed):

| Round | Lane 1 design/algo | Lane 2 OCPP spec | Lane 3 harmonization | Lane 4 terminology | Outcome |
|-------|-------------------|------------------|----------------------|--------------------|---------|
| R1    | MAJOR (reloadEvProfiles dead) | MINOR (injectSession no gate) | MAJOR (same root as L1) + MINOR (banner) | 8 NITs | Cross-validated L1+L3 → template-reload wire-up + injectSession gate + banner |
| R2    | NIT (JSDoc overreach) | MINOR (mid-tx flag-flip mixed provenance) | (folded into R2 L2) | CLEAN + 1 NIT (test future-proofing) | L2 MINOR → drop else `deleteInstance`; L1 NIT → JSDoc calibration |

Round-2 delta commits `458362ad9` + `47870cc28` complete the fresh pass — all lanes CONVERGED / PASS with only sub-threshold tracked NITs (pre-existing OCPP 1.6 vs 2.0.x TransactionEnd asymmetry — confirmed NOT a spec violation per whitepaper §3.3.4; phantom manager allocation in non-production tests — test-hygiene follow-up).

OCPP spec whitepaper §3.3.4 (`StartTxnSampledData`) verified verbatim against the extracted `buildCoherentTransactionBeginMeterValue` fallback logic: _"If it is not implemented or the value is an empty list, this extra MeterValues.req will not be sent (standard OCPP 1.6 behaviour)"_ — code path matches.

## Quality gates

`pnpm typecheck && pnpm lint && pnpm test` — clean on every commit. Test invariant `fail: 0, skipped: 6` preserved throughout (tests total 2899–2931, within the node:test-discovery-flaky range; post-round-2 run: 2925 pass / 6 skipped / 0 fail / 2931 total).

## Blast radius

```
 cspell.config.yaml                                 |   1 +
 src/charging-station/ChargingStation.ts            | 128 ++++------
 src/charging-station/CoherentMeterValuesManager.ts | 271 +++++++++++++++++++++
 src/charging-station/meter-values/CoherentMeterValuesGenerator.ts | 42 ++--
 src/charging-station/meter-values/types.ts         |   6 +-
 src/charging-station/ocpp/1.6/OCPP16ServiceUtils.ts | 57 ++++--
 src/charging-station/ocpp/OCPPServiceUtils.ts      |   8 +-
 tests/charging-station/meter-values/CoherentMeterValuesGenerator.test.ts | 13 +-
 8 files changed, 387 insertions(+), 139 deletions(-)
```

`CoherentMeterValuesManager.ts` weighs in at **271 LOC** — pure code (excluding ~145 lines of JSDoc) is ~125 LOC, under the AGENTS.md 250-line ceiling. JSDoc density is higher than sibling multitons (`AutomaticTransactionGenerator`, `IdTagsCache`, `SharedLRUCache`, `PerformanceStatistics`) because the `peekInstance` / `getInstance` split encodes a load-bearing invariant that must be explicit at every call-site decision.

## Not in this PR (tracked separately in issue #1936)

- Item (c) `Prng.ts` → `PRNG.ts` rename
- Item (d) OCPP 1.6 signed-meter-values wrapper for TriggerMessage + broadcast
- Item (f) `Helpers.ts` split
- Item (g) EVSE-level template inheritance for coherent path (blocked on this PR's cleaner `ICoherentContext`)
- Item (h) physics refinements
- Item (i) `CoherentMeterValuesGenerator.ts` split (blocked on this PR's cleaner ownership boundaries)
- Item (j) OCPP 2.0.1 `TriggerMessage(MeterValues)` F06.FR.06 spec fix
- Item (k) `SampledDataCtrlr.RegisterValuesWithoutPhases` support
- Item (l) repo-wide cleanup of leftover H9/H10/H11 internal-review-round markers

Closes items (a), (b), (e) of #1936.
