### PR TITLE
refactor(ocpp20): rewrite H9/H10/H11 markers as descriptive comments (issue #1936 l)

### DIFF
--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -3037,7 +3037,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
       `${chargingStation.logPrefix()} ${moduleName}.handleRequestUpdateFirmware: Received UpdateFirmware request with requestId ${requestId.toString()} for location '${firmware.location}'`
     )
 
-    // C10: Validate signing certificate PEM format if present
+    // Reject malformed signing certificates up front so the firmware update path handles only parsable PEMs
     if (isNotEmptyString(firmware.signingCertificate)) {
       if (
         !hasCertificateManager(chargingStation) ||
@@ -3066,7 +3066,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
       )
     }
 
-    // H10: Cancel any in-progress firmware update
+    // Cancel any in-progress firmware update; respond with AcceptedCanceled so the new request starts fresh
     const stationState = this.getStationState(chargingStation)
     if (stationState.activeFirmwareUpdateAbortController != null) {
       const previousRequestId = stationState.activeFirmwareUpdateRequestId
@@ -3673,7 +3673,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
   ): Promise<void> {
     const { installDateTime, location, retrieveDateTime, signature } = firmware
 
-    // H10: Set up abort controller for cancellation support
+    // Store the abort controller so a subsequent UpdateFirmware can cancel this in-progress update
     const abortController = new AbortController()
     const stationState = this.getStationState(chargingStation)
     stationState.activeFirmwareUpdateAbortController = abortController
@@ -3681,7 +3681,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
 
     const checkAborted = (): boolean => abortController.signal.aborted
 
-    // C12: If retrieveDateTime is in the future, send DownloadScheduled and wait
+    // Delay the download until retrieveDateTime; inform the CSMS via DownloadScheduled first
     const now = Date.now()
     const retrieveTime = convertToDate(retrieveDateTime)?.getTime() ?? now
     if (retrieveTime > now) {
@@ -3703,7 +3703,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
     await sleep(OCPP20Constants.FIRMWARE_STATUS_DELAY_MS)
     if (checkAborted()) return
 
-    // H9: If firmware location is empty or malformed, send DownloadFailed and stop
+    // Empty or malformed firmware location: simulate the L01.FR.30 download retries, then emit DownloadFailed and stop
     if (isEmpty(location) || !this.isValidFirmwareLocation(location)) {
       // L01.FR.30: Simulate download retries before reporting DownloadFailed
       const maxRetries = retries ?? 0
@@ -3778,7 +3778,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
       )
     }
 
-    // C12: If installDateTime is in the future, send InstallScheduled and wait
+    // Delay the install until installDateTime; inform the CSMS via InstallScheduled first
     if (installDateTime != null) {
       const currentTime = Date.now()
       const installTime = convertToDate(installDateTime)?.getTime() ?? currentTime
@@ -3845,7 +3845,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
       requestId
     )
 
-    // H11: Send SecurityEventNotification for successful firmware update
+    // Send SecurityEventNotification after a successful firmware update
     this.sendSecurityEventNotification(
       chargingStation,
       'FirmwareUpdated',

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-UpdateFirmware.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-UpdateFirmware.test.ts
@@ -405,7 +405,7 @@ await describe('L01/L02 - UpdateFirmware', async () => {
           await flushMicrotasks()
           assert.strictEqual(sentRequests[3].payload.status, OCPP20FirmwareStatusEnumType.Installed)
 
-          // H11: SecurityEventNotification for FirmwareUpdated
+          // Expect SecurityEventNotification of type FirmwareUpdated on successful install
           assert.strictEqual(sentRequests.length, 5)
           assert.strictEqual(
             sentRequests[4].command,
@@ -723,7 +723,7 @@ await describe('L01/L02 - UpdateFirmware', async () => {
           await flushMicrotasks()
           assert.strictEqual(sentRequests[4].payload.status, OCPP20FirmwareStatusEnumType.Installed)
 
-          // H11: SecurityEventNotification after Installed
+          // Expect SecurityEventNotification to be emitted after the Installed status
           assert.strictEqual(sentRequests.length, 6)
           assert.strictEqual(
             sentRequests[5].command,


### PR DESCRIPTION
## Context

Addresses item **(l)** from issue #1936 — repo-wide cleanup of leftover internal-review-round markers.

Nine inline comments in `src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts` and its sibling test file carried internal audit-round finding numbers (`H9`, `H10`, `H11`, `C10`, `C12`) as if they were code identifiers. The markers cross-referenced an internal audit's own numbering rather than describing what the code does — a reader outside that review session cannot resolve the reference.

**Origin**:
- 7 markers in the production file (`H9`, `H10`×2, `H11`, `C10`, `C12`×2) from commit `3a6e89f634 fix(ocpp20): remediate all OCPP 2.0.1 audit findings (#1726)` — predates PR #1935.
- 2 markers in the test file (both `H11`) from commit `b50f9e5f refactor(tests): separate handler/listener tests and remove setTimeout hacks` — same audit-round family, different origin commit.

Same category as the `(regression: XX)` label suffixes cleaned from test files during PR #1935.

## Rewrites

### Production file — `src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts`

Each rewrite replaces an audit-code marker with a WHY-rationale describing current-state behavior:

| Line | Before | After |
|------|--------|-------|
| L3040 | `// C10: Validate signing certificate PEM format if present` | `// Reject malformed signing certificates up front so the firmware update path handles only parsable PEMs` |
| L3069 | `// H10: Cancel any in-progress firmware update` | `// Cancel any in-progress firmware update; respond with AcceptedCanceled so the new request starts fresh` |
| L3676 | `// H10: Set up abort controller for cancellation support` | `// Store the abort controller so a subsequent UpdateFirmware can cancel this in-progress update` |
| L3684 | `// C12: If retrieveDateTime is in the future, send DownloadScheduled and wait` | `// Delay the download until retrieveDateTime; inform the CSMS via DownloadScheduled first` |
| L3706 | `// H9: If firmware location is empty or malformed, send DownloadFailed and stop` | `// Empty or malformed firmware location: simulate the L01.FR.30 download retries, then emit DownloadFailed and stop` |
| L3781 | `// C12: If installDateTime is in the future, send InstallScheduled and wait` | `// Delay the install until installDateTime; inform the CSMS via InstallScheduled first` |
| L3848 | `// H11: Send SecurityEventNotification for successful firmware update` | `// Send SecurityEventNotification after a successful firmware update` |

### Test file — `tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-UpdateFirmware.test.ts`

BDD-style expectation labels replacing audit-code markers:

| Line | Before | After |
|------|--------|-------|
| L408 | `// H11: SecurityEventNotification for FirmwareUpdated` | `// Expect SecurityEventNotification of type FirmwareUpdated on successful install` |
| L726 | `// H11: SecurityEventNotification after Installed` | `// Expect SecurityEventNotification to be emitted after the Installed status` |

## Verification

Letter-agnostic verification using POSIX character classes (portable across all `git-grep -E` builds — the `\s` shorthand is a PCRE extension not supported by POSIX ERE):

```bash
git grep -inE '^[[:space:]]*//[[:space:]]*[A-Z]+[0-9]+[]:)-]' -- src/ tests/
# returns empty
```

Legitimate OCPP spec markers elsewhere in the repo (`B11 - Reset`, `F06.FR.06`, `A02.FR.06`, `E05.FR.09`, `L01.FR.30`, `C10.FR.04`, `C12.FR.05`, etc.) all follow the `<UC>.FR.<NN>` shape and are unaffected — the pattern above matches only the bare `//<letter+><digits>[:-)]` audit-marker shape.

## Quality gates

Comment-only change. `pnpm typecheck && pnpm lint && pnpm test` — clean. Invariant `fail: 0, skipped: 6` preserved.

## Independence

This PR is based directly on `main` — it does **not** depend on #1937 (merged as `1986b399`) or #1938 (merged as `53b747bf`). Can merge in any order.

Closes item (l) of #1936.
