### PR TITLE
fix(ocpp20): trigger meterValues path emits MeterValuesRequest per F06.FR.06 (issue #1936 j)

### DIFF
--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -78,6 +78,7 @@ import {
   type OCPP20InstallCertificateResponse,
   type OCPP20LogStatusNotificationRequest,
   type OCPP20LogStatusNotificationResponse,
+  OCPP20MeasurandEnumType,
   type OCPP20MeterValue,
   type OCPP20MeterValuesRequest,
   type OCPP20MeterValuesResponse,
@@ -635,7 +636,13 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
               }
               if (meterValues.length === 0) {
                 meterValues.push({
-                  sampledValue: [{ value: 0 }],
+                  sampledValue: [
+                    {
+                      context: OCPP20ReadingContextEnumType.TRIGGER,
+                      measurand: OCPP20MeasurandEnumType.POWER_ACTIVE_IMPORT,
+                      value: 0,
+                    },
+                  ],
                   timestamp: new Date(),
                 })
               }

--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -141,6 +141,7 @@ import {
   convertToIntOrNaN,
   ensureError,
   generateUUID,
+  getErrorMessage,
   handleIncomingRequestError,
   isEmpty,
   isNotEmptyArray,
@@ -1317,13 +1318,21 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
     const meterValues: OCPP20MeterValue[] = []
     for (const connector of evseStatus.connectors.values()) {
       if (connector.transactionId == null) continue
-      const meterValue = buildMeterValue(
-        chargingStation,
-        connector.transactionId,
-        alignedInterval,
-        alignedMeasurandsKey,
-        OCPP20ReadingContextEnumType.TRIGGER
-      ) as OCPP20MeterValue
+      let meterValue: OCPP20MeterValue
+      try {
+        meterValue = buildMeterValue(
+          chargingStation,
+          connector.transactionId,
+          alignedInterval,
+          alignedMeasurandsKey,
+          OCPP20ReadingContextEnumType.TRIGGER
+        ) as OCPP20MeterValue
+      } catch (error) {
+        logger.warn(
+          `${chargingStation.logPrefix()} ${moduleName}.emitEvseMeterValues: ${getErrorMessage(error)}`
+        )
+        continue
+      }
       // OCPP 2.0.1 MeterValueType.sampledValue cardinality is 1..*:
       // skip a MeterValue whose emit set collapsed to empty so the
       // outgoing MeterValuesRequest stays schema-conforming.

--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -593,6 +593,13 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
               .catch(errorHandler)
             break
           case MessageTriggerEnumType.MeterValues: {
+            // OCPP 2.0.1 F06.FR.06: TriggerMessage with MessageTrigger.MeterValues
+            // MUST respond with MeterValuesRequest (not TransactionEventRequest),
+            // using the AlignedDataCtrlr.Measurands allow-list and TRIGGER
+            // ReadingContext. One MeterValuesRequest per target EVSE, aggregating
+            // MeterValues from every connector with an active transaction; when
+            // an EVSE has no active transactions, still emit one request with a
+            // schema-conforming placeholder so the CSMS observes the response.
             const targetEvseIds: number[] = []
             if (evse?.id != null && evse.id > 0) {
               targetEvseIds.push(evse.id)
@@ -601,53 +608,44 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
                 targetEvseIds.push(evseId)
               }
             }
-            let hasSentTransactionEvent = false
+            const alignedInterval = OCPP20ServiceUtils.getAlignedDataInterval(chargingStation)
+            const alignedMeasurandsKey = buildConfigKey(
+              OCPP20ComponentName.AlignedDataCtrlr,
+              OCPP20RequiredVariableName.Measurands
+            )
             for (const targetEvseId of targetEvseIds) {
               const evseStatus = chargingStation.getEvseStatus(targetEvseId)
               if (evseStatus == null) continue
-              for (const [cId, connector] of evseStatus.connectors) {
+              const meterValues: OCPP20MeterValue[] = []
+              for (const connector of evseStatus.connectors.values()) {
                 if (connector.transactionId == null) continue
-                hasSentTransactionEvent = true
-                const txUpdatedInterval = OCPP20ServiceUtils.getTxUpdatedInterval(chargingStation)
                 const meterValue = buildMeterValue(
                   chargingStation,
                   connector.transactionId,
-                  txUpdatedInterval,
-                  buildConfigKey(
-                    OCPP20ComponentName.SampledDataCtrlr,
-                    OCPP20RequiredVariableName.TxUpdatedMeasurands
-                  ),
+                  alignedInterval,
+                  alignedMeasurandsKey,
                   OCPP20ReadingContextEnumType.TRIGGER
                 ) as OCPP20MeterValue
-                // OCPP 2.0.1 MeterValueType.sampledValue cardinality is 1..*, while
-                // TransactionEventRequest.meterValue is 0..*: when TxUpdatedMeasurands
-                // yields no sampled values, omit the meterValue field entirely rather
-                // than send an empty-wrapper schema violation.
-                const eventPayload = isNotEmptyArray(meterValue.sampledValue)
-                  ? { meterValue: [meterValue] }
-                  : {}
-                OCPP20ServiceUtils.sendTransactionEvent(
-                  chargingStation,
-                  OCPP20TransactionEventEnumType.Updated,
-                  OCPP20TriggerReasonEnumType.Trigger,
-                  cId,
-                  connector.transactionId as string,
-                  eventPayload
-                ).catch(errorHandler)
+                // OCPP 2.0.1 MeterValueType.sampledValue cardinality is 1..*:
+                // skip a MeterValue whose emit set collapsed to empty so the
+                // outgoing MeterValuesRequest stays schema-conforming.
+                if (isNotEmptyArray(meterValue.sampledValue)) {
+                  meterValues.push(meterValue)
+                }
               }
-            }
-            if (!hasSentTransactionEvent) {
-              const meterValue: OCPP20MeterValue = {
-                sampledValue: [{ value: 0 }],
-                timestamp: new Date(),
+              if (meterValues.length === 0) {
+                meterValues.push({
+                  sampledValue: [{ value: 0 }],
+                  timestamp: new Date(),
+                })
               }
               chargingStation.ocppRequestService
                 .requestHandler<OCPP20MeterValuesRequest, OCPP20MeterValuesResponse>(
                   chargingStation,
                   OCPP20RequestCommand.METER_VALUES,
                   {
-                    evseId: evse?.id ?? 1,
-                    meterValue: [meterValue],
+                    evseId: targetEvseId,
+                    meterValue: meterValues,
                   },
                   { skipBufferingOnError: true, triggerMessage: true }
                 )

--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -593,73 +593,9 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
               )
               .catch(errorHandler)
             break
-          case MessageTriggerEnumType.MeterValues: {
-            // OCPP 2.0.1 F06.FR.06: TriggerMessage with MessageTrigger.MeterValues
-            // MUST respond with MeterValuesRequest (not TransactionEventRequest),
-            // using the AlignedDataCtrlr.Measurands allow-list and TRIGGER
-            // ReadingContext. One MeterValuesRequest per target EVSE, aggregating
-            // MeterValues from every connector with an active transaction; when
-            // an EVSE has no active transactions, still emit one request with a
-            // schema-conforming placeholder so the CSMS observes the response.
-            const targetEvseIds: number[] = []
-            if (evse?.id != null && evse.id > 0) {
-              targetEvseIds.push(evse.id)
-            } else {
-              for (const { evseId } of chargingStation.iterateEvses(true)) {
-                targetEvseIds.push(evseId)
-              }
-            }
-            const alignedInterval = OCPP20ServiceUtils.getAlignedDataInterval(chargingStation)
-            const alignedMeasurandsKey = buildConfigKey(
-              OCPP20ComponentName.AlignedDataCtrlr,
-              OCPP20RequiredVariableName.Measurands
-            )
-            for (const targetEvseId of targetEvseIds) {
-              const evseStatus = chargingStation.getEvseStatus(targetEvseId)
-              if (evseStatus == null) continue
-              const meterValues: OCPP20MeterValue[] = []
-              for (const connector of evseStatus.connectors.values()) {
-                if (connector.transactionId == null) continue
-                const meterValue = buildMeterValue(
-                  chargingStation,
-                  connector.transactionId,
-                  alignedInterval,
-                  alignedMeasurandsKey,
-                  OCPP20ReadingContextEnumType.TRIGGER
-                ) as OCPP20MeterValue
-                // OCPP 2.0.1 MeterValueType.sampledValue cardinality is 1..*:
-                // skip a MeterValue whose emit set collapsed to empty so the
-                // outgoing MeterValuesRequest stays schema-conforming.
-                if (isNotEmptyArray(meterValue.sampledValue)) {
-                  meterValues.push(meterValue)
-                }
-              }
-              if (meterValues.length === 0) {
-                meterValues.push({
-                  sampledValue: [
-                    {
-                      context: OCPP20ReadingContextEnumType.TRIGGER,
-                      measurand: OCPP20MeasurandEnumType.POWER_ACTIVE_IMPORT,
-                      value: 0,
-                    },
-                  ],
-                  timestamp: new Date(),
-                })
-              }
-              chargingStation.ocppRequestService
-                .requestHandler<OCPP20MeterValuesRequest, OCPP20MeterValuesResponse>(
-                  chargingStation,
-                  OCPP20RequestCommand.METER_VALUES,
-                  {
-                    evseId: targetEvseId,
-                    meterValue: meterValues,
-                  },
-                  { skipBufferingOnError: true, triggerMessage: true }
-                )
-                .catch(errorHandler)
-            }
+          case MessageTriggerEnumType.MeterValues:
+            this.triggerMeterValues(chargingStation, evse, errorHandler)
             break
-          }
           case MessageTriggerEnumType.StatusNotification:
             this.triggerStatusNotification(chargingStation, evse, errorHandler)
             break
@@ -1357,6 +1293,67 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
       return true
     }
     return queue.some(({ request }) => request.transactionInfo.transactionId === transactionId)
+  }
+
+  /**
+   * Emits one `MeterValuesRequest` aggregating the given EVSE's
+   * active-transaction connectors, or a schema-conforming placeholder
+   * when the EVSE has no active transactions.
+   * @param chargingStation - Target charging station.
+   * @param evseId - Target EVSE identifier.
+   * @param evseStatus - Target EVSE status (yields the connectors).
+   * @param alignedInterval - Aligned-data emission interval in milliseconds.
+   * @param alignedMeasurandsKey - Configuration key for the AlignedDataCtrlr.Measurands allow-list.
+   * @param errorHandler - Handler for downstream request-emission errors.
+   */
+  private emitEvseMeterValues (
+    chargingStation: ChargingStation,
+    evseId: number,
+    evseStatus: EvseStatus,
+    alignedInterval: number,
+    alignedMeasurandsKey: string,
+    errorHandler: (error: unknown) => void
+  ): void {
+    const meterValues: OCPP20MeterValue[] = []
+    for (const connector of evseStatus.connectors.values()) {
+      if (connector.transactionId == null) continue
+      const meterValue = buildMeterValue(
+        chargingStation,
+        connector.transactionId,
+        alignedInterval,
+        alignedMeasurandsKey,
+        OCPP20ReadingContextEnumType.TRIGGER
+      ) as OCPP20MeterValue
+      // OCPP 2.0.1 MeterValueType.sampledValue cardinality is 1..*:
+      // skip a MeterValue whose emit set collapsed to empty so the
+      // outgoing MeterValuesRequest stays schema-conforming.
+      if (isNotEmptyArray(meterValue.sampledValue)) {
+        meterValues.push(meterValue)
+      }
+    }
+    if (meterValues.length === 0) {
+      meterValues.push({
+        sampledValue: [
+          {
+            context: OCPP20ReadingContextEnumType.TRIGGER,
+            measurand: OCPP20MeasurandEnumType.POWER_ACTIVE_IMPORT,
+            value: 0,
+          },
+        ],
+        timestamp: new Date(),
+      })
+    }
+    chargingStation.ocppRequestService
+      .requestHandler<OCPP20MeterValuesRequest, OCPP20MeterValuesResponse>(
+        chargingStation,
+        OCPP20RequestCommand.METER_VALUES,
+        {
+          evseId,
+          meterValue: meterValues,
+        },
+        { skipBufferingOnError: true, triggerMessage: true }
+      )
+      .catch(errorHandler)
   }
 
   private getRestoredConnectorStatus (
@@ -3946,6 +3943,55 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
           { skipBufferingOnError: true, triggerMessage: true }
         )
         .catch(errorHandler)
+    }
+  }
+
+  /**
+   * OCPP 2.0.1 F06.FR.06: TriggerMessage with `MessageTrigger.MeterValues`
+   * SHALL respond with `MeterValuesRequest` (not `TransactionEventRequest`),
+   * using the `AlignedDataCtrlr.Measurands` allow-list and `TRIGGER`
+   * ReadingContext. One `MeterValuesRequest` per target EVSE aggregating
+   * MeterValues from every connector with an active transaction; when an
+   * EVSE has no active transactions, still emit one request with a
+   * schema-conforming placeholder so the CSMS observes the response
+   * (F06.FR.10). F06.FR.11 broadcast semantics apply when `evse` is absent.
+   * @param chargingStation - Target charging station.
+   * @param evse - Optional target EVSE from the TriggerMessage payload.
+   * @param errorHandler - Handler for downstream request-emission errors.
+   */
+  private triggerMeterValues (
+    chargingStation: ChargingStation,
+    evse: OCPP20TriggerMessageRequest['evse'],
+    errorHandler: (error: unknown) => void
+  ): void {
+    const alignedInterval = OCPP20ServiceUtils.getAlignedDataInterval(chargingStation)
+    const alignedMeasurandsKey = buildConfigKey(
+      OCPP20ComponentName.AlignedDataCtrlr,
+      OCPP20RequiredVariableName.Measurands
+    )
+    if (evse?.id != null && evse.id > 0) {
+      const evseStatus = chargingStation.getEvseStatus(evse.id)
+      if (evseStatus != null) {
+        this.emitEvseMeterValues(
+          chargingStation,
+          evse.id,
+          evseStatus,
+          alignedInterval,
+          alignedMeasurandsKey,
+          errorHandler
+        )
+      }
+    } else {
+      for (const { evseId, evseStatus } of chargingStation.iterateEvses(true)) {
+        this.emitEvseMeterValues(
+          chargingStation,
+          evseId,
+          evseStatus,
+          alignedInterval,
+          alignedMeasurandsKey,
+          errorHandler
+        )
+      }
     }
   }
 

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-TriggerMessage.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-TriggerMessage.test.ts
@@ -532,7 +532,10 @@ await describe('F06 - TriggerMessage', async () => {
         assert.strictEqual(options.skipBufferingOnError, true)
         assert.strictEqual(options.triggerMessage, true)
       }
-      assert.deepStrictEqual([...observedEvseIds].sort(), [1, 2, 3])
+      assert.deepStrictEqual(
+        [...observedEvseIds].sort((a, b) => a - b),
+        [1, 2, 3]
+      )
     })
 
     await it('should broadcast StatusNotification for all EVSEs on Accepted without specific EVSE', () => {

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-TriggerMessage.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-TriggerMessage.test.ts
@@ -20,6 +20,7 @@ import { OCPP20IncomingRequestService } from '../../../../src/charging-station/o
 import {
   MessageTriggerEnumType,
   OCPP20IncomingRequestCommand,
+  OCPP20MeasurandEnumType,
   OCPP20ReadingContextEnumType,
   OCPP20RequestCommand,
   OCPPVersion,
@@ -528,6 +529,11 @@ await describe('F06 - TriggerMessage', async () => {
           firstSample.context,
           OCPP20ReadingContextEnumType.TRIGGER,
           'Expected sampledValue[0].context = Trigger per TC_F_12_CS'
+        )
+        assert.strictEqual(
+          firstSample.measurand,
+          OCPP20MeasurandEnumType.POWER_ACTIVE_IMPORT,
+          'Expected sampledValue[0].measurand = Power.Active.Import (placeholder emits Power.Active.Import = 0 W, truthful when idle, regardless of AlignedDataCtrlr.Measurands default which is Energy.Active.Import.Register)'
         )
         assert.strictEqual(options.skipBufferingOnError, true)
         assert.strictEqual(options.triggerMessage, true)

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-TriggerMessage.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-TriggerMessage.test.ts
@@ -7,6 +7,7 @@ import assert from 'node:assert/strict'
 import { afterEach, beforeEach, describe, it, mock } from 'node:test'
 
 import type {
+  OCPP20MeterValuesRequest,
   OCPP20StatusNotificationRequest,
   OCPP20TriggerMessageRequest,
   OCPP20TriggerMessageResponse,
@@ -19,6 +20,7 @@ import { OCPP20IncomingRequestService } from '../../../../src/charging-station/o
 import {
   MessageTriggerEnumType,
   OCPP20IncomingRequestCommand,
+  OCPP20ReadingContextEnumType,
   OCPP20RequestCommand,
   OCPPVersion,
   ReasonCodeEnumType,
@@ -498,8 +500,39 @@ await describe('F06 - TriggerMessage', async () => {
 
       // F06.FR.06: TriggerMessage(MessageTrigger.MeterValues) without a
       // specific EVSE MUST emit one MeterValuesRequest per EVSE. Fixture has
-      // 3 EVSEs → 3 requests.
-      assert.strictEqual(requestHandlerMock.mock.callCount(), 3)
+      // 3 EVSEs -> 3 requests.
+      const callCount = requestHandlerMock.mock.callCount()
+      assert.strictEqual(callCount, 3)
+      const observedEvseIds = new Set<number>()
+      for (const call of requestHandlerMock.mock.calls) {
+        const args = call.arguments as [
+          unknown,
+          string,
+          Partial<OCPP20MeterValuesRequest>,
+          RequestParams
+        ]
+        const [, command, payload, options] = args
+        assert.strictEqual(command, OCPP20RequestCommand.METER_VALUES)
+        assert.notStrictEqual(payload, undefined)
+        assert.ok('evseId' in payload, 'Expected payload to include evseId')
+        assert.ok('meterValue' in payload, 'Expected payload to include meterValue')
+        assert.ok(
+          payload.evseId != null && payload.evseId > 0,
+          'Expected evseId > 0 (EVSE 0 excluded)'
+        )
+        observedEvseIds.add(payload.evseId)
+        assert.ok(Array.isArray(payload.meterValue), 'Expected meterValue to be an array')
+        assert.ok(payload.meterValue.length >= 1, 'Expected meterValue.length >= 1')
+        const firstSample = payload.meterValue[0].sampledValue[0]
+        assert.strictEqual(
+          firstSample.context,
+          OCPP20ReadingContextEnumType.TRIGGER,
+          'Expected sampledValue[0].context = Trigger per TC_F_12_CS'
+        )
+        assert.strictEqual(options.skipBufferingOnError, true)
+        assert.strictEqual(options.triggerMessage, true)
+      }
+      assert.deepStrictEqual([...observedEvseIds].sort(), [1, 2, 3])
     })
 
     await it('should broadcast StatusNotification for all EVSEs on Accepted without specific EVSE', () => {

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-TriggerMessage.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-TriggerMessage.test.ts
@@ -459,10 +459,6 @@ await describe('F06 - TriggerMessage', async () => {
         name: 'LogStatusNotification',
         trigger: MessageTriggerEnumType.LogStatusNotification,
       },
-      {
-        name: 'MeterValues',
-        trigger: MessageTriggerEnumType.MeterValues,
-      },
     ]
 
     for (const { name, trigger } of triggerCases) {
@@ -484,6 +480,27 @@ await describe('F06 - TriggerMessage', async () => {
         assert.strictEqual(requestHandlerMock.mock.callCount(), 1)
       })
     }
+
+    await it('should broadcast MeterValuesRequest for all EVSEs on Accepted (F06.FR.06)', () => {
+      const request: OCPP20TriggerMessageRequest = {
+        requestedMessage: MessageTriggerEnumType.MeterValues,
+      }
+      const response: OCPP20TriggerMessageResponse = {
+        status: TriggerMessageStatusEnumType.Accepted,
+      }
+
+      incomingRequestServiceForListener.emit(
+        OCPP20IncomingRequestCommand.TRIGGER_MESSAGE,
+        mockStation,
+        request,
+        response
+      )
+
+      // F06.FR.06: TriggerMessage(MessageTrigger.MeterValues) without a
+      // specific EVSE MUST emit one MeterValuesRequest per EVSE. Fixture has
+      // 3 EVSEs → 3 requests.
+      assert.strictEqual(requestHandlerMock.mock.callCount(), 3)
+    })
 
     await it('should broadcast StatusNotification for all EVSEs on Accepted without specific EVSE', () => {
       const request: OCPP20TriggerMessageRequest = {


### PR DESCRIPTION
## Context

Addresses item **(j)** from issue #1936 — a pre-existing OCPP 2.0.1 spec-conformance bug introduced by PR #1726.

## The bug

OCPP 2.0.1 F06.FR.06 requires that when a CSMS sends a `TriggerMessage` with `MessageTrigger.MeterValues`, the Charging Station SHALL respond with a `MeterValuesRequest` carrying the requested Measurand values.

The current `OCPP20IncomingRequestService.handleRequestTriggerMessage` handler for `MessageTrigger.MeterValues` iterated all connectors with active transactions and sent `TransactionEventRequest(Updated)` — a spec violation. It only fell back to sending a `MeterValuesRequest` when no active transactions existed.

## The fix

Always emit `MeterValuesRequest` for `MessageTrigger.MeterValues`:

1. **Iterate target EVSEs** — specific from `evse.id`, or all EVSEs if unspecified.
2. **Per EVSE, build one MeterValue per active-transaction connector** using the OCPP 2.0.1 `AlignedDataCtrlr.Measurands` allow-list and `TRIGGER` `ReadingContext` (matches F06 semantics for aligned/triggered data). MeterValues with empty `sampledValue` arrays are skipped per `MeterValueType.sampledValue`'s 1..* cardinality.
3. **Emit one MeterValuesRequest per target EVSE** aggregating those MeterValues. When an EVSE has no active transactions, still emit one request with a schema-conforming placeholder (`context: Trigger`, `measurand: Power.Active.Import = 0 W` — truthful when idle, avoids the schema-default `Energy.Active.Import.Register` cumulative-register semantic footgun) so the CSMS observes the response.

## Behavior matrix

| Trigger scenario | Pre-fix behavior | Post-fix behavior |
|------------------|------------------|-------------------|
| MeterValues + specific EVSE, active tx present | `TransactionEventRequest(Updated)` per connector ← **spec violation** | 1× `MeterValuesRequest` for the EVSE aggregating all its connector MeterValues |
| MeterValues + specific EVSE, no active tx | 1× `MeterValuesRequest` with placeholder | 1× `MeterValuesRequest` with placeholder (unchanged) |
| MeterValues + no specific EVSE, active tx present | `TransactionEventRequest(Updated)` per connector across all EVSEs ← **spec violation** | 1× `MeterValuesRequest` per EVSE (broadcast) — matches sibling `StatusNotification` broadcast semantics |
| MeterValues + no specific EVSE, no active tx | 1× `MeterValuesRequest` with placeholder | 1× `MeterValuesRequest` per EVSE with placeholder |

## Test updates

- **Removed** the `MeterValues` entry from the shared parameterized *"fires requestHandler once"* loop (that assertion baked in the pre-fix 1-call fallback behavior).
- **Added** a dedicated F06.FR.06 broadcast test asserting one `MeterValuesRequest` per EVSE (3 EVSEs → 3 requests), symmetric with the existing `StatusNotification` broadcast test at the same site.

## Quality gates

`pnpm typecheck && pnpm lint && pnpm test` — clean. Invariant `fail: 0, skipped: 6` preserved (totals fluctuate within the node:test-discovery-flaky range disclosed by prior PRs in the series).

## Spec citations

- OCPP 2.0.1 edition 3 part 2, §F06.FR.06 (TriggerMessage → MeterValues MUST emit MeterValuesRequest)
- OCPP 2.0.1 edition 3 part 2, `AlignedDataCtrlr.Measurands` (measurand allow-list for aligned/triggered data)
- OCPP 2.0.1 edition 3 part 2, `MeterValueType.sampledValue` cardinality: 1..*

## Independence

Based directly on `main` — does **not** depend on #1937 / #1938 / #1939 / #1940 / #1941 / #1942. Can merge in any order.

Closes item (j) of #1936.

