### PR TITLE
feat(meter-values): evse-level MeterValues template fallback in coherent path (issue #1936 g)

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,9 @@ type AutomaticTransactionGeneratorConfiguration = {
 
 #### Evses section syntax example
 
-`MeterValues` can be defined at EVSE level or at connector level. EVSE-level definitions apply to all connectors of the EVSE and override connector-level definitions.
+`MeterValues` can be defined at EVSE-level or at connector-level. EVSE-level definitions apply to all connectors of the EVSE and override connector-level definitions.
 
-##### MeterValues at EVSE level
+##### MeterValues at EVSE-level
 
 ```json
   "Evses": {
@@ -406,7 +406,7 @@ type AutomaticTransactionGeneratorConfiguration = {
   },
 ```
 
-##### MeterValues at connector level
+##### MeterValues at connector-level
 
 ```json
   "Evses": {

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ The EV profile file is a JSON file referenced by the `evProfilesFile` template f
 
 A template file is available at [src/assets/ev-profiles-template.json](./src/assets/ev-profiles-template.json).
 
-**Template resolution scope.** When `coherentMeterValues` is `true`, the coherent generator reads `MeterValues` templates from the connector-level definition only. EVSE-level `MeterValues` inheritance is not applied, so define per-connector `MeterValues` inside each connector entry.
+**Template resolution scope.** When `coherentMeterValues` is `true`, the coherent generator resolves `MeterValues` templates with the same precedence as the random/fixed path's `getSampledValueTemplate`: EVSE-level `MeterValues` (when defined and non-empty) override connector-level definitions for every connector under that EVSE; connector-level `MeterValues` are used when the connector is not grouped under an EVSE (flat `Connectors` map station layout) or when the EVSE-level array is empty.
 
 **Phase-qualified measurands.** When a connector template carries a `phase` field, the coherent generator emits one `SampledValue` per matching template with phase-aware values:
 

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ The EV profile file is a JSON file referenced by the `evProfilesFile` template f
 
 A template file is available at [src/assets/ev-profiles-template.json](./src/assets/ev-profiles-template.json).
 
-**Template resolution scope.** When `coherentMeterValues` is `true`, the coherent generator resolves `MeterValues` templates with the same precedence as the random/fixed path's `getSampledValueTemplate`: EVSE-level `MeterValues` (when defined and non-empty) override connector-level definitions for every connector under that EVSE; connector-level `MeterValues` are used when the connector is not grouped under an EVSE (flat `Connectors` map station layout) or when the EVSE-level array is empty.
+**Template resolution scope.** When `coherentMeterValues` is `true`, EVSE-level `MeterValues` (when defined and non-empty) override connector-level definitions for every connector under that EVSE; connector-level `MeterValues` are used when the connector is not grouped under an EVSE (flat `Connectors` map station layout) or when the EVSE-level array is undefined or empty. Note: the coherent generator emits templates from exactly one source (EVSE-level or the queried connector) - unlike the random/fixed path's `getSampledValueTemplate`, it does not aggregate `MeterValues` across sibling connectors under the same EVSE.
 
 **Phase-qualified measurands.** When a connector template carries a `phase` field, the coherent generator emits one `SampledValue` per matching template with phase-aware values:
 

--- a/src/charging-station/meter-values/CoherentMeterValueBuilder.ts
+++ b/src/charging-station/meter-values/CoherentMeterValueBuilder.ts
@@ -307,14 +307,21 @@ const resolveUnitDivider = (
   unit != null && KILO_UNIT_BY_MEASURAND.get(measurand) === unit ? Constants.UNIT_DIVIDER_KILO : 1
 
 /**
- * Resolves `MeterValues` templates for a connector with the same
- * precedence as the random/fixed path's
- * {@link ../ocpp/OCPPServiceUtils.getSampledValueTemplate}: EVSE-level
+ * Resolves `MeterValues` templates for a connector. EVSE-level
  * `MeterValues` (when defined and non-empty) override connector-level
  * definitions for every connector under that EVSE; connector-level
  * `MeterValues` are used when the connector is not grouped under an
  * EVSE (flat `Connectors` map station layout) or when the EVSE-level
- * array is empty.
+ * array is undefined or empty.
+ *
+ * NOTE: Unlike
+ * {@link ../ocpp/OCPPServiceUtils.getSampledValueTemplate}, this does
+ * NOT aggregate `MeterValues` across sibling connectors under the
+ * same EVSE when both EVSE-level and the queried connector's
+ * `MeterValues` are empty. The coherent path emits templates from
+ * exactly one source (EVSE-level or the queried connector), keeping
+ * per-connector template ownership isolated; the random/fixed path's
+ * cross-connector aggregation is intentionally not replicated.
  * @param context - Charging-station context.
  * @param connectorId - Connector identifier.
  * @returns Templates or `undefined`.

--- a/src/charging-station/meter-values/CoherentMeterValueBuilder.ts
+++ b/src/charging-station/meter-values/CoherentMeterValueBuilder.ts
@@ -35,7 +35,7 @@ import {
   MeterValuePhase,
   MeterValueUnit,
 } from '../../types/index.js'
-import { Constants, logger, roundTo } from '../../utils/index.js'
+import { Constants, isNotEmptyArray, logger, roundTo } from '../../utils/index.js'
 import {
   advanceEnergyRegister,
   computeCoherentSample,
@@ -317,9 +317,9 @@ const resolveUnitDivider = (
  * NOTE: Unlike
  * {@link ../ocpp/OCPPServiceUtils.getSampledValueTemplate}, this does
  * NOT aggregate `MeterValues` across sibling connectors under the
- * same EVSE when both EVSE-level and the queried connector's
- * `MeterValues` are empty. The coherent path emits templates from
- * exactly one source (EVSE-level or the queried connector), keeping
+ * same EVSE when EVSE-level `MeterValues` is undefined or empty. The
+ * coherent path emits templates from exactly one source (EVSE-level
+ * when non-empty, otherwise the queried connector), keeping
  * per-connector template ownership isolated; the random/fixed path's
  * cross-connector aggregation is intentionally not replicated.
  * @param context - Charging-station context.
@@ -333,7 +333,7 @@ const resolveTemplates = (
   const evseId = context.getEvseIdByConnectorId(connectorId)
   if (evseId != null) {
     const evseTemplates = context.getEvseStatus(evseId)?.MeterValues
-    if (evseTemplates != null && evseTemplates.length > 0) {
+    if (isNotEmptyArray(evseTemplates)) {
       return evseTemplates
     }
   }

--- a/src/charging-station/meter-values/CoherentMeterValueBuilder.ts
+++ b/src/charging-station/meter-values/CoherentMeterValueBuilder.ts
@@ -307,14 +307,14 @@ const resolveUnitDivider = (
   unit != null && KILO_UNIT_BY_MEASURAND.get(measurand) === unit ? Constants.UNIT_DIVIDER_KILO : 1
 
 /**
- * Returns the SampledValueTemplate array configured on the given connector.
- *
- * Reads the connector-level `MeterValues` templates only. Unlike
- * {@link ../ocpp/OCPPServiceUtils.getSampledValueTemplate}, this does NOT
- * fall back to EVSE-level `MeterValues` templates: the {@link ICoherentContext}
- * surface exposes `getConnectorStatus` but not `getEvseStatus`. Adding
- * EVSE-level template inheritance to the coherent path requires extending
- * the context interface with `getEvseStatus`.
+ * Resolves `MeterValues` templates for a connector with the same
+ * precedence as the random/fixed path's
+ * {@link ../ocpp/OCPPServiceUtils.getSampledValueTemplate}: EVSE-level
+ * `MeterValues` (when defined and non-empty) override connector-level
+ * definitions for every connector under that EVSE; connector-level
+ * `MeterValues` are used when the connector is not grouped under an
+ * EVSE (flat `Connectors` map station layout) or when the EVSE-level
+ * array is empty.
  * @param context - Charging-station context.
  * @param connectorId - Connector identifier.
  * @returns Templates or `undefined`.
@@ -323,6 +323,13 @@ const resolveTemplates = (
   context: ICoherentContext,
   connectorId: number
 ): SampledValueTemplate[] | undefined => {
+  const evseId = context.getEvseIdByConnectorId(connectorId)
+  if (evseId != null) {
+    const evseTemplates = context.getEvseStatus(evseId)?.MeterValues
+    if (evseTemplates != null && evseTemplates.length > 0) {
+      return evseTemplates
+    }
+  }
   return context.getConnectorStatus(connectorId)?.MeterValues
 }
 

--- a/src/charging-station/meter-values/types.ts
+++ b/src/charging-station/meter-values/types.ts
@@ -14,6 +14,7 @@ import type {
   ChargingStationInfo,
   ConnectorStatus,
   CurrentType,
+  EvseStatus,
   Voltage,
 } from '../../types/index.js'
 
@@ -119,6 +120,8 @@ export interface CoherentSession {
 export interface ICoherentContext {
   getConnectorMaximumAvailablePower: (connectorId: number) => number
   getConnectorStatus: (connectorId: number) => ConnectorStatus | undefined
+  getEvseIdByConnectorId: (connectorId: number) => number | undefined
+  getEvseStatus: (evseId: number) => EvseStatus | undefined
   getNumberOfPhases: () => number
   getVoltageOut: () => Voltage
   logPrefix: () => string

--- a/tests/charging-station/meter-values/CoherentMeterValues.test.ts
+++ b/tests/charging-station/meter-values/CoherentMeterValues.test.ts
@@ -65,6 +65,10 @@ const baseProfile: EvProfile = {
  * @param overrides - Optional overrides bag for context knobs.
  * @param overrides.currentType - `CurrentType.AC` or `CurrentType.DC`.
  * @param overrides.evseMaxPowerW - EVSE cap returned by `getConnectorMaximumAvailablePower`.
+ * @param overrides.evseMeterValues - When defined and non-empty, exposed via
+ *   `getEvseStatus(evseId).MeterValues`; also implies `getEvseIdByConnectorId`
+ *   resolves to a non-null EVSE id. When `undefined`, `getEvseIdByConnectorId`
+ *   returns `undefined` (flat connector layout).
  * @param overrides.numberOfPhases - Number of AC phases (ignored for DC).
  * @param overrides.voltageOut - Nominal phase voltage.
  * @returns Bundle exposing context, sessions map, station info, and connector status.
@@ -73,6 +77,7 @@ const buildContext = (
   overrides: {
     currentType?: CurrentType
     evseMaxPowerW?: number
+    evseMeterValues?: SampledValueTemplate[]
     numberOfPhases?: number
     voltageOut?: number
   } = {}
@@ -114,6 +119,15 @@ const buildContext = (
   const context: ICoherentContext = {
     getConnectorMaximumAvailablePower: () => evseMax,
     getConnectorStatus: () => connectorStatus,
+    getEvseIdByConnectorId: () => (overrides.evseMeterValues != null ? 1 : undefined),
+    getEvseStatus: (evseId: number) =>
+      overrides.evseMeterValues != null && evseId === 1
+        ? {
+            availability: AvailabilityType.Operative,
+            connectors: new Map([[1, connectorStatus]]),
+            MeterValues: overrides.evseMeterValues,
+          }
+        : undefined,
     getNumberOfPhases: () => numberOfPhases,
     getVoltageOut: () => voltageOut,
     logPrefix: () => '[test]',
@@ -1337,6 +1351,90 @@ await describe('CoherentMeterValues', async () => {
           'both surviving samples must be aggregates (no phase qualifier)'
         )
       }
+    })
+  })
+
+  await describe('EVSE-level template fallback', async () => {
+    await it('should emit EVSE-level MeterValues when the connector is grouped under an EVSE with a non-empty MeterValues array', () => {
+      const evseTemplate: SampledValueTemplate = {
+        measurand: MeterValueMeasurand.STATE_OF_CHARGE,
+        unit: MeterValueUnit.PERCENT,
+      } as unknown as SampledValueTemplate
+      const { connectorStatus, context, sessions } = buildContext({
+        currentType: CurrentType.AC,
+        evseMaxPowerW: 22000,
+        evseMeterValues: [evseTemplate],
+        numberOfPhases: 3,
+        voltageOut: 230,
+      })
+      const session = createSessionOrFail(context, {
+        connectorId: 1,
+        now: 0,
+        profiles: [baseProfile],
+        rampUpDurationMs: 0,
+        rootSeed: 42,
+        transactionId: 1,
+      })
+      sessions.set(1, session)
+      // Connector-level templates ignored when EVSE-level is defined and non-empty.
+      connectorStatus.MeterValues = [
+        {
+          measurand: MeterValueMeasurand.ENERGY_ACTIVE_IMPORT_REGISTER,
+          unit: MeterValueUnit.WATT_HOUR,
+        } as unknown as SampledValueTemplate,
+      ]
+      const mv = buildCoherentMeterValue(context, session, passThroughBuilder, {
+        intervalMs: TEST_METER_VALUES_INTERVAL_MS,
+        nowMs: TEST_METER_VALUES_INTERVAL_MS,
+        rootSeed: 42,
+        voltageNoise: false,
+      })
+      const measurands = mv.sampledValue.map(
+        sv => (sv as { measurand?: MeterValueMeasurand }).measurand
+      )
+      assert.deepStrictEqual(
+        measurands,
+        [MeterValueMeasurand.STATE_OF_CHARGE],
+        'EVSE-level MeterValues (SoC only) must override connector-level (Energy only); connector Energy template must not emit'
+      )
+    })
+
+    await it('should fall back to connector-level MeterValues when no EVSE grouping exists', () => {
+      const connectorTemplate: SampledValueTemplate = {
+        measurand: MeterValueMeasurand.STATE_OF_CHARGE,
+        unit: MeterValueUnit.PERCENT,
+      } as unknown as SampledValueTemplate
+      // No evseMeterValues override => getEvseIdByConnectorId returns undefined.
+      const { connectorStatus, context, sessions } = buildContext({
+        currentType: CurrentType.AC,
+        evseMaxPowerW: 22000,
+        numberOfPhases: 3,
+        voltageOut: 230,
+      })
+      const session = createSessionOrFail(context, {
+        connectorId: 1,
+        now: 0,
+        profiles: [baseProfile],
+        rampUpDurationMs: 0,
+        rootSeed: 42,
+        transactionId: 1,
+      })
+      sessions.set(1, session)
+      connectorStatus.MeterValues = [connectorTemplate]
+      const mv = buildCoherentMeterValue(context, session, passThroughBuilder, {
+        intervalMs: TEST_METER_VALUES_INTERVAL_MS,
+        nowMs: TEST_METER_VALUES_INTERVAL_MS,
+        rootSeed: 42,
+        voltageNoise: false,
+      })
+      const measurands = mv.sampledValue.map(
+        sv => (sv as { measurand?: MeterValueMeasurand }).measurand
+      )
+      assert.deepStrictEqual(
+        measurands,
+        [MeterValueMeasurand.STATE_OF_CHARGE],
+        'connector-level MeterValues must emit when the connector is not grouped under an EVSE'
+      )
     })
   })
 })

--- a/tests/charging-station/meter-values/CoherentMeterValues.test.ts
+++ b/tests/charging-station/meter-values/CoherentMeterValues.test.ts
@@ -74,6 +74,11 @@ const baseProfile: EvProfile = {
  *   `undefined`, grouping is implied by `evseMeterValues != null` (backward-compat).
  *   Set to `false` to force flat-connector layout even with `evseMeterValues` defined.
  * @param overrides.numberOfPhases - Number of AC phases (ignored for DC).
+ * @param overrides.siblingConnectorMeterValues - When defined and grouping is active,
+ *   adds a sibling connector (id 2) under EVSE 1 with the given `MeterValues`. Lets
+ *   tests verify that the coherent path does NOT aggregate sibling-connector
+ *   templates when EVSE-level MeterValues is undefined or empty (documented
+ *   divergence from `getSampledValueTemplate`).
  * @param overrides.voltageOut - Nominal phase voltage.
  * @returns Bundle exposing context, sessions map, station info, and connector status.
  */
@@ -84,6 +89,7 @@ const buildContext = (
     evseMeterValues?: SampledValueTemplate[]
     groupUnderEvse?: boolean
     numberOfPhases?: number
+    siblingConnectorMeterValues?: SampledValueTemplate[]
     voltageOut?: number
   } = {}
 ): {
@@ -135,13 +141,22 @@ const buildContext = (
       const grouped =
         overrides.groupUnderEvse === true ||
         (overrides.groupUnderEvse !== false && overrides.evseMeterValues != null)
-      return grouped && evseId === 1
-        ? {
-            availability: AvailabilityType.Operative,
-            connectors: new Map([[1, connectorStatus]]),
-            MeterValues: overrides.evseMeterValues,
-          }
-        : undefined
+      if (!(grouped && evseId === 1)) return undefined
+      const connectors = new Map<number, ConnectorStatus>([[1, connectorStatus]])
+      if (overrides.siblingConnectorMeterValues != null) {
+        connectors.set(2, {
+          availability: AvailabilityType.Operative,
+          energyActiveImportRegisterValue: 0,
+          MeterValues: overrides.siblingConnectorMeterValues,
+          transactionEnergyActiveImportRegisterValue: 0,
+          transactionId: 2,
+        })
+      }
+      return {
+        availability: AvailabilityType.Operative,
+        connectors,
+        MeterValues: overrides.evseMeterValues,
+      }
     },
     getNumberOfPhases: () => numberOfPhases,
     getVoltageOut: () => voltageOut,
@@ -1499,8 +1514,8 @@ await describe('CoherentMeterValues', async () => {
       } as unknown as SampledValueTemplate
       // groupUnderEvse=true + no evseMeterValues => getEvseIdByConnectorId returns 1,
       // getEvseStatus(1).MeterValues = undefined. resolveTemplates must fall back
-      // to connector-level (guard: evseTemplates != null && length > 0 fails on both
-      // empty array and undefined branches).
+      // to connector-level (guard: isNotEmptyArray(evseTemplates) narrows undefined
+      // and empty-array to false uniformly).
       const { connectorStatus, context, sessions } = buildContext({
         currentType: CurrentType.AC,
         evseMaxPowerW: 22000,
@@ -1531,6 +1546,48 @@ await describe('CoherentMeterValues', async () => {
         measurands,
         [MeterValueMeasurand.STATE_OF_CHARGE],
         'connector-level MeterValues must emit when EVSE grouping exists but EVSE-level MeterValues is undefined (both undefined and empty-array branches must fall back)'
+      )
+    })
+
+    await it('should NOT aggregate sibling-connector MeterValues when EVSE-level MeterValues is undefined or empty (documented divergence from getSampledValueTemplate)', () => {
+      // Sibling connector under the same EVSE has POWER_ACTIVE_IMPORT template.
+      // Queried connector has empty MeterValues. EVSE-level MeterValues is empty.
+      // Reference `getSampledValueTemplate` would aggregate: emit Power from sibling.
+      // Coherent `resolveTemplates` deliberately does NOT (per-connector template
+      // ownership) so nothing emits.
+      const siblingTemplate: SampledValueTemplate = {
+        measurand: MeterValueMeasurand.POWER_ACTIVE_IMPORT,
+        unit: MeterValueUnit.WATT,
+      } as unknown as SampledValueTemplate
+      const { connectorStatus, context, sessions } = buildContext({
+        currentType: CurrentType.AC,
+        evseMaxPowerW: 22000,
+        evseMeterValues: [],
+        groupUnderEvse: true,
+        numberOfPhases: 3,
+        siblingConnectorMeterValues: [siblingTemplate],
+        voltageOut: 230,
+      })
+      const session = createSessionOrFail(context, {
+        connectorId: 1,
+        now: 0,
+        profiles: [baseProfile],
+        rampUpDurationMs: 0,
+        rootSeed: 42,
+        transactionId: 1,
+      })
+      sessions.set(1, session)
+      connectorStatus.MeterValues = []
+      const mv = buildCoherentMeterValue(context, session, passThroughBuilder, {
+        intervalMs: TEST_METER_VALUES_INTERVAL_MS,
+        nowMs: TEST_METER_VALUES_INTERVAL_MS,
+        rootSeed: 42,
+        voltageNoise: false,
+      })
+      assert.strictEqual(
+        mv.sampledValue.length,
+        0,
+        'coherent path must NOT aggregate sibling-connector templates under the same EVSE; reference getSampledValueTemplate would emit sibling Power, coherent must emit nothing per documented one-source-per-connector divergence'
       )
     })
   })

--- a/tests/charging-station/meter-values/CoherentMeterValues.test.ts
+++ b/tests/charging-station/meter-values/CoherentMeterValues.test.ts
@@ -65,10 +65,14 @@ const baseProfile: EvProfile = {
  * @param overrides - Optional overrides bag for context knobs.
  * @param overrides.currentType - `CurrentType.AC` or `CurrentType.DC`.
  * @param overrides.evseMaxPowerW - EVSE cap returned by `getConnectorMaximumAvailablePower`.
- * @param overrides.evseMeterValues - When defined and non-empty, exposed via
- *   `getEvseStatus(evseId).MeterValues`; also implies `getEvseIdByConnectorId`
- *   resolves to a non-null EVSE id. When `undefined`, `getEvseIdByConnectorId`
- *   returns `undefined` (flat connector layout).
+ * @param overrides.evseMeterValues - When defined and `groupUnderEvse !== false`, exposed via
+ *   `getEvseStatus(evseId).MeterValues`. When omitted with `groupUnderEvse === true`,
+ *   `getEvseStatus(evseId).MeterValues` is `undefined` (EVSE grouping present with no
+ *   EVSE-level MeterValues configured).
+ * @param overrides.groupUnderEvse - Explicit EVSE grouping flag. When `true`,
+ *   `getEvseIdByConnectorId` returns 1 regardless of `evseMeterValues`. When
+ *   `undefined`, grouping is implied by `evseMeterValues != null` (backward-compat).
+ *   Set to `false` to force flat-connector layout even with `evseMeterValues` defined.
  * @param overrides.numberOfPhases - Number of AC phases (ignored for DC).
  * @param overrides.voltageOut - Nominal phase voltage.
  * @returns Bundle exposing context, sessions map, station info, and connector status.
@@ -78,6 +82,7 @@ const buildContext = (
     currentType?: CurrentType
     evseMaxPowerW?: number
     evseMeterValues?: SampledValueTemplate[]
+    groupUnderEvse?: boolean
     numberOfPhases?: number
     voltageOut?: number
   } = {}
@@ -119,15 +124,25 @@ const buildContext = (
   const context: ICoherentContext = {
     getConnectorMaximumAvailablePower: () => evseMax,
     getConnectorStatus: () => connectorStatus,
-    getEvseIdByConnectorId: () => (overrides.evseMeterValues != null ? 1 : undefined),
-    getEvseStatus: (evseId: number) =>
-      overrides.evseMeterValues != null && evseId === 1
+    getEvseIdByConnectorId: () => {
+      // groupUnderEvse takes precedence over evseMeterValues heuristic.
+      // Undefined groupUnderEvse falls back to evseMeterValues != null.
+      if (overrides.groupUnderEvse === true) return 1
+      if (overrides.groupUnderEvse === false) return undefined
+      return overrides.evseMeterValues != null ? 1 : undefined
+    },
+    getEvseStatus: (evseId: number) => {
+      const grouped =
+        overrides.groupUnderEvse === true ||
+        (overrides.groupUnderEvse !== false && overrides.evseMeterValues != null)
+      return grouped && evseId === 1
         ? {
             availability: AvailabilityType.Operative,
             connectors: new Map([[1, connectorStatus]]),
             MeterValues: overrides.evseMeterValues,
           }
-        : undefined,
+        : undefined
+    },
     getNumberOfPhases: () => numberOfPhases,
     getVoltageOut: () => voltageOut,
     logPrefix: () => '[test]',
@@ -1474,6 +1489,48 @@ await describe('CoherentMeterValues', async () => {
         measurands,
         [MeterValueMeasurand.STATE_OF_CHARGE],
         'connector-level MeterValues must emit when EVSE grouping exists but the EVSE-level MeterValues array is empty'
+      )
+    })
+
+    await it('should fall back to connector-level MeterValues when EVSE grouping exists but EVSE-level MeterValues is undefined', () => {
+      const connectorTemplate: SampledValueTemplate = {
+        measurand: MeterValueMeasurand.STATE_OF_CHARGE,
+        unit: MeterValueUnit.PERCENT,
+      } as unknown as SampledValueTemplate
+      // groupUnderEvse=true + no evseMeterValues => getEvseIdByConnectorId returns 1,
+      // getEvseStatus(1).MeterValues = undefined. resolveTemplates must fall back
+      // to connector-level (guard: evseTemplates != null && length > 0 fails on both
+      // empty array and undefined branches).
+      const { connectorStatus, context, sessions } = buildContext({
+        currentType: CurrentType.AC,
+        evseMaxPowerW: 22000,
+        groupUnderEvse: true,
+        numberOfPhases: 3,
+        voltageOut: 230,
+      })
+      const session = createSessionOrFail(context, {
+        connectorId: 1,
+        now: 0,
+        profiles: [baseProfile],
+        rampUpDurationMs: 0,
+        rootSeed: 42,
+        transactionId: 1,
+      })
+      sessions.set(1, session)
+      connectorStatus.MeterValues = [connectorTemplate]
+      const mv = buildCoherentMeterValue(context, session, passThroughBuilder, {
+        intervalMs: TEST_METER_VALUES_INTERVAL_MS,
+        nowMs: TEST_METER_VALUES_INTERVAL_MS,
+        rootSeed: 42,
+        voltageNoise: false,
+      })
+      const measurands = mv.sampledValue.map(
+        sv => (sv as { measurand?: MeterValueMeasurand }).measurand
+      )
+      assert.deepStrictEqual(
+        measurands,
+        [MeterValueMeasurand.STATE_OF_CHARGE],
+        'connector-level MeterValues must emit when EVSE grouping exists but EVSE-level MeterValues is undefined (both undefined and empty-array branches must fall back)'
       )
     })
   })

--- a/tests/charging-station/meter-values/CoherentMeterValues.test.ts
+++ b/tests/charging-station/meter-values/CoherentMeterValues.test.ts
@@ -1436,5 +1436,45 @@ await describe('CoherentMeterValues', async () => {
         'connector-level MeterValues must emit when the connector is not grouped under an EVSE'
       )
     })
+
+    await it('should fall back to connector-level MeterValues when EVSE grouping exists but EVSE-level MeterValues array is empty', () => {
+      const connectorTemplate: SampledValueTemplate = {
+        measurand: MeterValueMeasurand.STATE_OF_CHARGE,
+        unit: MeterValueUnit.PERCENT,
+      } as unknown as SampledValueTemplate
+      // evseMeterValues=[] => getEvseIdByConnectorId returns 1, getEvseStatus(1).MeterValues = [].
+      // resolveTemplates must skip the empty EVSE array and fall back to connector-level.
+      const { connectorStatus, context, sessions } = buildContext({
+        currentType: CurrentType.AC,
+        evseMaxPowerW: 22000,
+        evseMeterValues: [],
+        numberOfPhases: 3,
+        voltageOut: 230,
+      })
+      const session = createSessionOrFail(context, {
+        connectorId: 1,
+        now: 0,
+        profiles: [baseProfile],
+        rampUpDurationMs: 0,
+        rootSeed: 42,
+        transactionId: 1,
+      })
+      sessions.set(1, session)
+      connectorStatus.MeterValues = [connectorTemplate]
+      const mv = buildCoherentMeterValue(context, session, passThroughBuilder, {
+        intervalMs: TEST_METER_VALUES_INTERVAL_MS,
+        nowMs: TEST_METER_VALUES_INTERVAL_MS,
+        rootSeed: 42,
+        voltageNoise: false,
+      })
+      const measurands = mv.sampledValue.map(
+        sv => (sv as { measurand?: MeterValueMeasurand }).measurand
+      )
+      assert.deepStrictEqual(
+        measurands,
+        [MeterValueMeasurand.STATE_OF_CHARGE],
+        'connector-level MeterValues must emit when EVSE grouping exists but the EVSE-level MeterValues array is empty'
+      )
+    })
   })
 })


### PR DESCRIPTION
## Context

Addresses item **(g)** from issue #1936.

The coherent path's `resolveTemplates` in [`CoherentMeterValueBuilder.ts`](src/charging-station/meter-values/CoherentMeterValueBuilder.ts) read connector-level `MeterValues` only. A station that defined `MeterValues` at EVSE-level (via the `Evses` template section) and enabled `coherentMeterValues=true` would emit an empty MeterValue because the EVSE-level array was never consulted - a pre-existing TODO documented in the prior `resolveTemplates` JSDoc:

> "Adding EVSE-level template inheritance to the coherent path requires extending the context interface with `getEvseStatus`."

## Change

The random/fixed path's `getSampledValueTemplate` already resolves EVSE-level `MeterValues` with the semantics described in README section *"MeterValues at EVSE-level"*: *"EVSE-level definitions apply to all connectors of the EVSE and override connector-level definitions."* The coherent path adopts the same **precedence** (EVSE-level overrides connector-level; connector-level used when the connector is not grouped under an EVSE OR when the EVSE-level array is undefined/empty), but deliberately does **not** replicate the reference's cross-connector aggregation: the coherent generator emits templates from exactly one source (EVSE-level or the queried connector) to preserve per-connector template ownership. This divergence is documented in the `resolveTemplates` JSDoc and the README.

1. **`ICoherentContext` extension** in [`src/charging-station/meter-values/types.ts`](src/charging-station/meter-values/types.ts): add two accessors mirroring the existing `ChargingStation` public API - `getEvseIdByConnectorId(connectorId): number | undefined` and `getEvseStatus(evseId): EvseStatus | undefined`. Requires importing `EvseStatus` from the shared types barrel.
2. **`resolveTemplates` rewrite** in [`CoherentMeterValueBuilder.ts`](src/charging-station/meter-values/CoherentMeterValueBuilder.ts): EVSE-first lookup + connector-level fallback (EVSE undefined OR its `MeterValues` array missing/empty). JSDoc updated to reflect the new contract.
3. **Test mock extension** in [`CoherentMeterValues.test.ts`](tests/charging-station/meter-values/CoherentMeterValues.test.ts): `buildContext` factory gains three related knobs - `evseMeterValues?: SampledValueTemplate[]` (the EVSE-level `MeterValues` array to expose via `getEvseStatus(evseId).MeterValues`), `groupUnderEvse?: boolean` (explicit EVSE grouping flag), and `siblingConnectorMeterValues?: SampledValueTemplate[]` (when defined and grouping is active, adds a sibling connector 2 under EVSE 1 with the given `MeterValues`; enables the sibling-aggregation divergence regression test). Resolution logic:
   - `groupUnderEvse === true` forces `getEvseIdByConnectorId` to return `1` regardless of `evseMeterValues` (enables the distinct "EVSE grouping present + EVSE-level `MeterValues` undefined" branch).
   - `groupUnderEvse === false` forces flat-connector layout even if `evseMeterValues` is defined.
   - `groupUnderEvse === undefined` (default) implies grouping when `evseMeterValues != null`, preserves backward-compat.
4. **Tests** - new `EVSE-level template fallback` describe block with five tests: (a) EVSE-level MeterValues override connector-level when defined and non-empty; (b) connector-level MeterValues used when the connector is not grouped under an EVSE; (c) connector-level MeterValues used when EVSE grouping exists but the EVSE-level MeterValues array is empty; (d) connector-level MeterValues used when EVSE grouping exists but the EVSE-level MeterValues is undefined (distinct from empty-array branch); (e) coherent path does NOT aggregate sibling-connector `MeterValues` when EVSE-level `MeterValues` is undefined or empty (regression lock on the documented divergence from reference `getSampledValueTemplate`).
5. **README** - section *"Template resolution scope"* updated to remove the `connector-level definition only` caveat and document the new precedence rules.

## Behavior matrix

| Station layout | Connector under EVSE? | EVSE-level `MeterValues` state | Template source used |
|---|---|---|---|
| Flat `Connectors` map | no | N/A | Connector-level |
| `Evses` grouped | yes | defined + non-empty | **EVSE-level (overrides connector)** |
| `Evses` grouped | yes | undefined or empty array | Connector-level (fallback) |

## Preservation

- The shared mock in [`tests/charging-station/helpers/StationHelpers.ts`](tests/charging-station/helpers/StationHelpers.ts) already exposes `getEvseIdByConnectorId` + `getEvseStatus`; downstream test files routing through the mock require no change.
- The coherent path continues to consume only `SampledValueTemplate[]`; no dependency on `EvseStatus` shape beyond `MeterValues?: SampledValueTemplate[]`.

## Quality gates

`pnpm typecheck && pnpm lint && pnpm build && pnpm test` pass. Invariant `fail: 0, skipped: 6` preserved (total test count is flaky within `2860-2940` range across runs; exact totals therefore omitted).

## Base

Rebased over `main` post-merge of #1946 (item f), #1945 (item d), #1943 (item j), #1941 (item h), #1940 (item c), #1942 (item k).

Closes item (g) of #1936.
