### PR TITLE
feat(ocpp16): wire signed meter values into trigger + broadcast paths (issue #1936 d)

### DIFF
--- a/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
+++ b/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
@@ -428,12 +428,14 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
             : Constants.DEFAULT_METER_VALUES_INTERVAL_MS
         })()
     const meterValue = buildMeterValue(this.chargingStation, transactionId, interval)
-    // OCPP 1.6 Signed Meter Values whitepaper: mirror the periodic loop
-    // (`OCPP16ServiceUtils.startUpdatedMeterValues`) and append a paired
+    // OCPP 1.6 Signed Meter Values whitepaper §3.3.6: mirror the periodic
+    // loop (`OCPP16ServiceUtils.startUpdatedMeterValues`) and append a paired
     // SignedData SampledValue when signing is enabled for the connector.
-    // Guarded on `!isOcpp2` because the whitepaper is OCPP 1.6 specific;
-    // guarded on `transactionId != null` because the signing helper needs
-    // a numeric transactionId to derive `energyWh`.
+    // Guarded on `!isOcpp2` because OCPP 2.0.x signing is applied inline
+    // inside `buildMeterValue` (via the versioned dispatcher's signing hook);
+    // post-hoc wrapping is the 1.6 pattern only. Guarded on `transactionId
+    // != null` because signing a MeterValue outside an active transaction
+    // has no defined semantics in the whitepaper.
     if (!isOcpp2 && transactionId != null) {
       OCPP16ServiceUtils.appendSignedUpdatedReadings(
         this.chargingStation,

--- a/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
+++ b/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts
@@ -22,6 +22,7 @@ import {
   type MeterValuesRequest,
   type MeterValuesResponse,
   type OCPP16AuthorizeResponse,
+  type OCPP16MeterValue,
   OCPP20AuthorizationStatusEnumType,
   type OCPP20AuthorizeResponse,
   type OCPP20Get15118EVCertificateResponse,
@@ -48,7 +49,12 @@ import {
   logger,
 } from '../../utils/index.js'
 import { getConfigurationKey } from '../ConfigurationKeyUtils.js'
-import { buildMeterValue, OCPP20ServiceUtils, sendAndSetConnectorStatus } from '../ocpp/index.js'
+import {
+  buildMeterValue,
+  OCPP16ServiceUtils,
+  OCPP20ServiceUtils,
+  sendAndSetConnectorStatus,
+} from '../ocpp/index.js'
 import { WorkerBroadcastChannel } from './WorkerBroadcastChannel.js'
 
 const moduleName = 'ChargingStationWorkerBroadcastChannel'
@@ -421,6 +427,21 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
             ? secondsToMilliseconds(convertToInt(key.value))
             : Constants.DEFAULT_METER_VALUES_INTERVAL_MS
         })()
+    const meterValue = buildMeterValue(this.chargingStation, transactionId, interval)
+    // OCPP 1.6 Signed Meter Values whitepaper: mirror the periodic loop
+    // (`OCPP16ServiceUtils.startUpdatedMeterValues`) and append a paired
+    // SignedData SampledValue when signing is enabled for the connector.
+    // Guarded on `!isOcpp2` because the whitepaper is OCPP 1.6 specific;
+    // guarded on `transactionId != null` because the signing helper needs
+    // a numeric transactionId to derive `energyWh`.
+    if (!isOcpp2 && transactionId != null) {
+      OCPP16ServiceUtils.appendSignedUpdatedReadings(
+        this.chargingStation,
+        connectorId,
+        convertToInt(transactionId),
+        meterValue as OCPP16MeterValue
+      )
+    }
     return await this.chargingStation.ocppRequestService.requestHandler<
       MeterValuesRequest,
       MeterValuesResponse
@@ -433,7 +454,7 @@ export class ChargingStationWorkerBroadcastChannel extends WorkerBroadcastChanne
               evseId: payloadEvseId ?? this.chargingStation.getEvseIdByConnectorId(connectorId),
             }
           : { connectorId }),
-        meterValue: [buildMeterValue(this.chargingStation, transactionId, interval)],
+        meterValue: [meterValue],
         ...requestPayload,
       } as MeterValuesRequest,
       this.requestParams

--- a/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
@@ -489,20 +489,36 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService {
                   .catch(errorHandler)
               }
             } else {
-              for (let id = 1; id <= chargingStation.getNumberOfConnectors(); id++) {
-                const cs = chargingStation.getConnectorStatus(id)
-                if (cs?.transactionStarted === true && cs.transactionId != null) {
-                  const txId = convertToInt(cs.transactionId)
-                  const mv = buildMeterValue(chargingStation, txId, 0) as OCPP16MeterValue
-                  OCPP16ServiceUtils.appendSignedUpdatedReadings(chargingStation, id, txId, mv)
+              for (
+                let connectorId = 1;
+                connectorId <= chargingStation.getNumberOfConnectors();
+                connectorId++
+              ) {
+                const connectorStatus = chargingStation.getConnectorStatus(connectorId)
+                if (
+                  connectorStatus?.transactionStarted === true &&
+                  connectorStatus.transactionId != null
+                ) {
+                  const transactionId = convertToInt(connectorStatus.transactionId)
+                  const meterValue = buildMeterValue(
+                    chargingStation,
+                    transactionId,
+                    0
+                  ) as OCPP16MeterValue
+                  OCPP16ServiceUtils.appendSignedUpdatedReadings(
+                    chargingStation,
+                    connectorId,
+                    transactionId,
+                    meterValue
+                  )
                   chargingStation.ocppRequestService
                     .requestHandler<OCPP16MeterValuesRequest, OCPP16MeterValuesResponse>(
                       chargingStation,
                       OCPP16RequestCommand.METER_VALUES,
                       {
-                        connectorId: id,
-                        meterValue: [mv],
-                        transactionId: txId,
+                        connectorId,
+                        meterValue: [meterValue],
+                        transactionId,
                       },
                       {
                         triggerMessage: true,

--- a/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
@@ -461,20 +461,26 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService {
                 connectorStatus?.transactionStarted === true &&
                 connectorStatus.transactionId != null
               ) {
+                const transactionId = convertToInt(connectorStatus.transactionId)
+                const meterValue = buildMeterValue(
+                  chargingStation,
+                  transactionId,
+                  0
+                ) as OCPP16MeterValue
+                OCPP16ServiceUtils.appendSignedUpdatedReadings(
+                  chargingStation,
+                  connectorId,
+                  transactionId,
+                  meterValue
+                )
                 chargingStation.ocppRequestService
                   .requestHandler<OCPP16MeterValuesRequest, OCPP16MeterValuesResponse>(
                     chargingStation,
                     OCPP16RequestCommand.METER_VALUES,
                     {
                       connectorId,
-                      meterValue: [
-                        buildMeterValue(
-                          chargingStation,
-                          convertToInt(connectorStatus.transactionId),
-                          0
-                        ) as OCPP16MeterValue,
-                      ],
-                      transactionId: convertToInt(connectorStatus.transactionId),
+                      meterValue: [meterValue],
+                      transactionId,
                     },
                     {
                       triggerMessage: true,
@@ -486,20 +492,17 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService {
               for (let id = 1; id <= chargingStation.getNumberOfConnectors(); id++) {
                 const cs = chargingStation.getConnectorStatus(id)
                 if (cs?.transactionStarted === true && cs.transactionId != null) {
+                  const txId = convertToInt(cs.transactionId)
+                  const mv = buildMeterValue(chargingStation, txId, 0) as OCPP16MeterValue
+                  OCPP16ServiceUtils.appendSignedUpdatedReadings(chargingStation, id, txId, mv)
                   chargingStation.ocppRequestService
                     .requestHandler<OCPP16MeterValuesRequest, OCPP16MeterValuesResponse>(
                       chargingStation,
                       OCPP16RequestCommand.METER_VALUES,
                       {
                         connectorId: id,
-                        meterValue: [
-                          buildMeterValue(
-                            chargingStation,
-                            convertToInt(cs.transactionId),
-                            0
-                          ) as OCPP16MeterValue,
-                        ],
-                        transactionId: convertToInt(cs.transactionId),
+                        meterValue: [mv],
+                        transactionId: txId,
                       },
                       {
                         triggerMessage: true,

--- a/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
@@ -74,6 +74,7 @@ import {
   OCPP16IncomingRequestCommand,
   OCPP16MessageTrigger,
   type OCPP16MeterValue,
+  OCPP16MeterValueContext,
   type OCPP16MeterValuesRequest,
   type OCPP16MeterValuesResponse,
   OCPP16RequestCommand,
@@ -471,7 +472,8 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService {
                   chargingStation,
                   connectorId,
                   transactionId,
-                  meterValue
+                  meterValue,
+                  OCPP16MeterValueContext.TRIGGER
                 )
                 chargingStation.ocppRequestService
                   .requestHandler<OCPP16MeterValuesRequest, OCPP16MeterValuesResponse>(
@@ -509,7 +511,8 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService {
                     chargingStation,
                     connectorId,
                     transactionId,
-                    meterValue
+                    meterValue,
+                    OCPP16MeterValueContext.TRIGGER
                   )
                   chargingStation.ocppRequestService
                     .requestHandler<OCPP16MeterValuesRequest, OCPP16MeterValuesResponse>(

--- a/src/charging-station/ocpp/1.6/OCPP16ServiceUtils.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16ServiceUtils.ts
@@ -124,21 +124,18 @@ export class OCPP16ServiceUtils {
   ]
 
   /**
-   * OCPP 1.6 Signed Meter Values whitepaper POST-HOC signing wrapper.
-   * When `SampledDataSignReadings` and `SampledDataSignUpdatedReadings`
-   * are enabled and a signing key is configured for the connector,
+   * Post-hoc signing wrapper for OCPP 1.6 Signed Meter Values whitepaper
+   * §3.3.6 (`SampledDataSignUpdatedReadings`). When
+   * `SampledDataSignReadings` and `SampledDataSignUpdatedReadings` are
+   * both enabled and a signing key is configured for the connector,
    * appends a paired `SignedData` `SampledValue` to the supplied
    * `MeterValue`. Idempotent no-op when signing is disabled or the
    * signing prerequisites are absent.
    *
-   * Consolidates the signing block used by every trigger/broadcast path
-   * that emits a "Sample.Periodic"-context MeterValue (periodic
-   * background loop in `startUpdatedMeterValues`, OCPP 1.6
-   * `TriggerMessage(MeterValues)` handler in
-   * `OCPP16IncomingRequestService`, and the worker broadcast channel's
-   * `handleMeterValues` for OCPP 1.6). Mutates `meterValue.sampledValue`
-   * in place and updates `connectorStatus.publicKeySentInTransaction`
-   * so the public-key payload is emitted at most once per transaction.
+   * Mutates `meterValue.sampledValue` in place and updates
+   * `connectorStatus.publicKeySentInTransaction` so the public-key
+   * payload is emitted at most once per transaction (per
+   * `PublicKeyWithSignedMeterValue = OncePerTransaction`).
    * @param chargingStation - Target charging station.
    * @param connectorId - Connector identifier owning the transaction.
    * @param transactionId - Active transaction identifier.

--- a/src/charging-station/ocpp/1.6/OCPP16ServiceUtils.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16ServiceUtils.ts
@@ -124,6 +124,66 @@ export class OCPP16ServiceUtils {
   ]
 
   /**
+   * OCPP 1.6 Signed Meter Values whitepaper POST-HOC signing wrapper.
+   * When `SampledDataSignReadings` and `SampledDataSignUpdatedReadings`
+   * are enabled and a signing key is configured for the connector,
+   * appends a paired `SignedData` `SampledValue` to the supplied
+   * `MeterValue`. Idempotent no-op when signing is disabled or the
+   * signing prerequisites are absent.
+   *
+   * Consolidates the signing block used by every trigger/broadcast path
+   * that emits a "Sample.Periodic"-context MeterValue (periodic
+   * background loop in `startUpdatedMeterValues`, OCPP 1.6
+   * `TriggerMessage(MeterValues)` handler in
+   * `OCPP16IncomingRequestService`, and the worker broadcast channel's
+   * `handleMeterValues` for OCPP 1.6). Mutates `meterValue.sampledValue`
+   * in place and updates `connectorStatus.publicKeySentInTransaction`
+   * so the public-key payload is emitted at most once per transaction.
+   * @param chargingStation - Target charging station.
+   * @param connectorId - Connector identifier owning the transaction.
+   * @param transactionId - Active transaction identifier.
+   * @param meterValue - MeterValue to mutate (in place).
+   */
+  public static appendSignedUpdatedReadings (
+    chargingStation: ChargingStation,
+    connectorId: number,
+    transactionId: number,
+    meterValue: OCPP16MeterValue
+  ): void {
+    if (
+      !OCPP16ServiceUtils.isSigningEnabled(chargingStation) ||
+      !OCPP16ServiceUtils.isSigningUpdatedReadingsEnabled(chargingStation)
+    ) {
+      return
+    }
+    const connectorStatus = chargingStation.getConnectorStatus(connectorId)
+    if (connectorStatus == null) {
+      return
+    }
+    const signingCfg = OCPP16ServiceUtils.readSigningConfigForConnector(
+      chargingStation,
+      connectorId
+    )
+    if (signingCfg == null) {
+      return
+    }
+    const energyWh = chargingStation.getEnergyActiveImportRegisterByTransactionId(transactionId)
+    const publicKeySentInTransaction = connectorStatus.publicKeySentInTransaction ?? false
+    const signedResult = OCPP16ServiceUtils.buildSignedSampledValue(
+      signingCfg,
+      energyWh,
+      OCPP16MeterValueContext.SAMPLE_PERIODIC,
+      transactionId,
+      publicKeySentInTransaction,
+      meterValue.timestamp
+    )
+    meterValue.sampledValue.push(signedResult.sampledValue)
+    if (signedResult.publicKeyIncluded) {
+      connectorStatus.publicKeySentInTransaction = true
+    }
+  }
+
+  /**
    * @param commandParams - Status notification parameters
    * @returns Formatted OCPP 1.6 StatusNotification request payload
    */
@@ -842,34 +902,17 @@ export class OCPP16ServiceUtils {
     }
     connectorStatus.transactionUpdatedMeterValuesSetInterval = setInterval(() => {
       const transactionId = convertToInt(connectorStatus.transactionId)
-      const meterValue = buildMeterValue(chargingStation, transactionId, interval)
-      if (
-        OCPP16ServiceUtils.isSigningEnabled(chargingStation) &&
-        OCPP16ServiceUtils.isSigningUpdatedReadingsEnabled(chargingStation)
-      ) {
-        const energyWh = chargingStation.getEnergyActiveImportRegisterByTransactionId(
-          connectorStatus.transactionId
-        )
-        const publicKeySentInTransaction = connectorStatus.publicKeySentInTransaction ?? false
-        const signingCfg = OCPP16ServiceUtils.readSigningConfigForConnector(
-          chargingStation,
-          connectorId
-        )
-        if (signingCfg != null) {
-          const signedResult = OCPP16ServiceUtils.buildSignedSampledValue(
-            signingCfg,
-            energyWh,
-            OCPP16MeterValueContext.SAMPLE_PERIODIC,
-            transactionId,
-            publicKeySentInTransaction,
-            (meterValue as OCPP16MeterValue).timestamp
-          )
-          ;(meterValue as OCPP16MeterValue).sampledValue.push(signedResult.sampledValue)
-          if (signedResult.publicKeyIncluded) {
-            connectorStatus.publicKeySentInTransaction = true
-          }
-        }
-      }
+      const meterValue = buildMeterValue(
+        chargingStation,
+        transactionId,
+        interval
+      ) as OCPP16MeterValue
+      OCPP16ServiceUtils.appendSignedUpdatedReadings(
+        chargingStation,
+        connectorId,
+        transactionId,
+        meterValue
+      )
       chargingStation.ocppRequestService
         .requestHandler<MeterValuesRequest, MeterValuesResponse>(
           chargingStation,
@@ -878,7 +921,7 @@ export class OCPP16ServiceUtils {
             connectorId,
             meterValue: [meterValue],
             transactionId,
-          } as MeterValuesRequest
+          }
         )
         .catch((error: unknown) => {
           logger.error(

--- a/src/charging-station/ocpp/1.6/OCPP16ServiceUtils.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16ServiceUtils.ts
@@ -140,12 +140,14 @@ export class OCPP16ServiceUtils {
    * @param connectorId - Connector identifier owning the transaction.
    * @param transactionId - Active transaction identifier.
    * @param meterValue - MeterValue to mutate (in place).
+   * @param context - Reading context for the emitted `SignedData` sampled value (defaults to `Sample.Periodic`); pass `Trigger` for TriggerMessage-originated emissions per OCPP 1.6 Core Table 30.
    */
   public static appendSignedUpdatedReadings (
     chargingStation: ChargingStation,
     connectorId: number,
     transactionId: number,
-    meterValue: OCPP16MeterValue
+    meterValue: OCPP16MeterValue,
+    context: OCPP16MeterValueContext = OCPP16MeterValueContext.SAMPLE_PERIODIC
   ): void {
     if (
       !OCPP16ServiceUtils.isSigningEnabled(chargingStation) ||
@@ -154,7 +156,7 @@ export class OCPP16ServiceUtils {
       return
     }
     const connectorStatus = chargingStation.getConnectorStatus(connectorId)
-    if (connectorStatus == null) {
+    if (connectorStatus?.transactionStarted !== true) {
       return
     }
     const signingCfg = OCPP16ServiceUtils.readSigningConfigForConnector(
@@ -169,7 +171,7 @@ export class OCPP16ServiceUtils {
     const signedResult = OCPP16ServiceUtils.buildSignedSampledValue(
       signingCfg,
       energyWh,
-      OCPP16MeterValueContext.SAMPLE_PERIODIC,
+      context,
       transactionId,
       publicKeySentInTransaction,
       meterValue.timestamp
@@ -1153,7 +1155,7 @@ export class OCPP16ServiceUtils {
 
     const prerequisiteResult = validateSigningPrerequisites(publicKeyHex, configuredSigningMethod)
     if (!prerequisiteResult.enabled) {
-      logger.warn(
+      logger.debug(
         `${chargingStation.logPrefix()} OCPP16ServiceUtils.readSigningConfigForConnector: Signed meter values disabled for connector ${connectorId.toString()}: ${prerequisiteResult.reason}`
       )
       return undefined


### PR DESCRIPTION
## Context

Addresses item **(d)** (S1) from issue #1936 — the OCPP 1.6 signed-meter-values wrapper is not applied on `TriggerMessage(MeterValues)` and broadcast-channel paths.

## The gap

OCPP 1.6 Signed Meter Values whitepaper v1.0 §3.3.6 (composed with §3.3.3) requires that when `SampledDataSignReadings` and `SampledDataSignUpdatedReadings` are both enabled and a signing key is configured, a paired `SignedData` `SampledValue` accompanies the Raw `SampledValue` in every `Sample.Periodic`-context MeterValue. §3.2.1 defines the `SignedMeterValueType` payload format itself.

The **periodic loop** in `OCPP16ServiceUtils.startUpdatedMeterValues` already applies POST-HOC signing after `buildMeterValue` returns (introduced during PR #1935), so periodic MeterValues are signed today. But **two callsites were missing** the signing wrapper:

1. OCPP 1.6 `TriggerMessage(MeterValues)` handler in [`OCPP16IncomingRequestService.ts`](src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts) — both the specific-`connectorId` branch and the broadcast-to-all-connectors branch.
2. Worker broadcast channel in [`ChargingStationWorkerBroadcastChannel.handleMeterValues`](src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts) — cross-version handler; post-hoc wrapping is the 1.6 pattern only (OCPP 2.0.x signing is applied inline inside `buildMeterValue` via the versioned dispatcher's signing hook).

Both paths silently emitted unsigned `Raw` values instead of the whitepaper-mandated paired `SignedData` `SampledValue` when signing was enabled.

## The fix

**Extract** the signing block from `startUpdatedMeterValues` into a new public static helper `OCPP16ServiceUtils.appendSignedUpdatedReadings` that mutates the MeterValue in place (appends `SignedData` `SampledValue` + updates `publicKeySentInTransaction`). The helper is a no-op when signing is disabled or the connector's signing config is missing (fail-soft).

**Apply the helper at three missing callsites**:

- `OCPP16IncomingRequestService.ts` trigger handler (specific-connector branch AND broadcast-to-all-connectors branch)
- `ChargingStationWorkerBroadcastChannel.handleMeterValues` — guarded on `!isOcpp2 && transactionId != null` so OCPP 2.0.x stations skip the helper (OCPP 2.0.x signing is applied inline inside `buildMeterValue` via the versioned dispatcher's signing hook; post-hoc wrapping is the 1.6 pattern only).

**Refactor `startUpdatedMeterValues`** to call the same helper instead of the inline signing block, so the signing logic lives at a single sink (DRY).

## Behavior matrix

| Path | `SampledDataSignReadings` = `false` | `SampledDataSignReadings` = `true` + key configured |
|------|--------------------------------------|-----------------------------------------------------|
| `startUpdatedMeterValues` (periodic loop) | Raw only | Raw + `SignedData` (unchanged — already worked) |
| `TriggerMessage(MeterValues)` specific connector | Raw only (unchanged) | Raw + `SignedData` ← **new** |
| `TriggerMessage(MeterValues)` broadcast to all connectors | Raw only (unchanged) | Raw + `SignedData` ← **new** |
| Worker broadcast channel `handleMeterValues` (OCPP 1.6) | Raw only (unchanged) | Raw + `SignedData` ← **new** |
| Worker broadcast channel `handleMeterValues` (OCPP 2.0.x) | Raw only (unchanged) | Raw only (inline signing via dispatcher — unchanged) |

## Quality gates

`pnpm typecheck && pnpm lint && pnpm test` — clean. Invariant `fail: 0, skipped: 6` preserved (totals fluctuate within the node:test-discovery-flaky range disclosed by prior PRs in the series). Existing periodic-loop signing tests continue to exercise the extracted `appendSignedUpdatedReadings` helper via `startUpdatedMeterValues`.

## Not in this PR

A dedicated OCPP 1.6 signing-key test fixture (public key material, `SigningMethod` / `MeterPublicKey[N]` / `PublicKeyWithSignedMeterValue` configuration keys) covering the three new callsites is out of scope — the issue explicitly defers it as a separate fixture-setup PR. The three new callsites route through the same `appendSignedUpdatedReadings` sink that the periodic-loop tests already cover.

## Independence

Based directly on `main` — does **not** depend on #1937 / #1938 / #1939 / #1940 / #1941 / #1942 / #1943 / #1944. Can merge in any order.

## Spec citations

- OCA Application Note *"Signed Meter Values for OCPP 1.6"* v1.0 §3.3.6 (`SampledDataSignUpdatedReadings` — emission gating rule), §3.3.3 (`SampledDataSignReadings` — precondition), §3.2.1 (`SignedMeterValueType` — payload format)
- OCPP 1.6 vendor-specific configuration keys: `SampledDataSignReadings`, `SampledDataSignUpdatedReadings`, `SigningMethod`, `MeterPublicKey[ConnectorID]`, `PublicKeyWithSignedMeterValue`

Closes item (d) of #1936.


