### PR TITLE
refactor(charging-station): extract reservation helpers from Helpers.ts (issue #1936 f Phase 1)

### DIFF
--- a/src/charging-station/Helpers.ts
+++ b/src/charging-station/Helpers.ts
@@ -263,7 +263,7 @@ export const getDefaultConnectorMaximumPower = (
   const staticCount =
     stationTemplate.Evses != null
       ? // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        getMaxNumberOfEvses(stationTemplate.Evses) - (stationTemplate.Evses['0'] != null ? 1 : 0)
+      getMaxNumberOfEvses(stationTemplate.Evses) - (stationTemplate.Evses['0'] != null ? 1 : 0)
       : getMaxNumberOfConnectors(stationTemplate.Connectors) -
         (stationTemplate.Connectors?.['0'] != null ? 1 : 0)
   return staticCount > 0 ? maximumPower / staticCount : undefined
@@ -530,8 +530,8 @@ export const createSerialNumber = (
   }
   const serialNumberSuffix = params.randomSerialNumber
     ? getRandomSerialNumberSuffix({
-        upperCase: params.randomSerialNumberUpperCase,
-      })
+      upperCase: params.randomSerialNumberUpperCase,
+    })
     : ''
   isNotEmptyString(stationTemplate.chargePointSerialNumberPrefix) &&
     (stationInfo.chargePointSerialNumber = `${stationTemplate.chargePointSerialNumberPrefix}${serialNumberSuffix}`)
@@ -716,10 +716,10 @@ const buildChargingProfilesLimit = (
       return chargingSchedule.chargingRateUnit === ChargingRateUnitType.WATT
         ? limit
         : ACElectricUtils.powerTotal(
-            chargingStation.getNumberOfPhases(),
-            chargingStation.getVoltageOut(),
-            limit
-          )
+          chargingStation.getNumberOfPhases(),
+          chargingStation.getVoltageOut(),
+          limit
+        )
     case CurrentType.DC:
       return chargingSchedule.chargingRateUnit === ChargingRateUnitType.WATT
         ? limit

--- a/src/charging-station/Helpers.ts
+++ b/src/charging-station/Helpers.ts
@@ -11,7 +11,6 @@ import {
   isAfter,
   isBefore,
   isDate,
-  isPast,
   isWithinInterval,
   toDate,
 } from 'date-fns'
@@ -46,8 +45,6 @@ import {
   OCPPVersion,
   PowerUnits,
   RecurrencyKindType,
-  type Reservation,
-  ReservationTerminationReason,
   StandardParametersKey,
   type SupportedFeatureProfiles,
   Voltage,
@@ -105,62 +102,12 @@ export const getChargingStationId = (
       )}${idSuffix}`
 }
 
-export const hasReservationExpired = (reservation: Reservation): boolean => {
-  return isPast(reservation.expiryDate)
-}
-
-/**
- * Checks if a connector has a pending (non-expired) reservation.
- * @param connectorStatus - The connector status to check
- * @returns true if the connector has a pending reservation, false otherwise
- */
-export const hasPendingReservation = (connectorStatus: ConnectorStatus): boolean => {
-  return connectorStatus.reservation != null && !hasReservationExpired(connectorStatus.reservation)
-}
-
-/**
- * Checks if a charging station has any pending (non-expired) reservations.
- * @param chargingStation - The charging station to check
- * @returns true if any connector has a pending reservation, false otherwise
- */
-export const hasPendingReservations = (chargingStation: ChargingStation): boolean => {
-  for (const { connectorStatus } of chargingStation.iterateConnectors()) {
-    if (hasPendingReservation(connectorStatus)) {
-      return true
-    }
-  }
-  return false
-}
-
-export const removeExpiredReservations = async (
-  chargingStation: ChargingStation
-): Promise<void> => {
-  const reservations: Reservation[] = []
-  for (const { connectorStatus } of chargingStation.iterateConnectors()) {
-    if (connectorStatus.reservation != null && hasReservationExpired(connectorStatus.reservation)) {
-      reservations.push(connectorStatus.reservation)
-    }
-  }
-  const results = await Promise.allSettled(
-    reservations.map(reservation =>
-      chargingStation.removeReservation(reservation, ReservationTerminationReason.EXPIRED)
-    )
-  )
-  let failureCount = 0
-  for (const result of results) {
-    if (result.status === 'rejected') {
-      ++failureCount
-      logger.warn(
-        `${chargingStation.logPrefix()} ${moduleName}.removeExpiredReservations: reservation removal failed: ${String(result.reason)}`
-      )
-    }
-  }
-  if (failureCount > 0) {
-    logger.error(
-      `${chargingStation.logPrefix()} ${moduleName}.removeExpiredReservations: ${failureCount.toString()}/${reservations.length.toString()} expired reservation removal(s) failed`
-    )
-  }
-}
+export {
+  hasPendingReservation,
+  hasPendingReservations,
+  hasReservationExpired,
+  removeExpiredReservations,
+} from './HelpersReservation.js'
 
 export const getHashId = (
   index: number,
@@ -316,7 +263,7 @@ export const getDefaultConnectorMaximumPower = (
   const staticCount =
     stationTemplate.Evses != null
       ? // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      getMaxNumberOfEvses(stationTemplate.Evses) - (stationTemplate.Evses['0'] != null ? 1 : 0)
+        getMaxNumberOfEvses(stationTemplate.Evses) - (stationTemplate.Evses['0'] != null ? 1 : 0)
       : getMaxNumberOfConnectors(stationTemplate.Connectors) -
         (stationTemplate.Connectors?.['0'] != null ? 1 : 0)
   return staticCount > 0 ? maximumPower / staticCount : undefined
@@ -583,8 +530,8 @@ export const createSerialNumber = (
   }
   const serialNumberSuffix = params.randomSerialNumber
     ? getRandomSerialNumberSuffix({
-      upperCase: params.randomSerialNumberUpperCase,
-    })
+        upperCase: params.randomSerialNumberUpperCase,
+      })
     : ''
   isNotEmptyString(stationTemplate.chargePointSerialNumberPrefix) &&
     (stationInfo.chargePointSerialNumber = `${stationTemplate.chargePointSerialNumberPrefix}${serialNumberSuffix}`)
@@ -769,10 +716,10 @@ const buildChargingProfilesLimit = (
       return chargingSchedule.chargingRateUnit === ChargingRateUnitType.WATT
         ? limit
         : ACElectricUtils.powerTotal(
-          chargingStation.getNumberOfPhases(),
-          chargingStation.getVoltageOut(),
-          limit
-        )
+            chargingStation.getNumberOfPhases(),
+            chargingStation.getVoltageOut(),
+            limit
+          )
     case CurrentType.DC:
       return chargingSchedule.chargingRateUnit === ChargingRateUnitType.WATT
         ? limit

--- a/src/charging-station/HelpersReservation.ts
+++ b/src/charging-station/HelpersReservation.ts
@@ -1,0 +1,91 @@
+// Copyright Jerome Benoit. 2021-2026. All Rights Reserved.
+
+/**
+ * @file Reservation lifecycle helpers.
+ * @description Extracted from {@link ./Helpers} as the first slice of the
+ *   issue #1936 (item f) file split. The `Helpers.ts` barrel re-exports
+ *   every symbol so external callers keep their existing import path
+ *   (`import { hasReservationExpired, ... } from './Helpers.js'`).
+ */
+
+import { isPast } from 'date-fns'
+
+import type { ChargingStation } from './ChargingStation.js'
+
+import {
+  type ConnectorStatus,
+  type Reservation,
+  ReservationTerminationReason,
+} from '../types/index.js'
+import { logger } from '../utils/index.js'
+
+const moduleName = 'HelpersReservation'
+
+/**
+ * Determines whether a reservation's `expiryDate` is in the past.
+ * @param reservation - The reservation to check.
+ * @returns `true` when the reservation has expired.
+ */
+export const hasReservationExpired = (reservation: Reservation): boolean => {
+  return isPast(reservation.expiryDate)
+}
+
+/**
+ * Checks if a connector has a pending (non-expired) reservation.
+ * @param connectorStatus - The connector status to check.
+ * @returns `true` if the connector has a pending reservation, `false` otherwise.
+ */
+export const hasPendingReservation = (connectorStatus: ConnectorStatus): boolean => {
+  return connectorStatus.reservation != null && !hasReservationExpired(connectorStatus.reservation)
+}
+
+/**
+ * Checks if a charging station has any pending (non-expired) reservations.
+ * @param chargingStation - The charging station to check.
+ * @returns `true` if any connector has a pending reservation, `false` otherwise.
+ */
+export const hasPendingReservations = (chargingStation: ChargingStation): boolean => {
+  for (const { connectorStatus } of chargingStation.iterateConnectors()) {
+    if (hasPendingReservation(connectorStatus)) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Removes every expired reservation currently attached to the station's
+ * connectors. Failures are logged per-reservation and aggregated into a
+ * single error log at the end so a partial-failure batch is still
+ * observable.
+ * @param chargingStation - The charging station whose expired reservations should be cleared.
+ */
+export const removeExpiredReservations = async (
+  chargingStation: ChargingStation
+): Promise<void> => {
+  const reservations: Reservation[] = []
+  for (const { connectorStatus } of chargingStation.iterateConnectors()) {
+    if (connectorStatus.reservation != null && hasReservationExpired(connectorStatus.reservation)) {
+      reservations.push(connectorStatus.reservation)
+    }
+  }
+  const results = await Promise.allSettled(
+    reservations.map(reservation =>
+      chargingStation.removeReservation(reservation, ReservationTerminationReason.EXPIRED)
+    )
+  )
+  let failureCount = 0
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      ++failureCount
+      logger.warn(
+        `${chargingStation.logPrefix()} ${moduleName}.removeExpiredReservations: reservation removal failed: ${String(result.reason)}`
+      )
+    }
+  }
+  if (failureCount > 0) {
+    logger.error(
+      `${chargingStation.logPrefix()} ${moduleName}.removeExpiredReservations: ${failureCount.toString()}/${reservations.length.toString()} expired reservation removal(s) failed`
+    )
+  }
+}

--- a/src/charging-station/HelpersReservation.ts
+++ b/src/charging-station/HelpersReservation.ts
@@ -32,7 +32,7 @@ export const hasReservationExpired = (reservation: Reservation): boolean => {
 }
 
 /**
- * Checks if a connector has a pending (non-expired) reservation.
+ * Determines whether a connector has a pending (non-expired) reservation.
  * @param connectorStatus - The connector status to check.
  * @returns `true` if the connector has a pending reservation, `false` otherwise.
  */
@@ -41,7 +41,7 @@ export const hasPendingReservation = (connectorStatus: ConnectorStatus): boolean
 }
 
 /**
- * Checks if a charging station has any pending (non-expired) reservations.
+ * Determines whether a charging station has any pending (non-expired) reservations.
  * @param chargingStation - The charging station to check.
  * @returns `true` if any connector has a pending reservation, `false` otherwise.
  */

--- a/src/charging-station/HelpersReservation.ts
+++ b/src/charging-station/HelpersReservation.ts
@@ -1,10 +1,11 @@
-// Copyright Jerome Benoit. 2021-2026. All Rights Reserved.
+// Partial Copyright Jerome Benoit. 2021-2025. All Rights Reserved.
 
 /**
  * @file Reservation lifecycle helpers.
- * @description Extracted from {@link ./Helpers} as the first slice of the
- *   issue #1936 (item f) file split. The `Helpers.ts` barrel re-exports
- *   every symbol so external callers keep their existing import path
+ * @description Predicates for reservation state (`hasReservationExpired`,
+ *   `hasPendingReservation`, `hasPendingReservations`) and a best-effort
+ *   bulk cleanup (`removeExpiredReservations`). Re-exported from
+ *   `./Helpers.js` so callers keep the barrel import path
  *   (`import { hasReservationExpired, ... } from './Helpers.js'`).
  */
 
@@ -59,6 +60,7 @@ export const hasPendingReservations = (chargingStation: ChargingStation): boolea
  * single error log at the end so a partial-failure batch is still
  * observable.
  * @param chargingStation - The charging station whose expired reservations should be cleared.
+ * @returns Resolves once every expiry sweep has settled; individual failures are logged, never rethrown.
  */
 export const removeExpiredReservations = async (
   chargingStation: ChargingStation


### PR DESCRIPTION
## Context

Addresses item **(f)** from issue #1936 — Phase 1 of the `Helpers.ts` file split.

`Helpers.ts` is **1389 LOC** — 5.5× the 250 LOC ceiling documented in AGENTS.md's programming skill. This PR extracts the smallest cohesive block (the 4 reservation helpers) into a dedicated file as an initial step, **proving the barrel-preservation pattern** so the remaining slices can follow in subsequent PRs without breaking any callers.

## Change

**Extracted into [`HelpersReservation.ts`](src/charging-station/HelpersReservation.ts)** (93 LOC):

| Symbol | Purpose |
|--------|---------|
| `hasReservationExpired(reservation)` | Type predicate: `isPast(reservation.expiryDate)` |
| `hasPendingReservation(connectorStatus)` | Connector has a non-expired reservation |
| `hasPendingReservations(chargingStation)` | Station has any pending reservations across connectors |
| `removeExpiredReservations(chargingStation)` | Async cleanup with per-reservation failure logging + aggregate error |

**`Helpers.ts` (1389 → 1336 LOC)** keeps the public API via a barrel re-export block. Every external caller (`import { hasReservationExpired, ... } from './Helpers.js'`) continues to work unchanged. Now-unused imports in `Helpers.ts` (`isPast`, `Reservation`, `ReservationTerminationReason`) are dropped.

## Rationale for phased approach

A full 5-way split of `Helpers.ts` (config / template / connector-status / serial-number / charging-profile blocks) is a substantial refactor that benefits from tight PR scope for review. This PR proves the pattern with a small, low-risk cohesive block; the remaining slices land in follow-up PRs each addressing one concern.

## Follow-up slices (each planned as its own PR to keep review scope tight)

1. **Charging profile helpers** (~13 symbols — the largest cohesive block, ~500 LOC)
2. **Connector-status helpers** (~8 symbols: `buildConnectorsMap`, `initializeConnectorsMapStatus`, `resetConnectorStatus`, `resetAuthorizeConnectorStatus`, `prepareConnectorStatus`, `initializeConnectorStatus`, `checkStationInfoConnectorStatus`, `getBootConnectorStatus`)
3. **Serial-number / id helpers** (`createSerialNumber`, `getHashId`, `getChargingStationId`, `propagateSerialNumber`, `getRandomSerialNumberSuffix`)
4. **Configuration / template helpers** (`stationTemplateToStationInfo`, `setChargingStationOptions`, `validateStationInfo`, `getEvProfilesFile`, `getIdTagsFile`, `getDefaultVoltageOut`, `getDefaultConnectorMaximumPower`, `buildTemplateName`, `checkConfiguration`, `getAmperageLimitationUnitDivider`)

## Quality gates

`pnpm typecheck && pnpm lint && pnpm test` — clean. Invariant `fail: 0, skipped: 6` preserved (totals fluctuate within the node:test-discovery-flaky range disclosed by prior PRs in the series). Zero caller changes required outside `Helpers.ts` because of the barrel re-export pattern.

## Observable log-prefix change

`removeExpiredReservations` logs now carry the prefix `HelpersReservation.removeExpiredReservations: …` instead of the pre-refactor `Helpers.removeExpiredReservations: …` because the new file rebinds `moduleName = 'HelpersReservation'` to reflect its actual source location. Log-based monitoring or alerting that greps for the old prefix must be updated. Consistent with the per-file `moduleName` convention adopted by prior splits in this series (#1937 `CoherentMeterValuesManager`, #1938 `CoherentSession` / `CoherentMeterValueBuilder`).

## Independence

Based directly on `main` — does **not** depend on any other #1936 follow-up PR (#1937 / #1938 / #1939 / #1940 / #1941 / #1942 / #1943 / #1944 / #1945). Can merge in any order.

Closes item (f) of #1936 Phase 1 of N.


