### PR TITLE
refactor: convention alignment — helpers, constants, imports, tests

### DIFF
--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -1683,12 +1683,12 @@ export class ChargingStation extends EventEmitter {
       const powerArrayRandomIndex = Math.floor(secureRandom() * stationTemplate.power.length)
       stationInfo.maximumPower =
         stationTemplate.powerUnit === PowerUnits.KILO_WATT
-          ? stationTemplate.power[powerArrayRandomIndex] * 1000
+          ? stationTemplate.power[powerArrayRandomIndex] * Constants.UNIT_DIVIDER_KILO
           : stationTemplate.power[powerArrayRandomIndex]
     } else if (typeof stationTemplate.power === 'number') {
       stationInfo.maximumPower =
         stationTemplate.powerUnit === PowerUnits.KILO_WATT
-          ? stationTemplate.power * 1000
+          ? stationTemplate.power * Constants.UNIT_DIVIDER_KILO
           : stationTemplate.power
     }
     stationInfo.maximumAmperage = this.getMaximumAmperage(stationInfo)

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -1606,7 +1606,7 @@ export class ChargingStation extends EventEmitter {
     }
     return this.stationInfo?.reconnectExponentialDelay === true
       ? computeExponentialBackOffDelay({
-        baseDelayMs: Constants.DEFAULT_RECONNECT_BASE_DELAY_MS,
+        baseDelayMs: Constants.DEFAULT_EXPONENTIAL_BACKOFF_BASE_DELAY_MS,
         jitterPercent: 0.2,
         retryNumber: this.wsConnectionRetryCount,
       })
@@ -2786,7 +2786,7 @@ export class ChargingStation extends EventEmitter {
         // eslint-disable-next-line promise/no-promise-in-callback
         sleep(
           computeExponentialBackOffDelay({
-            baseDelayMs: Constants.DEFAULT_RECONNECT_BASE_DELAY_MS,
+            baseDelayMs: Constants.DEFAULT_EXPONENTIAL_BACKOFF_BASE_DELAY_MS,
             jitterPercent: 0.2,
             retryNumber: messageIdx ?? 0,
           })

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -1954,7 +1954,7 @@ export class ChargingStation extends EventEmitter {
         'hex'
       )
       const connectorsConfigChanged =
-        this.connectors.size !== 0 && this.connectorsConfigurationHash !== connectorsConfigHash
+        !isEmpty(this.connectors) && this.connectorsConfigurationHash !== connectorsConfigHash
       if (isEmpty(this.connectors) || connectorsConfigChanged) {
         connectorsConfigChanged && this.connectors.clear()
         this.connectorsConfigurationHash = connectorsConfigHash
@@ -2118,7 +2118,7 @@ export class ChargingStation extends EventEmitter {
         'hex'
       )
       const evsesConfigChanged =
-        this.evses.size !== 0 && this.evsesConfigurationHash !== evsesConfigHash
+        !isEmpty(this.evses) && this.evsesConfigurationHash !== evsesConfigHash
       if (isEmpty(this.evses) || evsesConfigChanged) {
         evsesConfigChanged && this.evses.clear()
         this.evsesConfigurationHash = evsesConfigHash

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -1606,7 +1606,7 @@ export class ChargingStation extends EventEmitter {
     }
     return this.stationInfo?.reconnectExponentialDelay === true
       ? computeExponentialBackOffDelay({
-        baseDelayMs: 100,
+        baseDelayMs: Constants.DEFAULT_RECONNECT_BASE_DELAY_MS,
         jitterPercent: 0.2,
         retryNumber: this.wsConnectionRetryCount,
       })
@@ -2786,7 +2786,7 @@ export class ChargingStation extends EventEmitter {
         // eslint-disable-next-line promise/no-promise-in-callback
         sleep(
           computeExponentialBackOffDelay({
-            baseDelayMs: 100,
+            baseDelayMs: Constants.DEFAULT_RECONNECT_BASE_DELAY_MS,
             jitterPercent: 0.2,
             retryNumber: messageIdx ?? 0,
           })

--- a/src/charging-station/CoherentMeterValuesManager.ts
+++ b/src/charging-station/CoherentMeterValuesManager.ts
@@ -13,7 +13,7 @@
 import type { ChargingStation } from './ChargingStation.js'
 
 import { BaseError } from '../exception/index.js'
-import { logger } from '../utils/index.js'
+import { isEmpty, logger } from '../utils/index.js'
 import { getEvProfilesFile } from './Helpers.js'
 import { disposeCoherentSessionRuntime } from './meter-values/CoherentSampleComputer.js'
 import {
@@ -154,7 +154,7 @@ export class CoherentMeterValuesManager {
     if (this.chargingStation.stationInfo?.coherentMeterValues !== true) {
       return undefined
     }
-    if (this.evProfiles == null || this.evProfiles.profiles.length === 0) {
+    if (this.evProfiles == null || isEmpty(this.evProfiles.profiles)) {
       return undefined
     }
     const session = createCoherentSession(this.chargingStation, {

--- a/src/charging-station/HelpersConfig.ts
+++ b/src/charging-station/HelpersConfig.ts
@@ -36,7 +36,7 @@ import {
   PowerUnits,
   Voltage,
 } from '../types/index.js'
-import { clone, isEmpty, isNotEmptyArray, logger, secureRandom } from '../utils/index.js'
+import { clone, Constants, isEmpty, isNotEmptyArray, logger, secureRandom } from '../utils/index.js'
 
 const moduleName = 'HelpersConfig'
 
@@ -170,12 +170,12 @@ export const getDefaultConnectorMaximumPower = (
     const powerArrayRandomIndex = Math.floor(secureRandom() * stationTemplate.power.length)
     maximumPower =
       stationTemplate.powerUnit === PowerUnits.KILO_WATT
-        ? stationTemplate.power[powerArrayRandomIndex] * 1000
+        ? stationTemplate.power[powerArrayRandomIndex] * Constants.UNIT_DIVIDER_KILO
         : stationTemplate.power[powerArrayRandomIndex]
   } else if (typeof stationTemplate.power === 'number') {
     maximumPower =
       stationTemplate.powerUnit === PowerUnits.KILO_WATT
-        ? stationTemplate.power * 1000
+        ? stationTemplate.power * Constants.UNIT_DIVIDER_KILO
         : stationTemplate.power
   }
   if (maximumPower == null) {

--- a/src/charging-station/meter-values/CoherentMeterValueBuilder.ts
+++ b/src/charging-station/meter-values/CoherentMeterValueBuilder.ts
@@ -35,7 +35,7 @@ import {
   MeterValuePhase,
   MeterValueUnit,
 } from '../../types/index.js'
-import { Constants, isNotEmptyArray, logger, roundTo } from '../../utils/index.js'
+import { Constants, isEmpty, isNotEmptyArray, logger, roundTo } from '../../utils/index.js'
 import {
   advanceEnergyRegister,
   computeCoherentSample,
@@ -171,7 +171,7 @@ const applyRegisterValuesWithoutPhases = (
   const surviving: SampledValueTemplate[] = []
   for (const family of Map.groupBy(bucket, templateFamilyKey).values()) {
     const perPhaseLN = family.filter(isLineToNeutralTemplate)
-    if (perPhaseLN.length === 0) {
+    if (isEmpty(perPhaseLN)) {
       surviving.push(...family)
       continue
     }

--- a/src/charging-station/meter-values/CoherentSession.ts
+++ b/src/charging-station/meter-values/CoherentSession.ts
@@ -19,7 +19,7 @@
 import type { CoherentSession, EvProfile, ICoherentContext } from './types.js'
 
 import { CurrentType, Voltage } from '../../types/index.js'
-import { Constants, logger } from '../../utils/index.js'
+import { Constants, isEmpty, logger } from '../../utils/index.js'
 import { selectEvProfile } from './EvProfiles.js'
 import { createStreamPrng, hashLabel } from './PRNG.js'
 
@@ -83,7 +83,7 @@ export const createCoherentSession = (
   context: ICoherentContext,
   options: CreateSessionOptions
 ): CoherentSession | undefined => {
-  if (options.profiles.length === 0) {
+  if (isEmpty(options.profiles)) {
     return undefined
   }
   const now = options.now ?? Date.now()

--- a/src/charging-station/meter-values/EvProfiles.ts
+++ b/src/charging-station/meter-values/EvProfiles.ts
@@ -12,7 +12,7 @@ import { readFileSync } from 'node:fs'
 import { z } from 'zod'
 
 import { BaseError } from '../../exception/index.js'
-import { getErrorMessage, logger } from '../../utils/index.js'
+import { getErrorMessage, isEmpty, logger } from '../../utils/index.js'
 import { type EvProfile, type EvProfilesFile, EvProfilesFileSchema } from './types.js'
 
 const moduleName = 'EvProfiles'
@@ -106,7 +106,7 @@ export const interpolateChargingCurve = (
   curve: { powerFraction: number; socPercent: number }[],
   socPercent: number
 ): number => {
-  if (curve.length === 0) {
+  if (isEmpty(curve)) {
     return 1
   }
   if (process.env.NODE_ENV !== 'production') {

--- a/src/charging-station/ocpp/2.0/OCPP20CertificateManager.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20CertificateManager.ts
@@ -474,7 +474,7 @@ export class OCPP20CertificateManager {
       const pemCertificates = pem.match(
         /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g
       )
-      if (pemCertificates == null || pemCertificates.length === 0) {
+      if (pemCertificates == null || isEmpty(pemCertificates)) {
         return { reason: 'No PEM certificate found', valid: false }
       }
 

--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -191,6 +191,13 @@ import { getVariableMetadata, VARIABLE_REGISTRY } from './OCPP20VariableRegistry
 
 const moduleName = 'OCPP20IncomingRequestService'
 
+// GetBaseReport response chunking: conservative project default.
+// The actual per-device limits are reported at runtime by the Charging Station via
+// OCPP 2.0.1 §2.1.16 DeviceDataCtrlr.ItemsPerMessage(instance:GetReport) and
+// §2.1.18 DeviceDataCtrlr.BytesPerMessage(instance:GetReport); both are ReadOnly
+// device capability declarations with no spec-defined ceiling.
+const MAX_ITEMS_PER_REPORT_MESSAGE = 100 as const
+
 interface StationInfoReportField {
   property: 'chargePointModel' | 'chargePointSerialNumber' | 'chargePointVendor' | 'firmwareVersion'
   variable: OCPP20DeviceInfoVariableName
@@ -3512,10 +3519,9 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
     const cached = stationState.reportDataCache.get(requestId)
     const reportData = cached ?? this.buildReportData(chargingStation, reportBase)
 
-    const maxItemsPerMessage = 100
     const chunks = []
-    for (let i = 0; i < reportData.length; i += maxItemsPerMessage) {
-      chunks.push(reportData.slice(i, i + maxItemsPerMessage))
+    for (let i = 0; i < reportData.length; i += MAX_ITEMS_PER_REPORT_MESSAGE) {
+      chunks.push(reportData.slice(i, i + MAX_ITEMS_PER_REPORT_MESSAGE))
     }
 
     if (!isNotEmptyArray(chunks)) {

--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -1340,7 +1340,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
         meterValues.push(meterValue)
       }
     }
-    if (meterValues.length === 0) {
+    if (isEmpty(meterValues)) {
       meterValues.push({
         sampledValue: [
           {

--- a/src/charging-station/ocpp/OCPPServiceUtils.ts
+++ b/src/charging-station/ocpp/OCPPServiceUtils.ts
@@ -1490,6 +1490,8 @@ const getLimitFromSampledValueTemplateCustomValue = (
     },
     ...options,
   }
+  // Number.parseFloat preserved: NaN sentinel drives the POSITIVE_INFINITY fallback below;
+  // convertToFloat throws on NaN and would break the fallback branch.
   const parsedValue = Number.parseFloat(value ?? '')
   if (options.limitationEnabled) {
     return max(

--- a/src/charging-station/ocpp/OCPPServiceUtils.ts
+++ b/src/charging-station/ocpp/OCPPServiceUtils.ts
@@ -59,7 +59,6 @@ import {
   getRandomFloatFluctuatedRounded,
   getRandomFloatRounded,
   handleFileException,
-  isEmpty,
   isNotEmptyArray,
   isNotEmptyString,
   JSONStringify,

--- a/src/charging-station/ocpp/OCPPServiceUtils.ts
+++ b/src/charging-station/ocpp/OCPPServiceUtils.ts
@@ -59,6 +59,7 @@ import {
   getRandomFloatFluctuatedRounded,
   getRandomFloatRounded,
   handleFileException,
+  isEmpty,
   isNotEmptyArray,
   isNotEmptyString,
   JSONStringify,
@@ -1110,6 +1111,9 @@ const resolveEnabledMeasurands = (
   const enabled = new Set<MeterValueMeasurand>()
   for (const entry of rawValue.split(',')) {
     const trimmed = entry.trim()
+    // Kept as `.length === 0`: entry is already trimmed above; `isEmpty()` here would be
+    // semantically identical (its string branch is `value.trim().length === 0`) — direct
+    // check avoids a redundant re-trim.
     if (trimmed.length === 0) {
       continue
     }

--- a/src/charging-station/ocpp/auth/cache/InMemoryAuthCache.ts
+++ b/src/charging-station/ocpp/auth/cache/InMemoryAuthCache.ts
@@ -8,7 +8,7 @@ import { AuthorizationStatus } from '../types/AuthTypes.js'
 
 const moduleName = 'InMemoryAuthCache'
 
-
+// Rough heap-footprint estimate per cached entry — not measured; used only for stats display.
 const AVG_ENTRY_SIZE_BYTES = 500 as const
 
 /**

--- a/src/charging-station/ocpp/auth/cache/InMemoryAuthCache.ts
+++ b/src/charging-station/ocpp/auth/cache/InMemoryAuthCache.ts
@@ -8,6 +8,9 @@ import { AuthorizationStatus } from '../types/AuthTypes.js'
 
 const moduleName = 'InMemoryAuthCache'
 
+
+const AVG_ENTRY_SIZE_BYTES = 500 as const
+
 /**
  * Cached authorization entry with expiration
  */
@@ -236,8 +239,7 @@ export class InMemoryAuthCache implements AuthCache {
     const hitRate = totalAccess > 0 ? (this.stats.hits / totalAccess) * 100 : 0
 
     // Calculate memory usage estimate
-    const avgEntrySize = 500 // Rough estimate: 500 bytes per entry
-    const memoryUsage = this.cache.size * avgEntrySize
+    const memoryUsage = this.cache.size * AVG_ENTRY_SIZE_BYTES
 
     // Clean expired rate limit entries
     this.cleanupExpiredRateLimits()

--- a/src/charging-station/ocpp/auth/services/OCPPAuthServiceImpl.ts
+++ b/src/charging-station/ocpp/auth/services/OCPPAuthServiceImpl.ts
@@ -599,7 +599,7 @@ export class OCPPAuthServiceImpl implements OCPPAuthService {
       allowOfflineTxForUnknownId: false,
       authKeyManagementEnabled: false,
       authorizationCacheEnabled: true,
-      authorizationCacheLifetime: 3600,
+      authorizationCacheLifetime: Constants.DEFAULT_AUTH_CACHE_TTL_SECONDS,
       authorizationTimeout: 30,
       certificateAuthEnabled:
         this.chargingStation.stationInfo?.ocppVersion !== OCPPVersion.VERSION_16,

--- a/src/charging-station/ui-server/UIMCPServer.ts
+++ b/src/charging-station/ui-server/UIMCPServer.ts
@@ -28,6 +28,7 @@ import {
   getErrorMessage,
   isEmpty,
   isNotEmptyArray,
+  JSONStringify,
   logger,
 } from '../../utils/index.js'
 import { AbstractUIServer } from './AbstractUIServer.js'
@@ -82,7 +83,7 @@ export class UIMCPServer extends AbstractUIServer {
   }
 
   private static createToolResponse (payload: unknown): CallToolResult {
-    return { content: [{ text: JSON.stringify(payload), type: 'text' as const }] }
+    return { content: [{ text: JSONStringify(payload), type: 'text' as const }] }
   }
 
   public override hasResponseHandler (uuid: UUIDv4): boolean {

--- a/src/charging-station/ui-server/UIServerNet.ts
+++ b/src/charging-station/ui-server/UIServerNet.ts
@@ -152,6 +152,7 @@ const parseIPv4MappedAddress = (address: string): string | undefined => {
   if (hexMatch == null) {
     return undefined
   }
+  // radix-16 required for IPv4-mapped IPv6 hex octet parsing; convertToInt does not accept a radix
   const high = Number.parseInt(hexMatch[1], 16)
   const low = Number.parseInt(hexMatch[2], 16)
   return [high >> 8, high & 0xff, low >> 8, low & 0xff].join('.')
@@ -172,6 +173,7 @@ const expandIPv6 = (address: string): string[] | undefined => {
   if (groups.length !== 8) {
     return undefined
   }
+  // radix-16 required for IPv6 hex group normalization; convertToInt does not accept a radix
   return groups.every(isIPv6Group)
     ? groups.map(group => Number.parseInt(group, 16).toString(16))
     : undefined

--- a/src/utils/Configuration.ts
+++ b/src/utils/Configuration.ts
@@ -90,9 +90,7 @@ const defaultWorkerConfiguration: WorkerConfiguration = {
   startDelay: DEFAULT_WORKER_START_DELAY_MS,
 }
 
-const defaultPersistState = true
-
-export const DEFAULT_PERSIST_STATE = defaultPersistState
+export const DEFAULT_PERSIST_STATE = true as const
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class Configuration {
@@ -195,7 +193,7 @@ export class Configuration {
   }
 
   public static getPersistState (): boolean {
-    return Configuration.getConfigurationData()?.persistState ?? defaultPersistState
+    return Configuration.getConfigurationData()?.persistState ?? DEFAULT_PERSIST_STATE
   }
 
   public static getStationTemplateUrls (): StationTemplateUrl[] | undefined {

--- a/src/utils/ConfigurationValidation.ts
+++ b/src/utils/ConfigurationValidation.ts
@@ -14,7 +14,7 @@ import {
 } from './ConfigurationMigrations.js'
 import { ConfigurationSchema } from './ConfigurationSchema.js'
 import { configurationLogPrefix } from './ConfigurationUtils.js'
-import { assertIsJsonObject, clone, isEmpty } from './Utils.js'
+import { assertIsJsonObject, clone, isEmpty, isNotEmptyArray } from './Utils.js'
 
 const moduleName = 'ConfigurationValidation'
 
@@ -121,7 +121,7 @@ export const validateConfiguration = (parsed: unknown, filePath: string): Config
       )}`
     )
   }
-  if (remapErrors.length > 0) {
+  if (isNotEmptyArray(remapErrors)) {
     throw new ConfigurationValidationError(remapErrors, {
       filePath,
       migratedFrom,

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -44,6 +44,8 @@ export class Constants {
 
   static readonly DEFAULT_EV_CONNECTION_TIMEOUT_SECONDS = 180
 
+  static readonly DEFAULT_EXPONENTIAL_BACKOFF_BASE_DELAY_MS = 100
+
   static readonly DEFAULT_FLUCTUATION_PERCENT = 5
 
   static readonly DEFAULT_HASH_ALGORITHM = 'sha384'
@@ -62,7 +64,6 @@ export class Constants {
 
   static readonly DEFAULT_PERFORMANCE_RECORDS_DB_NAME = 'e-mobility-charging-stations-simulator'
   static readonly DEFAULT_PERFORMANCE_RECORDS_FILENAME = 'performanceRecords.json'
-  static readonly DEFAULT_RECONNECT_BASE_DELAY_MS = 100
   static readonly DEFAULT_STATION_INFO: Readonly<Partial<ChargingStationInfo>> = Object.freeze({
     automaticTransactionGeneratorPersistentConfiguration: true,
     autoReconnectMaxRetries: -1,

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -62,6 +62,7 @@ export class Constants {
 
   static readonly DEFAULT_PERFORMANCE_RECORDS_DB_NAME = 'e-mobility-charging-stations-simulator'
   static readonly DEFAULT_PERFORMANCE_RECORDS_FILENAME = 'performanceRecords.json'
+  static readonly DEFAULT_RECONNECT_BASE_DELAY_MS = 100
   static readonly DEFAULT_STATION_INFO: Readonly<Partial<ChargingStationInfo>> = Object.freeze({
     automaticTransactionGeneratorPersistentConfiguration: true,
     autoReconnectMaxRetries: -1,

--- a/tests/charging-station/helpers/TemplateFixtures.ts
+++ b/tests/charging-station/helpers/TemplateFixtures.ts
@@ -2,7 +2,7 @@
  * @file Shared template fixtures for schema/migration/validation tests.
  */
 
-import { CURRENT_SCHEMA_VERSION } from '../../../src/charging-station/TemplateMigrations.js'
+import { CURRENT_SCHEMA_VERSION } from '../../../src/charging-station/index.js'
 import {
   TEST_CHARGE_POINT_MODEL,
   TEST_CHARGE_POINT_VENDOR,

--- a/tests/charging-station/ocpp/2.0/OCPP20CertSigningRetryManager.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20CertSigningRetryManager.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, it, mock } from 'node:test'
 
 import type { ChargingStation } from '../../../../src/charging-station/index.js'
 
-import { buildConfigKey } from '../../../../src/charging-station/ConfigurationKeyUtils.js'
+import { buildConfigKey } from '../../../../src/charging-station/index.js'
 import { OCPP20CertSigningRetryManager } from '../../../../src/charging-station/ocpp/2.0/OCPP20CertSigningRetryManager.js'
 import { OCPP20VariableManager } from '../../../../src/charging-station/ocpp/2.0/OCPP20VariableManager.js'
 import {

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-GetBaseReport.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-GetBaseReport.test.ts
@@ -12,7 +12,7 @@ import {
   addConfigurationKey,
   buildConfigKey,
   setConfigurationKeyValue,
-} from '../../../../src/charging-station/ConfigurationKeyUtils.js'
+} from '../../../../src/charging-station/index.js'
 import { createTestableIncomingRequestService } from '../../../../src/charging-station/ocpp/2.0/__testable__/index.js'
 import { OCPP20IncomingRequestService } from '../../../../src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.js'
 import { OCPP20VariableManager } from '../../../../src/charging-station/ocpp/2.0/OCPP20VariableManager.js'

--- a/tests/charging-station/ocpp/2.0/OCPP20ServiceUtils-TransactionEvent.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20ServiceUtils-TransactionEvent.test.ts
@@ -14,10 +14,9 @@ import assert from 'node:assert/strict'
 import { afterEach, beforeEach, describe, it, mock } from 'node:test'
 
 import type { ChargingStation } from '../../../../src/charging-station/index.js'
-import type { ConnectorStatus } from '../../../../src/types/ConnectorStatus.js'
-import type { EmptyObject } from '../../../../src/types/index.js'
+import type { ConnectorStatus, EmptyObject } from '../../../../src/types/index.js'
 
-import { addConfigurationKey } from '../../../../src/charging-station/ConfigurationKeyUtils.js'
+import { addConfigurationKey } from '../../../../src/charging-station/index.js'
 import {
   buildTransactionEvent,
   OCPP20ServiceUtils,

--- a/tests/charging-station/ocpp/2.0/OCPP20VariableManager.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20VariableManager.test.ts
@@ -13,7 +13,7 @@ import {
   buildConfigKey,
   deleteConfigurationKey,
   getConfigurationKey,
-} from '../../../../src/charging-station/ConfigurationKeyUtils.js'
+} from '../../../../src/charging-station/index.js'
 import { createTestableVariableManager } from '../../../../src/charging-station/ocpp/2.0/__testable__/index.js'
 import { OCPP20VariableManager } from '../../../../src/charging-station/ocpp/2.0/OCPP20VariableManager.js'
 import { VARIABLE_REGISTRY } from '../../../../src/charging-station/ocpp/2.0/OCPP20VariableRegistry.js'

--- a/tests/charging-station/ui-server/UIMCPServer.integration.test.ts
+++ b/tests/charging-station/ui-server/UIMCPServer.integration.test.ts
@@ -15,7 +15,7 @@ import { afterEach, beforeEach, describe, it } from 'node:test'
 import { UIMCPServer } from '../../../src/charging-station/ui-server/UIMCPServer.js'
 import { HttpMethod } from '../../../src/charging-station/ui-server/UIServerUtils.js'
 import { ApplicationProtocol, ConfigurationSection } from '../../../src/types/index.js'
-import { Configuration } from '../../../src/utils/Configuration.js'
+import { Configuration } from '../../../src/utils/index.js'
 import { standardCleanup } from '../../helpers/TestLifecycleHelpers.js'
 import { createMockBootstrap, createMockUIServerConfiguration } from './UIServerTestUtils.js'
 

--- a/tests/charging-station/ui-server/UIMCPServer.test.ts
+++ b/tests/charging-station/ui-server/UIMCPServer.test.ts
@@ -38,7 +38,7 @@ import {
   ProcedureName,
   ResponseStatus,
 } from '../../../src/types/index.js'
-import { logger } from '../../../src/utils/Logger.js'
+import { logger } from '../../../src/utils/index.js'
 import {
   createLoggerMocks,
   standardCleanup,

--- a/tests/charging-station/ui-server/UIWebSocketServer.test.ts
+++ b/tests/charging-station/ui-server/UIWebSocketServer.test.ts
@@ -25,7 +25,7 @@ import {
   ProcedureName,
   ResponseStatus,
 } from '../../../src/types/index.js'
-import { logger } from '../../../src/utils/Logger.js'
+import { logger } from '../../../src/utils/index.js'
 import { createLoggerMocks, standardCleanup } from '../../helpers/TestLifecycleHelpers.js'
 import { TEST_UUID } from './UIServerTestConstants.js'
 import {

--- a/tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts
+++ b/tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts
@@ -16,7 +16,7 @@ import {
   ResponseStatus,
   UIRequestOrigin,
 } from '../../../../src/types/index.js'
-import { logger } from '../../../../src/utils/Logger.js'
+import { logger } from '../../../../src/utils/index.js'
 import { standardCleanup } from '../../../helpers/TestLifecycleHelpers.js'
 import { TEST_HASH_ID, TEST_UUID } from '../UIServerTestConstants.js'
 import {

--- a/ui/common/tests/WebSocketClient.test.ts
+++ b/ui/common/tests/WebSocketClient.test.ts
@@ -7,6 +7,7 @@ import type { WebSocketFactory } from '../src/client/types.js'
 import type { ResponsePayload } from '../src/types/UIProtocol.js'
 
 import { ServerFailureError, WebSocketClient } from '../src/client/WebSocketClient.js'
+import { DEFAULT_HOST, DEFAULT_PORT } from '../src/constants.js'
 import {
   AuthenticationType,
   ProcedureName,
@@ -21,8 +22,8 @@ await describe('WebSocketClient', async () => {
     const mockWs = createMockWebSocketLike()
     const factory: WebSocketFactory = () => mockWs
     const client = new WebSocketClient(factory, {
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: Protocol.UI,
       version: ProtocolVersion['0.0.1'],
     })
@@ -45,8 +46,8 @@ await describe('WebSocketClient', async () => {
         type: AuthenticationType.PROTOCOL_BASIC_AUTH,
         username: 'admin',
       },
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: Protocol.UI,
       version: ProtocolVersion['0.0.1'],
     })
@@ -62,8 +63,8 @@ await describe('WebSocketClient', async () => {
     const mockWs = createMockWebSocketLike()
     const factory: WebSocketFactory = () => mockWs
     const client = new WebSocketClient(factory, {
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: Protocol.UI,
       version: ProtocolVersion['0.0.1'],
     })
@@ -90,8 +91,8 @@ await describe('WebSocketClient', async () => {
     const mockWs = createMockWebSocketLike()
     const factory: WebSocketFactory = () => mockWs
     const client = new WebSocketClient(factory, {
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: Protocol.UI,
       version: ProtocolVersion['0.0.1'],
     })
@@ -120,8 +121,8 @@ await describe('WebSocketClient', async () => {
     const mockWs = createMockWebSocketLike()
     const factory: WebSocketFactory = () => mockWs
     const client = new WebSocketClient(factory, {
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: Protocol.UI,
       version: ProtocolVersion['0.0.1'],
     })
@@ -164,8 +165,8 @@ await describe('WebSocketClient', async () => {
     const mockWs = createMockWebSocketLike()
     const factory: WebSocketFactory = () => mockWs
     const client = new WebSocketClient(factory, {
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: Protocol.UI,
       version: ProtocolVersion['0.0.1'],
     })
@@ -183,8 +184,8 @@ await describe('WebSocketClient', async () => {
     const mockWs = createMockWebSocketLike()
     const factory: WebSocketFactory = () => mockWs
     const client = new WebSocketClient(factory, {
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: Protocol.UI,
       version: ProtocolVersion['0.0.1'],
     })
@@ -203,8 +204,8 @@ await describe('WebSocketClient', async () => {
     const mockWs = createMockWebSocketLike()
     const factory: WebSocketFactory = () => mockWs
     const client = new WebSocketClient(factory, {
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: Protocol.UI,
       version: ProtocolVersion['0.0.1'],
     })
@@ -245,8 +246,8 @@ await describe('WebSocketClient', async () => {
     const mockWs = createMockWebSocketLike()
     const factory: WebSocketFactory = () => mockWs
     const client = new WebSocketClient(factory, {
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: Protocol.UI,
       version: ProtocolVersion['0.0.1'],
     })
@@ -264,8 +265,8 @@ await describe('WebSocketClient', async () => {
     const mockWs = createMockWebSocketLike()
     const factory: WebSocketFactory = () => mockWs
     const client = new WebSocketClient(factory, {
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: Protocol.UI,
       version: ProtocolVersion['0.0.1'],
     })
@@ -286,8 +287,8 @@ await describe('WebSocketClient', async () => {
     const mockWs = createMockWebSocketLike()
     const factory: WebSocketFactory = () => mockWs
     const client = new WebSocketClient(factory, {
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: Protocol.UI,
       version: ProtocolVersion['0.0.1'],
     })
@@ -306,8 +307,8 @@ await describe('WebSocketClient', async () => {
     const mockWs = createMockWebSocketLike()
     const factory: WebSocketFactory = () => mockWs
     const client = new WebSocketClient(factory, {
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: Protocol.UI,
       version: ProtocolVersion['0.0.1'],
     })
@@ -340,8 +341,8 @@ await describe('WebSocketClient', async () => {
     const client = new WebSocketClient(
       () => mockWs,
       {
-        host: 'localhost',
-        port: 8080,
+        host: DEFAULT_HOST,
+        port: DEFAULT_PORT,
         protocol: Protocol.UI,
         version: ProtocolVersion['0.0.1'],
       },
@@ -369,8 +370,8 @@ await describe('WebSocketClient', async () => {
     const client = new WebSocketClient(
       () => mockWs,
       {
-        host: 'localhost',
-        port: 8080,
+        host: DEFAULT_HOST,
+        port: DEFAULT_PORT,
         protocol: Protocol.UI,
         version: ProtocolVersion['0.0.1'],
       },
@@ -397,8 +398,8 @@ await describe('WebSocketClient', async () => {
     const mockWs = createMockWebSocketLike()
     const factory: WebSocketFactory = () => mockWs
     const client = new WebSocketClient(factory, {
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: Protocol.UI,
       version: ProtocolVersion['0.0.1'],
     })
@@ -421,8 +422,8 @@ await describe('WebSocketClient', async () => {
     const mockWs = createMockWebSocketLike()
     const factory: WebSocketFactory = () => mockWs
     const client = new WebSocketClient(factory, {
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: Protocol.UI,
       version: ProtocolVersion['0.0.1'],
     })
@@ -445,8 +446,8 @@ await describe('WebSocketClient', async () => {
     const mockWs = createMockWebSocketLike()
     const factory: WebSocketFactory = () => mockWs
     const client = new WebSocketClient(factory, {
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: Protocol.UI,
       version: ProtocolVersion['0.0.1'],
     })
@@ -469,7 +470,12 @@ await describe('WebSocketClient', async () => {
     const mockWs = createMockWebSocketLike()
     const client = new WebSocketClient(
       () => mockWs,
-      { host: 'localhost', port: 8080, protocol: Protocol.UI, version: ProtocolVersion['0.0.1'] },
+      {
+        host: DEFAULT_HOST,
+        port: DEFAULT_PORT,
+        protocol: Protocol.UI,
+        version: ProtocolVersion['0.0.1'],
+      },
       undefined,
       notification => {
         notifications.push(notification)
@@ -492,7 +498,12 @@ await describe('WebSocketClient', async () => {
     const factory: WebSocketFactory = () => mockWs
     const client = new WebSocketClient(
       factory,
-      { host: 'localhost', port: 8080, protocol: Protocol.UI, version: ProtocolVersion['0.0.1'] },
+      {
+        host: DEFAULT_HOST,
+        port: DEFAULT_PORT,
+        protocol: Protocol.UI,
+        version: ProtocolVersion['0.0.1'],
+      },
       undefined,
       notification => {
         notifications.push(notification)
@@ -514,8 +525,8 @@ await describe('WebSocketClient', async () => {
   await it('should NOT fire onNotification when callback is undefined', async () => {
     const mockWs = createMockWebSocketLike()
     const client = new WebSocketClient(() => mockWs, {
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: Protocol.UI,
       version: ProtocolVersion['0.0.1'],
     })

--- a/ui/common/tests/config.test.ts
+++ b/ui/common/tests/config.test.ts
@@ -2,12 +2,13 @@ import assert from 'node:assert'
 import { describe, it } from 'node:test'
 
 import { configurationSchema, uiServerConfigSchema } from '../src/config/schema.js'
+import { DEFAULT_HOST, DEFAULT_PORT } from '../src/constants.js'
 
 await describe('config schema validation', async () => {
   await it('should validate a minimal valid config', () => {
     const result = uiServerConfigSchema.safeParse({
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: 'ui',
       version: '0.0.1',
     })
@@ -16,8 +17,8 @@ await describe('config schema validation', async () => {
 
   await it('should reject config with empty protocol', () => {
     const result = uiServerConfigSchema.safeParse({
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: '',
       version: '0.0.1',
     })
@@ -26,8 +27,8 @@ await describe('config schema validation', async () => {
 
   await it('should reject config with protocol not in Protocol enum', () => {
     const result = uiServerConfigSchema.safeParse({
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: 'ws',
       version: '0.0.1',
     })
@@ -36,8 +37,8 @@ await describe('config schema validation', async () => {
 
   await it('should reject config with version not in ProtocolVersion enum', () => {
     const result = uiServerConfigSchema.safeParse({
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: 'ui',
       version: '2.0',
     })
@@ -46,7 +47,7 @@ await describe('config schema validation', async () => {
 
   await it('should reject missing required host field', () => {
     const result = uiServerConfigSchema.safeParse({
-      port: 8080,
+      port: DEFAULT_PORT,
       protocol: 'ui',
       version: '0.0.1',
     })
@@ -55,7 +56,7 @@ await describe('config schema validation', async () => {
 
   await it('should reject invalid port number', () => {
     const result = uiServerConfigSchema.safeParse({
-      host: 'localhost',
+      host: DEFAULT_HOST,
       port: 99999,
     })
     assert.strictEqual(result.success, false)
@@ -64,7 +65,7 @@ await describe('config schema validation', async () => {
   await it('should reject empty host string', () => {
     const result = uiServerConfigSchema.safeParse({
       host: '',
-      port: 8080,
+      port: DEFAULT_PORT,
       protocol: 'ui',
       version: '0.0.1',
     })
@@ -81,7 +82,7 @@ await describe('config schema validation', async () => {
       },
       host: 'simulator.example.com',
       name: 'My Simulator',
-      port: 8080,
+      port: DEFAULT_PORT,
       protocol: 'ui',
       secure: true,
       version: '0.0.1',
@@ -92,8 +93,8 @@ await describe('config schema validation', async () => {
   await it('should validate configuration with array of servers', () => {
     const result = configurationSchema.safeParse({
       uiServer: [
-        { host: 'server1.example.com', port: 8080, protocol: 'ui', version: '0.0.1' },
-        { host: 'server2.example.com', port: 8080, protocol: 'ui', version: '0.0.1' },
+        { host: 'server1.example.com', port: DEFAULT_PORT, protocol: 'ui', version: '0.0.1' },
+        { host: 'server2.example.com', port: DEFAULT_PORT, protocol: 'ui', version: '0.0.1' },
       ],
     })
     assert.strictEqual(result.success, true)
@@ -101,7 +102,7 @@ await describe('config schema validation', async () => {
 
   await it('should validate configuration with single server', () => {
     const result = configurationSchema.safeParse({
-      uiServer: { host: 'localhost', port: 8080, protocol: 'ui', version: '0.0.1' },
+      uiServer: { host: DEFAULT_HOST, port: DEFAULT_PORT, protocol: 'ui', version: '0.0.1' },
     })
     assert.strictEqual(result.success, true)
   })
@@ -112,8 +113,8 @@ await describe('config schema validation', async () => {
         enabled: true,
         type: 'protocol-basic-auth',
       },
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: 'ui',
       version: '0.0.1',
     })
@@ -137,8 +138,8 @@ await describe('config schema validation', async () => {
         type: 'protocol-basic-auth',
         username: '',
       },
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: 'ui',
       version: '0.0.1',
     })
@@ -158,8 +159,8 @@ await describe('config schema validation', async () => {
         type: 'protocol-basic-auth',
         username: 'admin',
       },
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: 'ui',
       version: '0.0.1',
     })
@@ -179,8 +180,8 @@ await describe('config schema validation', async () => {
         type: 'protocol-basic-auth',
         username: 'a:b',
       },
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: 'ui',
       version: '0.0.1',
     })
@@ -202,8 +203,8 @@ await describe('config schema validation', async () => {
         password: 'admin',
         type: 'protocol-basic-auth',
       },
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: 'ui',
       version: '0.0.1',
     })
@@ -222,8 +223,8 @@ await describe('config schema validation', async () => {
         type: 'protocol-basic-auth',
         username: 'admin',
       },
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: 'ui',
       version: '0.0.1',
     })
@@ -243,8 +244,8 @@ await describe('config schema validation', async () => {
         type: 'protocol-basic-auth',
         username: 'admin',
       },
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: 'ui',
       version: '0.0.1',
     })
@@ -257,8 +258,8 @@ await describe('config schema validation', async () => {
         enabled: false,
         type: 'protocol-basic-auth',
       },
-      host: 'localhost',
-      port: 8080,
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
       protocol: 'ui',
       version: '0.0.1',
     })

--- a/ui/web/vitest.config.ts
+++ b/ui/web/vitest.config.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from 'node:url'
 import { mergeConfig } from 'vite'
 import { configDefaults, defineConfig } from 'vitest/config'
 
-import viteConfig from './vite.config'
+import viteConfig from './vite.config.js'
 
 const nodeMajor = Number.parseInt(process.versions.node.split('.')[0], 10)
 


### PR DESCRIPTION
## Summary

Convention alignment across `src/`, `ui/common/tests/`, `ui/web/`, and root tests. 9 atomic commits, 28 files, +140/-113 lines. Zero behavior changes.

## Commits (rebase-merge preserves atomicity)

| Commit | Content |
|---|---|
| `refactor: adopt isEmpty() helper for emptiness checks` | 9 sites (strings, arrays, Maps) |
| `refactor: adopt Constants.UNIT_DIVIDER_KILO for kW→W conversion` | 4 sites |
| `refactor(ui-server): use JSONStringify for unknown MCP tool payload` | 1 site (Map/Set-bearing `unknown`) |
| `refactor: promote inline literals to named constants` | 5 constants (`as const` narrowing) |
| `refactor(ui-web): add .js extension to relative import in vitest.config` | 1 line (last missing `.js` in the codebase) |
| `docs: document Number.parseInt/parseFloat convention exceptions` | 3 anti-regression anchors (4 call sites) |
| `refactor(ui-common/tests): use DEFAULT_HOST/DEFAULT_PORT constants` | 72 test literals |
| `refactor(tests): use component barrels instead of deep imports` | 10 test imports |
| `refactor: apply post-review polish` | 4 findings: coverage gap + naming coherence + spec-anchor + qualifier restore |

## Findings resolved (by axis)

- **Helper adoption** — 9 `isEmpty()` + 1 `isNotEmptyArray()` + 1 `JSONStringify`. Uniform application of the utility usage rules in AGENTS.md.
- **Constants factorization** — 4 sites migrated to `Constants.UNIT_DIVIDER_KILO`; 5 module-scope constants promoted with SCREAMING_SNAKE_CASE + unit suffixes + `as const` literal-type narrowing (`DEFAULT_PERSIST_STATE`, `DEFAULT_EXPONENTIAL_BACKOFF_BASE_DELAY_MS`, `DEFAULT_AUTH_CACHE_TTL_SECONDS` reuse, `MAX_ITEMS_PER_REPORT_MESSAGE`, `AVG_ENTRY_SIZE_BYTES`).
- **Convention exception documentation** — 3 inline anti-regression anchors at `Number.parseInt`/`parseFloat` sites where `convertToInt`/`convertToFloat` cannot substitute (radix-16 hex parsing × 2, NaN sentinel for POSITIVE_INFINITY fallback × 1). Mirrors the existing `Number()` preservation anchor at `OCPP16IncomingRequestService.ts:273`.
- **Test-side convention** — 72 hardcoded `'localhost'`/`8080` literals in `ui/common/tests/` replaced with `DEFAULT_HOST`/`DEFAULT_PORT` from `ui/common/src/constants.ts`. 10 test deep-imports routed through component barrels. 1 missing `.js` extension corrected.

Details per commit in the respective commit bodies.

## Scope fence

Deferred to separate PRs:
- **Helpers reorganization**: relocate `getMessageTypeString`/`getWebSocketCloseEventStatusString` out of `Utils.ts`; rename `Helpers*.ts` → `*Helpers.ts` (domain-first); move `getConfiguredMaxNumberOfConnectors`/`hasFeatureProfile`/`getPhaseRotationValue` to their domain-specific modules.
- **`moduleName` mass rename**: 55 files, camelCase → SCREAMING_SNAKE_CASE.
- **Barrel gap fills**: `ocpp/index.js` and `performance/index.js` to eliminate ~150 unavoidable test deep-imports; lift `updateAuthorizationCache` common core to `OCPPServiceUtils.ts`; extract `applyBootNotificationResponse` prelude.
- **Branded numeric types**: `Milliseconds`/`Seconds`/`Bytes` template-literal brands (mirrors the existing `UUIDv4` pattern) to make unit-mismatch bugs compile-time errors.

None of these are touched here.

## Quality gates

| Package | typecheck | lint | tests |
|---|---|---|---|
| root (simulator) | pass | pass | 2954/2960 (6 skipped, unrelated to this PR) |
| `ui-common` | pass | pass | 120/120 |
| `ui-cli` | pass | pass | 152/152 |
| `ui-web` | pass | pass | 532/532 |

## Regressions

None. Each commit is a semantic-preserving substitution or comment-only addition. `git diff main..HEAD` adds:
- 0 new `.length === 0` / `.size !== 0` violations
- 0 new raw `JSON.stringify(unknown)` calls
- 0 new unguarded `Number.parseInt`/`parseFloat` calls
- 0 new type assertions (`as any`, `@ts-ignore`, etc.)

The 6 skipped tests in the root package are pre-existing (unrelated to any file changed by this PR).

## Merge recommendation

**Rebase-merge** to preserve atomic history — each commit is a self-contained review unit at a distinct convention axis.


