### PR TITLE
fix(utils): clamp computeExponentialBackOffDelay output to setTimeout-safe range

### DIFF
--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -418,14 +418,15 @@ export const insertAt = (str: string, subStr: string, pos: number): string =>
   `${str.slice(0, pos)}${subStr}${str.slice(pos)}`
 
 /**
- * Generalized exponential back-off: baseDelayMs × 2^min(retryNumber, maxRetries) + jitter.
+ * Generalized exponential back-off: baseDelayMs × 2^min(retryNumber, maxRetries) + jitter,
+ * clamped to [0, Constants.MAX_SETINTERVAL_DELAY_MS] for setTimeout/setInterval safety.
  * @param options - back-off configuration
  * @param options.baseDelayMs - base delay in milliseconds
  * @param options.retryNumber - current retry attempt (0-based)
  * @param options.maxRetries - stop doubling after this many retries (default: unlimited)
  * @param options.jitterMs - maximum fixed random jitter in milliseconds (default: 0)
  * @param options.jitterPercent - proportional jitter as fraction of computed delay, e.g. 0.2 = 20% (default: 0)
- * @returns delay in milliseconds
+ * @returns delay in milliseconds, guaranteed within [0, Constants.MAX_SETINTERVAL_DELAY_MS]
  */
 export const computeExponentialBackOffDelay = (options: {
   baseDelayMs: number
@@ -443,7 +444,7 @@ export const computeExponentialBackOffDelay = (options: {
   } else if (jitterMs != null && jitterMs > 0) {
     jitter = secureRandom() * jitterMs
   }
-  return delay + jitter
+  return clampToSafeTimerValue(delay + jitter)
 }
 
 /**

--- a/tests/utils/Utils.test.ts
+++ b/tests/utils/Utils.test.ts
@@ -706,6 +706,36 @@ await describe('Utils', async () => {
       const maxDelay = computeExponentialBackOffDelay({ baseDelayMs, retryNumber: 10 })
       assert.strictEqual(maxDelay, 102400) // ~102 seconds
     })
+
+    await it('should clamp overflowing delays to MAX_SETINTERVAL_DELAY_MS', () => {
+      // At retry 25 with base 100ms: 100 * 2^25 = 3_355_443_200 ms > MAX_SETINTERVAL_DELAY_MS
+      // Without clamping, setTimeout would silently coerce to 1 ms (Node.js docs), producing
+      // a tight-loop reconnect storm instead of the intended exponential backoff.
+      const overflowDelay = computeExponentialBackOffDelay({
+        baseDelayMs: 100,
+        retryNumber: 25,
+      })
+      assert.strictEqual(overflowDelay, Constants.MAX_SETINTERVAL_DELAY_MS)
+
+      const extremeDelay = computeExponentialBackOffDelay({
+        baseDelayMs: 100,
+        retryNumber: 30,
+      })
+      assert.strictEqual(extremeDelay, Constants.MAX_SETINTERVAL_DELAY_MS)
+
+      // Clamping applies AFTER jitter is added — jitter cannot push past the safe ceiling.
+      // At retry 25 with base 100ms, `delay = 100 * 2^25 = 3.35e9` already exceeds the ceiling
+      // before jitter, so every iteration pins exactly to MAX_SETINTERVAL_DELAY_MS regardless
+      // of the random draw.
+      for (let i = 0; i < 20; i++) {
+        const jitteredDelay = computeExponentialBackOffDelay({
+          baseDelayMs: 100,
+          jitterPercent: 0.2,
+          retryNumber: 25,
+        })
+        assert.strictEqual(jitteredDelay, Constants.MAX_SETINTERVAL_DELAY_MS)
+      }
+    })
   })
 
   await it('should return timestamped log prefix with optional string', () => {


### PR DESCRIPTION
## Summary

Fix a latent overflow bug in `computeExponentialBackOffDelay` that turns intended exponential backoff into a tight-loop retry storm at retry ≥25 (base 100 ms) or ≥16 (base 60_000 ms).

## The bug

`computeExponentialBackOffDelay` returned `baseDelayMs * 2^retry + jitter` **unclamped**. The overflow retry number depends on the base delay used at each site:

| baseDelayMs | Overflow at retry ≥ | Formula |
|---|---|---|
| 100 ms (`Constants.DEFAULT_EXPONENTIAL_BACKOFF_BASE_DELAY_MS`) | **25** | `100 * 2^25 = 3.35e9 ms > 2.15e9 ms` |
| 60_000 ms (`Constants.DEFAULT_BOOT_NOTIFICATION_INTERVAL_MS`) | **16** | `60_000 * 2^16 = 3.93e9 ms > 2.15e9 ms` |

The ceiling is `MAX_SETINTERVAL_DELAY_MS = 2_147_483_647 ms` (~24.8 days).

Downstream, all 5 call sites feed the result into `sleep()` / `setTimeout`, which per [Node.js `timers` docs](https://nodejs.org/api/timers.html#settimeoutcallback-delay-args) **silently coerces out-of-range delays to `1 ms`**:

> When delay is larger than 2147483647 or less than 1, the delay will be set to 1.

Result: the retry becomes immediate → tight-loop reconnect/retry storm instead of the intended exponential wait.

## Vulnerability surface — 5 call sites

| # | Site | Base delay | Retry driver | Overflow at retry ≥ | Vulnerable |
|---|---|---|---|---|---|
| 1 | `ChargingStation.ts:1608` `getReconnectDelay` | 100 ms | `wsConnectionRetryCount` unbounded when `autoReconnectMaxRetries = -1` (documented default) | 25 | ✅ |
| 2 | `ChargingStation.ts:2532` `onOpen` BootNotification retry | CSMS-provided `interval` or 60_000 ms fallback | `registrationRetryCount` unbounded when `registrationMaxRetries = -1` (documented default) | 16 (default) | ✅ |
| 3 | `ChargingStation.ts:2788` `sendMessageBuffer` recursion | 100 ms | `messageIdx` grows unbounded, no `maxRetries` cap | 25 | ✅ |
| 4 | `OCPP20ServiceUtils.ts:253` `computeReconnectDelay` (OCPP 2.0.1 §5.3 RetryBackOff) | 30_000 ms | `maxRetries: RetryBackOffRepeatTimes` (spec-defined, fallback 5) | never (worst: 960_000 ms) | ⚠️ safe by construction |
| 5 | `OCPP20CertSigningRetryManager.ts:96` `scheduleNextRetry` | `CertSigningWaitMinimum` (spec-defined) | `maxRetries: CertSigningRepeatTimes` (spec-defined) | never (bounded by OCPP variable) | ⚠️ safe by construction |

Both `autoReconnectMaxRetries = -1` and `registrationMaxRetries = -1` are the **documented defaults** per [README](../blob/main/README.md#charging-station-template-configuration).

## Fix

Wrap the return value with `clampToSafeTimerValue()` inside `computeExponentialBackOffDelay`. The function's documented contract is "delay in milliseconds" for timer scheduling — clamping to the setTimeout-safe range preserves that contract and catches all present and future callers via a single site (DRY over 5 wrap-at-site edits).

```diff
-  return delay + jitter
+  return clampToSafeTimerValue(delay + jitter)
```

The JSDoc is extended to advertise the clamp guarantee explicitly:

```diff
- * Generalized exponential back-off: baseDelayMs × 2^min(retryNumber, maxRetries) + jitter.
+ * Generalized exponential back-off: baseDelayMs × 2^min(retryNumber, maxRetries) + jitter,
+ * clamped to [0, Constants.MAX_SETINTERVAL_DELAY_MS] for setTimeout/setInterval safety.
...
- * @returns delay in milliseconds
+ * @returns delay in milliseconds, guaranteed within [0, Constants.MAX_SETINTERVAL_DELAY_MS]
```

The two OCPP 2.0.x sites (#4, #5) remain unchanged in effect — their `maxRetries` cap already keeps the pre-clamp delay under the ceiling. The clamp is a no-op for them.

## Tests

Added a regression test in `tests/utils/Utils.test.ts` that locks the invariant:
- retry 25 with base 100 ms → clamps to `MAX_SETINTERVAL_DELAY_MS`
- retry 30 (extreme upper bound) → clamps to `MAX_SETINTERVAL_DELAY_MS`
- clamping applies **after** jitter: at retry 25 the pre-jitter delay already exceeds the ceiling, so every clamp output is *exactly* the ceiling regardless of the random draw. The 20-sample jitter loop asserts strict equality with the ceiling (deterministic, not merely `<= MAX`).

Existing tests remain valid — the highest retry number in prior tests was 10 (delay `102_400 ms`, well below the clamp threshold).

Priority-3 comment anchors preserved per AGENTS.md algorithmic/security-adjacent justification:
- Mathematical formula anchor for the overflow boundary condition (`100 * 2^25 = 3.35e9 > MAX`)
- Ordering invariant anchor for clamp-after-jitter (protects future refactors that might reorder)

## Quality gates

- `pnpm typecheck` ✓ clean
- `pnpm lint` ✓ clean
- `tests/utils/Utils.test.ts` ✓ 54/54 pass

## Context

Identified as pre-existing latent bug during the Oracle #2 audit of PR #1950 ("refactor: convention alignment"), classified as out-of-scope for that convention-alignment PR to preserve its "no behavior change" invariant. Filed as follow-up per the PR-F scope fence.

Cross-agent review v2 applied (Oracle design + Oracle math + Librarian OCPP qmd + Explore fresh) with convergent findings applied:
- 4 call sites → **5** (missed `OCPP20CertSigningRetryManager.ts:96` in v1)
- Boundary math clarified per site (retry ≥25 at base 100 ms; retry ≥16 at base 60_000 ms for BootNotification)
- JSDoc extended to advertise the clamp guarantee
- Test assertion strengthened to `strictEqual(x, MAX)` (deterministic at retry ≥25)
