### PR TITLE
refactor: close barrel gaps for ui-server, broadcast-channel, DEFAULT_PERSIST_STATE

### DIFF
--- a/src/charging-station/broadcast-channel/index.ts
+++ b/src/charging-station/broadcast-channel/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @file Broadcast channel component barrel.
+ * @description Exposes the two concrete `WorkerBroadcastChannel` subclasses used for
+ *   main-thread ↔ worker-thread OCPP message routing.
+ *
+ *   Deliberately not re-exported:
+ *   - `WorkerBroadcastChannel` — abstract base subclassed only by the two concrete
+ *     channels within this sub-component; no external extenders exist.
+ */
+export { ChargingStationWorkerBroadcastChannel } from './ChargingStationWorkerBroadcastChannel.js'
+export { UIServiceWorkerBroadcastChannel } from './UIServiceWorkerBroadcastChannel.js'

--- a/src/charging-station/ui-server/index.ts
+++ b/src/charging-station/ui-server/index.ts
@@ -1,0 +1,29 @@
+/**
+ * @file UI server component barrel.
+ * @description Exposes concrete UI server implementations (`UIMCPServer`,
+ *   `UIWebSocketServer`) selected through `UIServerFactory`, the transport-agnostic
+ *   `HttpMethod` enum, the `DEFAULT_COMPRESSION_THRESHOLD_BYTES` canonical default,
+ *   plus the `AbstractUIService` base class and its `BroadcastChannelResponseLogContext`
+ *   type which are consumed as extension points across the broadcast-channel boundary.
+ *
+ *   Deliberately not re-exported:
+ *   - `AbstractUIServer` — internal extension point subclassed only by the concrete
+ *     servers within this sub-component; no external extenders exist.
+ *   - `UIHttpServer` — `@deprecated` pending removal; re-exporting through a fresh
+ *     barrel would surface the deprecation on every consumer via
+ *     `@typescript-eslint/no-deprecated`.
+ *   - `UIServerAccessPolicy` / `UIServerNet` / `UIServerSecurity` helpers beyond
+ *     `DEFAULT_COMPRESSION_THRESHOLD_BYTES` — internal to `UIServerFactory` and
+ *     the concrete servers.
+ *   - `ui-services/UIService001` / `ui-services/UIServiceFactory` concrete
+ *     implementations — internal to `AbstractUIService`.
+ */
+export {
+  AbstractUIService,
+  type BroadcastChannelResponseLogContext,
+} from './ui-services/AbstractUIService.js'
+export { UIMCPServer } from './UIMCPServer.js'
+export { UIServerFactory } from './UIServerFactory.js'
+export { DEFAULT_COMPRESSION_THRESHOLD_BYTES } from './UIServerSecurity.js'
+export { HttpMethod } from './UIServerUtils.js'
+export { UIWebSocketServer } from './UIWebSocketServer.js'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,7 +7,7 @@ export {
   buildEvseEntries,
   buildEvsesStatus,
 } from './ChargingStationConfigurationUtils.js'
-export { Configuration } from './Configuration.js'
+export { Configuration, DEFAULT_PERSIST_STATE } from './Configuration.js'
 export {
   applyConfigurationMigration,
   coerceConfigurationVersion,


### PR DESCRIPTION
## Summary

Close 3 barrel gaps identified during the PR #1950 audit chain:
1. `src/charging-station/ui-server/` had no `index.ts` — cross-component consumers forced into deep imports
2. `src/charging-station/broadcast-channel/` had no `index.ts` — same
3. `src/utils/index.ts` didn't re-export `DEFAULT_PERSIST_STATE` (Explore F-3 finding from PR #1950 review v3)

## Convention respected

The codebase uses **flat parent barrels** (verified: `src/charging-station/ocpp/index.ts` re-exports directly from `./1.6/OCPP16ServiceUtils.js` without an intermediate `1.6/index.ts`; `src/charging-station/ocpp/auth/index.ts` re-exports from `./cache/`, `./services/`, etc. without sub-barrels; `src/performance/index.ts` re-exports from `./storage/` without a `storage/index.ts`).

This PR follows that convention: creates parent-level barrels only, no sub-barrels.

## New barrels

Both new barrels carry an `@file` JSDoc header matching the peer convention (`meter-values/index.ts`, `ocpp/auth/index.ts`) that documents **what is exposed** and — critically — **what is deliberately NOT re-exported and why**. This anchors the exposure discipline in the barrel itself so a future maintainer opening the file can see the rationale without consulting commit history.

**`src/charging-station/ui-server/index.ts`** re-exports:
- `UIMCPServer`, `UIWebSocketServer`, `UIServerFactory`
- `HttpMethod` (from `UIServerUtils`)
- `DEFAULT_COMPRESSION_THRESHOLD_BYTES` (from `UIServerSecurity`)
- `AbstractUIService` + `BroadcastChannelResponseLogContext` (from `ui-services/AbstractUIService`)

**Deliberately NOT re-exported** (documented in the `@file` header):
- `AbstractUIServer` — internal extension point subclassed only by the concrete servers within this sub-component; no external extenders exist.
- `UIHttpServer` — `@deprecated` pending removal; re-exporting via a fresh barrel would surface the deprecation on every consumer via `@typescript-eslint/no-deprecated`.
- `UIServerAccessPolicy` / `UIServerNet` / `UIServerSecurity` helpers beyond `DEFAULT_COMPRESSION_THRESHOLD_BYTES` — internal to `UIServerFactory` and the concrete servers.
- `ui-services/UIService001` / `ui-services/UIServiceFactory` concrete implementations — internal to `AbstractUIService`.

**`src/charging-station/broadcast-channel/index.ts`** re-exports:
- `ChargingStationWorkerBroadcastChannel`
- `UIServiceWorkerBroadcastChannel`

**Deliberately NOT re-exported** (documented in the `@file` header):
- `WorkerBroadcastChannel` — abstract base subclassed only by the two concrete channels within this sub-component; no external extenders exist.

## Extended barrel

**`src/utils/index.ts`** — one-line change: add `DEFAULT_PERSIST_STATE` to the `Configuration` re-export block.

Rationale: Explore F-3 finding in PR #1950 v3 review noted the constant was exported from `Configuration.ts` but not surfaced by `src/utils/index.ts`, forcing any future caller into a deep import. Zero current callers are affected — this closes the gap prospectively.

## No consumer migrations in this PR

Existing test files inside `tests/charging-station/ui-server/` and `tests/charging-station/broadcast-channel/` are **internal-component tests** — each `X.test.ts` imports from `X.ts` directly, matching the PR #1950 precedent for test-of-that-file patterns. No migration needed.

Source-to-source deep imports (5 sites: `Bootstrap.ts`, `ChargingStation.ts`, `ConfigurationSchema.ts`, `UIServiceWorkerBroadcastChannel.ts`, `AbstractUIService.ts`) are **deferred to a follow-up** (PR-D') to keep this PR focused on barrel infrastructure only. Migrating those would enlarge the blast radius and mix two concerns.

## Diff

+41 / -1 across 3 files:
- `src/charging-station/broadcast-channel/index.ts` (new, +11 with JSDoc)
- `src/charging-station/ui-server/index.ts` (new, +29 with JSDoc)
- `src/utils/index.ts` (+1/-1, extend Configuration re-export line)

## Quality gates

- `pnpm typecheck` ✓ clean
- `pnpm lint` ✓ clean (after auto-fix on `perfectionist/sort-exports`)
- Targeted tests: 577/577 pass (ui-server + broadcast-channel + Configuration suites)

## Context

Part of the follow-up PR sequence after PR #1950 ("refactor: convention alignment — helpers, constants, imports, tests") was merged. The scope-fence in that PR listed PR-D as a follow-up. This is PR-D. The remaining follow-ups are:
- PR-C: `moduleName` mass rename — **skipped** (premise invalidated: convention is 100% consistent, not divergent)
- PR-B: helpers reorganization (`src/utils/Utils.ts` decomposition)
- PR-E: branded types (`Milliseconds`, `Watts`, etc.)
- PR-D': source-to-source deep-import migration to the barrels this PR creates

Cross-agent review v2 applied (Oracle design + Oracle math + Librarian ecosystem + Explore fresh) with convergent finding **D1 (3-hit: Oracle #1 B1 + Explore B-1 + B-4)** applied: barrels now carry the peer-convention `@file` header documenting exposure discipline symmetrically for every abstract-class omission and for the deprecated omission.
