### PR TITLE
refactor: migrate external deep imports to ui-server and broadcast-channel barrels

### DIFF
--- a/src/charging-station/Bootstrap.ts
+++ b/src/charging-station/Bootstrap.ts
@@ -58,7 +58,7 @@ import {
 } from '../worker/index.js'
 import { readStateFile, reconstructTemplateIndexes, writeStateFile } from './BootstrapStateUtils.js'
 import { buildTemplateName, waitChargingStationEvents } from './Helpers.js'
-import { UIServerFactory } from './ui-server/UIServerFactory.js'
+import { UIServerFactory } from './ui-server/index.js'
 
 const moduleName = 'Bootstrap'
 

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -111,7 +111,7 @@ import {
   watchJsonFile,
 } from '../utils/index.js'
 import { AutomaticTransactionGenerator } from './AutomaticTransactionGenerator.js'
-import { ChargingStationWorkerBroadcastChannel } from './broadcast-channel/ChargingStationWorkerBroadcastChannel.js'
+import { ChargingStationWorkerBroadcastChannel } from './broadcast-channel/index.js'
 import { CoherentMeterValuesManager } from './CoherentMeterValuesManager.js'
 import {
   addConfigurationKey,


### PR DESCRIPTION
## Summary

Migrate the 2 external cross-sub-component deep imports enabled by the barrels introduced in #1952 to route through the barrel index files per the codebase's flat parent barrel convention.

## Sites migrated (2)

| # | Site | From | To |
|---|---|---|---|
| 1 | `Bootstrap.ts:61` | `./ui-server/UIServerFactory.js` | `./ui-server/index.js` |
| 2 | `ChargingStation.ts:114` | `./broadcast-channel/ChargingStationWorkerBroadcastChannel.js` | `./broadcast-channel/index.js` |

## Sites deliberately NOT migrated

The PR #1952 v3 review identified 5 candidate deep-import sites for follow-up migration. Empirical validation (typecheck + test suite) narrowed the scope to 2 safe migrations. The other 3 sites are documented here for future reference:

| Site | Symbol | Reason not migrated |
|---|---|---|
| `Bootstrap.ts:13` | `AbstractUIServer` (type) | Not re-exported from `ui-server/index.ts` — internal extension point per the barrel's `@file` header omission list |
| `ConfigurationSchema.ts:7` | `UIServerNet.isHostLiteralWithoutPort` | `UIServerNet` not re-exported — internal helper per the barrel's omission list. Candidate for a separate fix (either promote the specific helper to a public utility, or move the Zod schema validator elsewhere) |
| `AbstractUIService.ts:33` | `UIServiceWorkerBroadcastChannel` (value) | Migrating this triggers a circular-load `ReferenceError: Cannot access 'AbstractUIServer' before initialization` at test time because the `broadcast-channel` barrel re-exports both concrete channels, transitively pulling `ChargingStationWorkerBroadcastChannel`'s charging-station chain back through `ui-server` before class declarations complete. Kept as direct import. |
| `UIServiceWorkerBroadcastChannel.ts:1` | `AbstractUIService` (type-only) | Adjacent sub-component crossing. Kept as direct import for symmetry with `AbstractUIService.ts:33`. Type-only import is erased at runtime, but keeping both adjacent crossings direct matches the `meter-values/index.ts` convention. |

## Convention codified

**Barrels are for CROSS-COMPONENT external consumers, not for adjacent-sub-component crossings within the same parent module.**

- `Bootstrap.ts` (in `charging-station/` but not in `ui-server/`) → barrel ✅
- `ChargingStation.ts` (in `charging-station/` but not in `broadcast-channel/`) → barrel ✅
- `AbstractUIService.ts` in `ui-server/` crossing to `broadcast-channel/` → **direct import** (adjacent)
- `UIServiceWorkerBroadcastChannel.ts` in `broadcast-channel/` crossing to `ui-server/` → **direct import** (adjacent)

This matches the codebase convention documented in `meter-values/index.ts` `@file` header: *"Internal helpers are intentionally not re-exported; tests and internal callers should import them directly from the owning sub-module."*

## Quality gates

- `pnpm typecheck` ✓ clean
- `pnpm lint` ✓ clean
- `pnpm test` ✓ 2955/2961 pass, 0 fail (6 skipped are pre-existing)

## Diff

+2 / -2 across 2 files.

## Context

Follow-up to #1952 (barrel gaps closure). This is PR-D' from the PR sequence tracked in #1950's scope fence.

Remaining follow-ups from the session-tracked plan:
- PR-C: `moduleName` mass rename — **skipped** (premise invalidated by data)
- PR-B: `src/utils/Utils.ts` decomposition — **skipped** by user
- PR-E: branded types (`Milliseconds`, `Watts`, etc.) — needs planning
