### PR TITLE
fix(ocpp): from-zero audit — Critical + High spec conformance and safety fixes

### DIFF
--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -209,20 +209,20 @@ export class ChargingStation extends EventEmitter {
 
   private automaticTransactionGeneratorConfiguration?: AutomaticTransactionGeneratorConfiguration
   private readonly chargingStationWorkerBroadcastChannel: ChargingStationWorkerBroadcastChannel
-  private configurationFile!: string
-  private configurationFileHash!: string
+  private configurationFile: string
+  private configurationFileHash: string
   private configuredSupervisionUrl!: URL
   private readonly connectors: Map<number, ConnectorStatus>
-  private connectorsConfigurationHash!: string
+  private connectorsConfigurationHash: string
   private readonly evses: Map<number, EvseStatus>
-  private evsesConfigurationHash!: string
+  private evsesConfigurationHash: string
   private flushingMessageBuffer: boolean
   private flushMessageBufferSetInterval?: NodeJS.Timeout
   private readonly messageQueue: string[]
   private ocppIncomingRequestService!: OCPPIncomingRequestService
   private readonly sharedLRUCache: SharedLRUCache
   private stopping: boolean
-  private templateFileHash!: string
+  private templateFileHash: string
   private templateFileWatcher?: FSWatcher
   private wsConnectionRetryCount: number
   private wsPingSetInterval?: NodeJS.Timeout
@@ -244,6 +244,11 @@ export class ChargingStation extends EventEmitter {
     this.sharedLRUCache = SharedLRUCache.getInstance()
     this.idTagsCache = IdTagsCache.getInstance()
     this.chargingStationWorkerBroadcastChannel = new ChargingStationWorkerBroadcastChannel(this)
+    this.configurationFile = ''
+    this.configurationFileHash = ''
+    this.connectorsConfigurationHash = ''
+    this.evsesConfigurationHash = ''
+    this.templateFileHash = ''
 
     this.on(ChargingStationEvents.added, () => {
       parentPort?.postMessage(buildAddedMessage(this))

--- a/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
@@ -597,7 +597,7 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService {
                 error
               )
             })
-          }, retrieveDate.getTime() - now)
+          }, retrieveDate.getTime() - now).unref()
         }
       }
     )

--- a/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
@@ -1301,10 +1301,14 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService {
         connectorId <= chargingStation.getNumberOfConnectors();
         connectorId++
       ) {
+        const connectorStatus = chargingStation.getConnectorStatus(connectorId)
+        const isReservedForOther =
+          connectorStatus?.status === OCPP16ChargePointStatus.Reserved &&
+          !OCPP16ServiceUtils.hasReservation(chargingStation, connectorId, commandPayload.idTag)
         if (
           chargingStation.isConnectorAvailable(connectorId) &&
-          chargingStation.getConnectorStatus(connectorId)?.transactionStarted === false &&
-          !OCPP16ServiceUtils.hasReservation(chargingStation, connectorId, commandPayload.idTag)
+          connectorStatus?.transactionStarted === false &&
+          !isReservedForOther
         ) {
           commandPayload.connectorId = connectorId
           break

--- a/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
@@ -590,6 +590,8 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService {
             )
           })
         } else {
+          // Unref: fire-and-forget deferred firmware update must not
+          // block node.js exit.
           setTimeout(() => {
             this.updateFirmwareSimulation(chargingStation).catch((error: unknown) => {
               logger.error(

--- a/src/charging-station/ocpp/1.6/OCPP16ServiceUtils.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16ServiceUtils.ts
@@ -949,6 +949,13 @@ export class OCPP16ServiceUtils {
     connectorId: number,
     reason?: StopTransactionReason
   ): Promise<StopTransactionResponse> {
+    const connectorStatus = chargingStation.getConnectorStatus(connectorId)
+    if (connectorStatus?.status !== OCPP16ChargePointStatus.Finishing) {
+      await sendAndSetConnectorStatus(chargingStation, {
+        connectorId,
+        status: OCPP16ChargePointStatus.Finishing,
+      } as OCPP16StatusNotificationRequest)
+    }
     const rawTransactionId = chargingStation.getConnectorStatus(connectorId)?.transactionId
     const transactionId = rawTransactionId != null ? convertToInt(rawTransactionId) : undefined
     if (

--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -3337,7 +3337,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
             `${chargingStation.logPrefix()} ${moduleName}.scheduleEvseReset: EVSE ${evseId.toString()} reset completed`
           )
         }
-      }, OCPP20Constants.RESET_DELAY_MS)
+      }, OCPP20Constants.RESET_DELAY_MS).unref()
     })
   }
 
@@ -3613,7 +3613,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
           stationState.isDrainingSecurityEvents = false
           setTimeout(() => {
             this.sendQueuedSecurityEvents(chargingStation)
-          }, OCPP20Constants.SECURITY_EVENT_RETRY_DELAY_MS)
+          }, OCPP20Constants.SECURITY_EVENT_RETRY_DELAY_MS).unref()
         })
     }
     drainNextEvent()

--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -3319,6 +3319,8 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
       logger.info(
         `${chargingStation.logPrefix()} ${moduleName}.scheduleEvseReset: Executing EVSE ${evseId.toString()} reset${hasActiveTransactions ? ' after transaction termination' : ''}`
       )
+      // Unref: fire-and-forget pending EVSE reset must not block
+      // node.js exit.
       setTimeout(() => {
         const evse = chargingStation.getEvseStatus(evseId)
         if (evse) {
@@ -3347,6 +3349,8 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
    * @param evseId - The EVSE identifier to reset
    */
   private scheduleEvseResetOnIdle (chargingStation: ChargingStation, evseId: number): void {
+    // Unref: idle-monitor poll must not block node.js exit; the interval
+    // self-clears once the EVSE is idle or its state is gone.
     const monitorInterval = setInterval(() => {
       const evse = chargingStation.getEvseStatus(evseId)
       if (evse != null) {
@@ -3368,6 +3372,8 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
    * @param chargingStation - The charging station instance
    */
   private scheduleResetOnIdle (chargingStation: ChargingStation): void {
+    // Unref: idle-monitor poll must not block node.js exit; the interval
+    // self-clears once the station reports idle.
     const monitorInterval = setInterval(() => {
       if (this.isChargingStationIdle(chargingStation)) {
         clearInterval(monitorInterval)
@@ -3611,6 +3617,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
           )
           queue.unshift({ ...event, retryCount })
           stationState.isDrainingSecurityEvents = false
+          // Unref: fire-and-forget retry must not block node.js exit.
           setTimeout(() => {
             this.sendQueuedSecurityEvents(chargingStation)
           }, OCPP20Constants.SECURITY_EVENT_RETRY_DELAY_MS).unref()

--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -3360,7 +3360,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
       } else {
         clearInterval(monitorInterval)
       }
-    }, OCPP20Constants.RESET_IDLE_MONITOR_INTERVAL_MS)
+    }, OCPP20Constants.RESET_IDLE_MONITOR_INTERVAL_MS).unref()
   }
 
   /**
@@ -3381,7 +3381,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
           )
         })
       }
-    }, OCPP20Constants.RESET_IDLE_MONITOR_INTERVAL_MS)
+    }, OCPP20Constants.RESET_IDLE_MONITOR_INTERVAL_MS).unref()
   }
 
   private selectAvailableEvse (chargingStation: ChargingStation): number | undefined {

--- a/src/charging-station/ocpp/OCPPRequestService.ts
+++ b/src/charging-station/ocpp/OCPPRequestService.ts
@@ -301,7 +301,7 @@ export abstract class OCPPRequestService {
         chargingStation.inRejectedState()) &&
         commandName === RequestCommand.BOOT_NOTIFICATION) ||
       (chargingStation.stationInfo?.ocppStrictCompliance === false &&
-        (chargingStation.inUnknownState() || chargingStation.inPendingState())) ||
+        chargingStation.inUnknownState()) ||
       chargingStation.inAcceptedState() ||
       (chargingStation.inPendingState() &&
         (params.triggerMessage === true || messageType === MessageType.CALL_RESULT_MESSAGE))

--- a/src/charging-station/ui-server/AbstractUIServer.ts
+++ b/src/charging-station/ui-server/AbstractUIServer.ts
@@ -1275,7 +1275,7 @@ export abstract class AbstractUIServer {
     this.metricsScrapeChain = this.metricsScrapeChain
       .catch((error: unknown) => {
         logger.warn(
-          `${this.logPrefix()} ${moduleName}.runMetricsScrape: previous scrape errored; chain reset to continue serving next scrape`,
+          `${this.logPrefix()} ${moduleName}.runMetricsScrape: previous scrape errored; absorbing rejection so next scrape can proceed`,
           error
         )
       })

--- a/src/charging-station/ui-server/AbstractUIServer.ts
+++ b/src/charging-station/ui-server/AbstractUIServer.ts
@@ -415,7 +415,12 @@ export abstract class AbstractUIServer {
           .finally(() => {
             registry.clear()
           })
-          .catch(() => undefined)
+          .catch((error: unknown) => {
+            logger.warn(
+              `${this.logPrefix()} ${moduleName}.disposeMetrics: registry cleanup failed`,
+              error
+            )
+          })
         this.metricsRegistry = undefined
       }
       // detachTransport() / uiService.stop() are subclass hooks — see
@@ -1268,7 +1273,12 @@ export abstract class AbstractUIServer {
     registry: Registry
   ): Promise<void> {
     this.metricsScrapeChain = this.metricsScrapeChain
-      .catch(() => undefined)
+      .catch((error: unknown) => {
+        logger.warn(
+          `${this.logPrefix()} ${moduleName}.runMetricsScrape: previous scrape errored; chain reset to continue serving next scrape`,
+          error
+        )
+      })
       .then(async () => {
         this.metricsSampleCount = 0
         // prom-client's sync prefix runs every collect() (each writing

--- a/src/charging-station/ui-server/AbstractUIServer.ts
+++ b/src/charging-station/ui-server/AbstractUIServer.ts
@@ -417,7 +417,7 @@ export abstract class AbstractUIServer {
           })
           .catch((error: unknown) => {
             logger.warn(
-              `${this.logPrefix()} ${moduleName}.disposeMetrics: registry cleanup failed`,
+              `${this.logPrefix()} ${moduleName}.stop: metrics registry cleanup failed`,
               error
             )
           })

--- a/tests/charging-station/ocpp/OCPPServiceOperations.test.ts
+++ b/tests/charging-station/ocpp/OCPPServiceOperations.test.ts
@@ -56,7 +56,7 @@ await describe('OCPPServiceOperations', async () => {
   })
 
   await describe('stopTransactionOnConnector', async () => {
-    await it('should send StatusNotification(Finishing) then StopTransaction for OCPP 1.6 stations (per §5.12)', async () => {
+    await it('should send StatusNotification(Finishing) then StopTransaction for OCPP 1.6 stations (matches remote-stop message sequence)', async () => {
       const { requestHandler, station } = createStationWithRequestHandler()
       requestHandler.mock.mockImplementation(async (..._args: unknown[]) =>
         Promise.resolve({ idTagInfo: { status: 'Accepted' } })

--- a/tests/charging-station/ocpp/OCPPServiceOperations.test.ts
+++ b/tests/charging-station/ocpp/OCPPServiceOperations.test.ts
@@ -56,7 +56,7 @@ await describe('OCPPServiceOperations', async () => {
   })
 
   await describe('stopTransactionOnConnector', async () => {
-    await it('should send StopTransaction for OCPP 1.6 stations and return accepted: true', async () => {
+    await it('should send StatusNotification(Finishing) then StopTransaction for OCPP 1.6 stations (per §5.12)', async () => {
       const { requestHandler, station } = createStationWithRequestHandler()
       requestHandler.mock.mockImplementation(async (..._args: unknown[]) =>
         Promise.resolve({ idTagInfo: { status: 'Accepted' } })
@@ -67,10 +67,15 @@ await describe('OCPPServiceOperations', async () => {
 
       assert.strictEqual(result.accepted, true)
       assert.ok(
-        requestHandler.mock.calls.length >= 1,
-        'request handler should have been called at least once'
+        requestHandler.mock.calls.length >= 2,
+        'request handler should have been called at least twice (StatusNotification + StopTransaction)'
       )
-      assert.strictEqual(requestHandler.mock.calls[0].arguments[1], 'StopTransaction')
+      assert.strictEqual(requestHandler.mock.calls[0].arguments[1], 'StatusNotification')
+      assert.strictEqual(
+        (requestHandler.mock.calls[0].arguments[2] as { status: string }).status,
+        'Finishing'
+      )
+      assert.strictEqual(requestHandler.mock.calls[1].arguments[1], 'StopTransaction')
     })
 
     await it('should send TransactionEvent(Ended) for OCPP 2.0 stations and return accepted: true', async () => {


### PR DESCRIPTION
## Summary

Follow-up to PR #1960 landing the remaining deferred Criticals and Highs from the from-zero audit, plus content-quality fixes surfaced during three iterative review rounds.

Eleven commits ship:

- 5 spec / behavioral fixes (1 Critical, 4 High)
- 1 partial refactor (H10, string fields)
- 1 H9 coverage extension (setInterval sites, round-3)
- 4 content-quality corrections (round-2 / round-3 review follow-ups)

3 audit findings were verified as false positives (no code change). 3 audit findings remain deferred with concrete follow-up rationale.

Each commit is atomic, spec-cited where applicable, and passes the full documented quality gates. Skott circular-dependency count preserved at **61**.

## Commits

| # | Commit | Kind | Origin | Description |
|---|--------|------|--------|-------------|
| 1 | `7c233157` | **fix(ocpp)** | Critical **C2** | Pending state: forbid non-triggered outbound messages even when `ocppStrictCompliance === false` (§4.2) |
| 2 | `c24d04c8` | **fix(ocpp/1.6)** | High **H2** | Emit `StatusNotification(Finishing)` before `StopTransaction.req` in the non-remote stop path |
| 3 | `f600626d` | **fix(ocpp/1.6)** | High **H6** | `RemoteStartTransaction` auto-select skips connectors reserved for a different idTag (§5.11) |
| 4 | `e82cc9a1` | **fix(ui-server)** | High **H11** | Log the errors previously swallowed by `.catch(() => undefined)` in AbstractUIServer |
| 5 | `fa2bea32` | **fix(ocpp)** | High **H9** *(partial)* | `.unref()` on 3 lifecycle `setTimeout` handles so they no longer block node.js shutdown |
| 6 | `6d5ebbb6` | **refactor(charging-station)** | High **H10** *(partial)* | Initialize 5 string `ChargingStation` fields in the constructor; drop their definite-assignment markers |
| 7 | `a72cb504` | **fix(ui-server)** | Round-2 review | Correct method name (`stop`, not `disposeMetrics`) in the metrics-cleanup log prefix at `AbstractUIServer.ts:420` |
| 8 | `7dfc5de2` | **fix(ocpp/2.0)** | Round-3 review | Extend H9 to 2 `setInterval` idle-monitor handles (`scheduleEvseResetOnIdle`, `scheduleResetOnIdle`) — same shutdown-blocking pattern as the setTimeout sites |
| 9 | `a4559d09` | **docs(ocpp)** | Round-3 review | Document the fire-and-forget + station-lifecycle-idempotent safety invariant on all 5 `.unref()` sites |
| 10 | `e8b79c1a` | **fix(ui-server)** | Round-3 review | Correct the `runMetricsScrape` catch-log wording (`chain reset` → `absorbing rejection so next scrape can proceed`) to match actual `.catch` semantics |
| 11 | `ca6b0182` | **test(ocpp)** | Round-3 review | Correct the spec-citation in the `stopTransactionOnConnector` test title (§5.12 covers only remote-stop; the helper is shared with ATG / unlock / station-stop paths) |

## Highlights

### Commit 1 — C2 spec-conformance (§4.2)

`OCPPRequestService.internalSendMessage` had four OR-branches gating outbound CALLs. One branch was `ocppStrictCompliance === false && (inUnknownState() || inPendingState())` — a blanket bypass that allowed any outgoing message in Pending, in direct violation of §4.2 (*"SHALL NOT send request messages ... unless instructed via TriggerMessage.req"*). Narrowed the bypass to Unknown state only. Pending now uniformly enforces the trigger-only restriction whether strict compliance is on or off. The Unknown-state allowance is preserved as a transient pre-boot convenience where the spec is not strict.

### Commit 2 — H2 spec-conformance (Finishing → StopTransaction sequence)

Only `remoteStopTransaction` emitted `StatusNotification(Finishing)` before `StopTransaction.req`; the non-remote `stopTransactionOnConnector` path (ATG stop, `unlockConnector`, station stop, etc.) skipped it. Moved the emission into `stopTransactionOnConnector` itself with an idempotent guard on the current connector status. Remote-stop callers short-circuit the guard so no duplicate is emitted; every non-remote path now matches the same two-message sequence used by the remote-stop path.

### Commit 3 — H6 spec-conformance (§5.11)

The `RemoteStartTransaction` auto-select loop rejected connectors reserved for the requesting idTag (`!hasReservation(cs, id, requesterIdTag)` returned `false` correctly) but let through connectors reserved for a different idTag — because `hasReservation` checks *"is this connector reserved for THIS specific idTag"*. A connector reserved by user A could therefore be auto-selected for a `RemoteStart` by user B, violating A's reservation. Reformulated the predicate: eligible when available, no transaction, AND (not Reserved OR Reserved-for-requester). The rejected path becomes *"Reserved AND not for us"*.

### Commit 4 — H11 silent-error logging

Two `.catch(() => undefined)` sites in `AbstractUIServer` swallowed errors without a log trace (`stop()` registry cleanup + `runMetricsScrape` chain-breaker). Replaced with `.catch((error: unknown) => logger.warn(...))` — the rejection is still absorbed (chain semantics preserved) but the failure gains an operational log entry.

### Commits 5 + 8 — H9 shutdown-unblock (5 timer sites total)

Five untracked timer sites in OCPP incoming-request services blocked clean node.js exit when a station stopped while a timer was pending:

- **3 setTimeout** (`fa2bea32`): `scheduleEvseReset` delay, `sendQueuedSecurityEvents` retry, deferred `updateFirmwareSimulation`
- **2 setInterval** (`7dfc5de2`): `scheduleEvseResetOnIdle`, `scheduleResetOnIdle` idle-poll monitors

Chained `.unref()` on each `Timeout` / `Interval` so node can exit even when the handle is still pending. Callback bodies are safe because the inner functions (`updateFirmwareSimulation`, `sendQueuedSecurityEvents`, `restoreConnectorStatus`, `isChargingStationIdle`) already gate on the station lifecycle or the interval self-clears once its idle condition is met. Full per-station `clearTimeout` tracking is left as follow-up — see below.

### Commit 6 — H10 partial (string fields)

Five private string fields on `ChargingStation` used `!:` even though they are only assigned in `initialize()`. Initialized them to `''` in the constructor and dropped the marker. Empty-string sentinels are safe because reads either compare against a computed hash (fresh station mismatches on first access) or fail cleanly at the fs boundary. Three non-string `!` fields remain — see below.

### Commits 7, 9, 10, 11 — review follow-ups

Content-quality corrections surfaced during three iterative from-zero reviews of the PR itself:

- **7 (`a72cb504`)** — the log message added at `e82cc9a1` claimed `${moduleName}.disposeMetrics` but the enclosing method is `stop()`; `disposeMetrics` is not a method on `AbstractUIServer` at all. Corrected to `${moduleName}.stop`.
- **9 (`a4559d09`)** — the 5 `.unref()` sites share a non-obvious safety invariant (fire-and-forget timer + station-lifecycle-idempotent callback) that a reader has no way to reconstruct without git history. A one-line state-describing comment above each site keeps the safety rationale next to the code.
- **10 (`e8b79c1a`)** — the `runMetricsScrape` catch-log claimed *"chain reset to continue serving next scrape"*, but nothing about the promise chain is reset there. What actually happens: the `.catch` absorbs the prior rejection so its `.then` continuation can run for the next scrape. Rewrote to match the real semantics.
- **11 (`ca6b0182`)** — the renamed test at `c24d04c8` cited `(per §5.12)`, but §5.12 is RemoteStopTransaction only; `stopTransactionOnConnector` is the shared helper. Rewrote the parenthetical to describe the verified design intent (*"matches remote-stop message sequence"*) instead of pointing at a spec section that only covers one caller.

## Audit findings verified as false positives (empirical rationale, no code change)

- **H4** — `ChangeAvailability` deferred trigger. Empirically the trigger IS wired: `handleRequestChangeAvailability` sets `connectorStatus.availability = Inoperative` (line 773) and returns Scheduled. When the transaction stops, `handleResponseStopTransaction` calls `sendPostTransactionStatus` which reads `isConnectorAvailable(connectorId)` (i.e. `availability === Operative`). If availability was set to Inoperative, the post-stop emission is `Unavailable` — that IS the deferred availability trigger. Audit finding rescinded.

- **H5** — MeterValues in `StopTransaction.transactionData`. The `STOP_TRANSACTION` payload builder at `OCPP16RequestService.ts:240-267` already embeds `transactionData` when the `transactionDataMeterValues` config flag is set. The audit's specific concern (separate `MeterValues` request when `beginEndMeterValues && strict && !outOfOrder`) is a distinct, documented feature (`beginEndMeterValues` toggles Transaction.Begin/End MeterValues as lifecycle events — README-documented). Both patterns are spec-permissible; §5.12 SHOULD ≠ SHALL, and the two features are orthogonal. Audit conflated them.

- **H8** — `console.*` in production code. Every one of the 14 flagged sites has documented defensive rationale:
  - `Configuration.ts:111,164` — config-load / pre-`process.exit(1)` (logger not yet configured)
  - `ErrorUtils.ts:28,36` — uncaught / unhandledRejection process-level handlers (logger state unknown; already has `logger?.error` fallback)
  - `ErrorUtils.ts:89,91,121,145` — behind `params.consoleOut === true` flag (documented escape hatch)
  - `ConfigurationValidation.ts:114` — inline rationale: `console.warn: logger.warn would recurse via Configuration → validateConfiguration`
  - `start.ts:14` — top-level startup error handler (logger init after)
  - `WorkerUtils.ts:45-54` — worker-lifecycle handlers (workers have separate logger context)

  None are anti-pattern uses. Audit finding rescinded.

## Findings still deferred (with concrete rationale)

- **H7** — ~15 `as unknown as X` casts across the OCPP request / response dispatch layer. Root cause is that the `Request` / `Response` union types are too wide; narrowing them per-command eliminates the casts but touches every OCPP command handler across `OCPP16RequestService`, `OCPP20RequestService`, `OCPP16IncomingRequestService`, `OCPP20IncomingRequestService`. Deserves its own PR dedicated to that type contract.

- **H9 residual** — the 5 timer sites now `.unref()` cleanly but full per-station `clearTimeout` tracking (`WeakMap<ChargingStation, Set<Timeout>>`) requires new plumbing on `OCPPIncomingRequestService` base class plus `stop(station)` overrides. Out of this PR's scope.

- **H10 residual** — 3 non-string `!` fields on `ChargingStation`:
  - `ocppRequestService!: OCPPRequestService` and `ocppIncomingRequestService!: OCPPIncomingRequestService` — depend on `stationInfo.ocppVersion` (only known after `initialize()` reads the template file), so cannot be constructed in the `ChargingStation` constructor.
  - `configuredSupervisionUrl!: URL` — no reasonable empty-URL sentinel; needs `URL | undefined` + null-checks.

  Full fix requires touching ~35 files (grep on `ocppRequestService.` / `ocppIncomingRequestService.` / `configuredSupervisionUrl.`). Coherent as a follow-up PR dedicated to the `ChargingStation` lifecycle contract.

## Verification

Full documented gates against the final tip of the branch (`ca6b0182`):

| Package | format | typecheck | lint | build | test |
|---------|:------:|:---------:|:----:|:-----:|:----:|
| root    | ✅ | ✅ | ✅ | ✅ | ✅ 2951 pass / 0 fail / 6 skipped |

Skott circular-dependency count: **61** (preserved, no change since PR #1960).