### PR TITLE
fix(ocpp): reset stationInfo.firmwareStatus on abort/exception in simulateFirmwareUpdateLifecycle

### DIFF
--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -255,6 +255,13 @@ const buildRejectedResponse = (
   ...(transactionId != null && { transactionId }),
 })
 
+type FirmwareStage = 'download' | 'install' | 'installed'
+
+const FIRMWARE_STAGE_FAILURE_STATUS = {
+  download: OCPP20FirmwareStatusEnumType.DownloadFailed,
+  install: OCPP20FirmwareStatusEnumType.InstallationFailed,
+} as const satisfies Record<Exclude<FirmwareStage, 'installed'>, OCPP20FirmwareStatusEnumType>
+
 interface OCPP20StationState {
   activeFirmwareUpdateAbortController?: AbortController
   activeFirmwareUpdateRequestId?: number
@@ -3781,6 +3788,14 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
 
     const checkAborted = (): boolean => abortController.signal.aborted
 
+    // Lifecycle-stage tracker for the finally-block terminal-status reset
+    // (issue #1969): advances only on actual lifecycle advancement, never on
+    // error/abort branches.
+    //   'download'  → still in the download/verify stage (initial)
+    //   'install'   → Installing notification succeeded, install stage entered
+    //   'installed' → Installed notification succeeded, lifecycle reached success
+    let stage: FirmwareStage = 'download'
+
     try {
       // Delay the download until retrieveDateTime; inform the CSMS via DownloadScheduled first
       const now = Date.now()
@@ -3938,6 +3953,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
         OCPP20FirmwareStatusEnumType.Installing,
         requestId
       )
+      stage = 'install'
 
       await interruptibleSleep(OCPP20Constants.RESET_DELAY_MS, abortController.signal)
       if (checkAborted()) return
@@ -3946,6 +3962,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
         OCPP20FirmwareStatusEnumType.Installed,
         requestId
       )
+      stage = 'installed'
 
       // Send SecurityEventNotification after a successful firmware update
       this.sendSecurityEventNotification(
@@ -3958,6 +3975,37 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
         `${chargingStation.logPrefix()} ${moduleName}.simulateFirmwareUpdateLifecycle: Firmware update simulation completed for requestId ${requestId.toString()}`
       )
     } finally {
+      // Reset stationInfo.firmwareStatus to a coherent terminal value when the
+      // lifecycle exits before reaching Installed (issue #1969): otherwise any
+      // consumer that does not cross-check activeFirmwareUpdateRequestId would
+      // observe a stale in-progress value. FirmwareStatusEnumType.Idle is
+      // SHALL-restricted to TriggerMessage-triggered notifications, so as a
+      // persistent local state Idle only fits the pre-install baseline: clean
+      // download-phase abort → Idle; clean install-phase abort → InstallationFailed
+      // (spec-recognized for cancellation per L01.FR.24 Note). No
+      // FirmwareStatusNotification is emitted from finally (L01.FR.24 Note MAY
+      // makes the terminal notification optional; L02.FR.15 omits the clause).
+      // Guards (`successorClaimed`, `isExplicitTerminal`) mirror
+      // `clearActiveFirmwareUpdate`'s requestId-supersession pattern and
+      // preserve any explicit terminal already emitted from inside try.
+      const activeRequestId = this.stationsState.get(chargingStation)?.activeFirmwareUpdateRequestId
+      const successorClaimed = activeRequestId != null && activeRequestId !== requestId
+      const currentStatus = chargingStation.stationInfo?.firmwareStatus
+      const isExplicitTerminal =
+        currentStatus === OCPP20FirmwareStatusEnumType.DownloadFailed ||
+        currentStatus === OCPP20FirmwareStatusEnumType.InstallationFailed ||
+        currentStatus === OCPP20FirmwareStatusEnumType.InvalidSignature
+      if (
+        stage !== 'installed' &&
+        !successorClaimed &&
+        !isExplicitTerminal &&
+        chargingStation.stationInfo != null
+      ) {
+        chargingStation.stationInfo.firmwareStatus =
+          abortController.signal.aborted && stage === 'download'
+            ? OCPP20FirmwareStatusEnumType.Idle
+            : FIRMWARE_STAGE_FAILURE_STATUS[stage]
+      }
       // Guarantee cleanup on every exit path (happy, abort, throw): without
       // this, a thrown await would leave activeFirmwareUpdateAbortController
       // set and any subsequent UpdateFirmware.req would abort a non-existent

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-UpdateFirmware.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-UpdateFirmware.test.ts
@@ -885,5 +885,437 @@ await describe('L01/L02 - UpdateFirmware', async () => {
         })
       })
     })
+
+    await describe('stationInfo.firmwareStatus reset on exit (issue #1969)', async () => {
+      await it('should reset stationInfo.firmwareStatus to Idle on clean abort mid-download (L01.FR.24)', async t => {
+        const { sentRequests, station: trackingStation } = createMockStationWithRequestTracking()
+        const service = new OCPP20IncomingRequestService()
+        const testable = createTestableIncomingRequestService(service)
+
+        const firstRequest: OCPP20UpdateFirmwareRequest = {
+          firmware: {
+            location: 'https://firmware.example.com/v1.bin',
+            retrieveDateTime: new Date('2020-01-01T00:00:00.000Z'),
+          },
+          requestId: 200,
+        }
+        const firstResponse: OCPP20UpdateFirmwareResponse = {
+          status: UpdateFirmwareStatusEnumType.Accepted,
+        }
+
+        await withMockTimers(t, ['setTimeout'], async () => {
+          service.emit(
+            OCPP20IncomingRequestCommand.UPDATE_FIRMWARE,
+            trackingStation,
+            firstRequest,
+            firstResponse
+          )
+          await flushMicrotasks()
+          assert.strictEqual(sentRequests.length, 1)
+          assert.strictEqual(
+            sentRequests[0].payload.status,
+            OCPP20FirmwareStatusEnumType.Downloading
+          )
+          assert.strictEqual(
+            trackingStation.stationInfo?.firmwareStatus,
+            OCPP20FirmwareStatusEnumType.Downloading
+          )
+
+          const secondRequest: OCPP20UpdateFirmwareRequest = {
+            firmware: {
+              location: 'https://firmware.example.com/v2.bin',
+              retrieveDateTime: new Date('2020-01-01T00:00:00.000Z'),
+            },
+            requestId: 201,
+          }
+          const secondResponse = testable.handleRequestUpdateFirmware(
+            trackingStation,
+            secondRequest
+          )
+          assert.strictEqual(secondResponse.status, UpdateFirmwareStatusEnumType.AcceptedCanceled)
+          await flushMicrotasks()
+
+          assert.strictEqual(
+            trackingStation.stationInfo.firmwareStatus,
+            OCPP20FirmwareStatusEnumType.Idle
+          )
+        })
+      })
+
+      await it('should reset stationInfo.firmwareStatus to InstallationFailed on clean abort mid-install (Idle TriggerMessage-only; L01.FR.24 MAY)', async t => {
+        const { sentRequests, station: trackingStation } = createMockStationWithRequestTracking()
+        const service = new OCPP20IncomingRequestService()
+        const testable = createTestableIncomingRequestService(service)
+
+        const firstRequest: OCPP20UpdateFirmwareRequest = {
+          firmware: {
+            location: 'https://firmware.example.com/v1.bin',
+            retrieveDateTime: new Date('2020-01-01T00:00:00.000Z'),
+          },
+          requestId: 210,
+        }
+        const firstResponse: OCPP20UpdateFirmwareResponse = {
+          status: UpdateFirmwareStatusEnumType.Accepted,
+        }
+
+        await withMockTimers(t, ['setTimeout'], async () => {
+          service.emit(
+            OCPP20IncomingRequestCommand.UPDATE_FIRMWARE,
+            trackingStation,
+            firstRequest,
+            firstResponse
+          )
+          await flushMicrotasks()
+          // Downloading emitted; advance past FIRMWARE_STATUS_DELAY_MS to reach Installing
+          t.mock.timers.tick(2000)
+          await flushMicrotasks()
+          assert.strictEqual(sentRequests.length, 3)
+          assert.strictEqual(
+            sentRequests[2].payload.status,
+            OCPP20FirmwareStatusEnumType.Installing
+          )
+          assert.strictEqual(
+            trackingStation.stationInfo?.firmwareStatus,
+            OCPP20FirmwareStatusEnumType.Installing
+          )
+
+          const secondRequest: OCPP20UpdateFirmwareRequest = {
+            firmware: {
+              location: 'https://firmware.example.com/v2.bin',
+              retrieveDateTime: new Date('2020-01-01T00:00:00.000Z'),
+            },
+            requestId: 211,
+          }
+          const secondResponse = testable.handleRequestUpdateFirmware(
+            trackingStation,
+            secondRequest
+          )
+          assert.strictEqual(secondResponse.status, UpdateFirmwareStatusEnumType.AcceptedCanceled)
+          await flushMicrotasks()
+
+          assert.strictEqual(
+            trackingStation.stationInfo.firmwareStatus,
+            OCPP20FirmwareStatusEnumType.InstallationFailed
+          )
+        })
+      })
+
+      await it('should reset stationInfo.firmwareStatus to DownloadFailed on exception during download', async t => {
+        const {
+          requestHandlerMock,
+          sentRequests,
+          station: trackingStation,
+        } = createMockStationWithRequestTracking()
+        const service = new OCPP20IncomingRequestService()
+
+        // Reject on the 2nd FirmwareStatusNotification (Downloaded) to force a throw in the download stage
+        requestHandlerMock.mock.mockImplementation((...args: unknown[]) => {
+          const payload = args[2] as { requestId?: number; status?: OCPP20FirmwareStatusEnumType }
+          sentRequests.push({
+            command: args[1] as OCPP20RequestCommand,
+            payload,
+          })
+          if (payload.status === OCPP20FirmwareStatusEnumType.Downloaded) {
+            return Promise.reject(new Error('simulated download failure'))
+          }
+          return Promise.resolve({})
+        })
+
+        const request: OCPP20UpdateFirmwareRequest = {
+          firmware: {
+            location: 'https://firmware.example.com/update.bin',
+            retrieveDateTime: new Date('2020-01-01T00:00:00.000Z'),
+          },
+          requestId: 220,
+        }
+        const response: OCPP20UpdateFirmwareResponse = {
+          status: UpdateFirmwareStatusEnumType.Accepted,
+        }
+
+        await withMockTimers(t, ['setTimeout'], async () => {
+          service.emit(
+            OCPP20IncomingRequestCommand.UPDATE_FIRMWARE,
+            trackingStation,
+            request,
+            response
+          )
+          await flushMicrotasks()
+          assert.strictEqual(
+            sentRequests[0].payload.status,
+            OCPP20FirmwareStatusEnumType.Downloading
+          )
+          t.mock.timers.tick(2000)
+          await flushMicrotasks()
+
+          assert.strictEqual(
+            trackingStation.stationInfo?.firmwareStatus,
+            OCPP20FirmwareStatusEnumType.DownloadFailed
+          )
+        })
+      })
+
+      await it('should reset stationInfo.firmwareStatus to InstallationFailed on exception during install', async t => {
+        const {
+          requestHandlerMock,
+          sentRequests,
+          station: trackingStation,
+        } = createMockStationWithRequestTracking()
+        const service = new OCPP20IncomingRequestService()
+
+        // Reject on the Installed FirmwareStatusNotification: Installing already succeeded so stage='install'
+        requestHandlerMock.mock.mockImplementation((...args: unknown[]) => {
+          const payload = args[2] as { requestId?: number; status?: OCPP20FirmwareStatusEnumType }
+          sentRequests.push({
+            command: args[1] as OCPP20RequestCommand,
+            payload,
+          })
+          if (payload.status === OCPP20FirmwareStatusEnumType.Installed) {
+            return Promise.reject(new Error('simulated install failure'))
+          }
+          return Promise.resolve({})
+        })
+
+        const request: OCPP20UpdateFirmwareRequest = {
+          firmware: {
+            location: 'https://firmware.example.com/update.bin',
+            retrieveDateTime: new Date('2020-01-01T00:00:00.000Z'),
+          },
+          requestId: 230,
+        }
+        const response: OCPP20UpdateFirmwareResponse = {
+          status: UpdateFirmwareStatusEnumType.Accepted,
+        }
+
+        await withMockTimers(t, ['setTimeout'], async () => {
+          service.emit(
+            OCPP20IncomingRequestCommand.UPDATE_FIRMWARE,
+            trackingStation,
+            request,
+            response
+          )
+          await flushMicrotasks()
+          t.mock.timers.tick(2000)
+          await flushMicrotasks()
+          assert.strictEqual(
+            sentRequests[2].payload.status,
+            OCPP20FirmwareStatusEnumType.Installing
+          )
+          t.mock.timers.tick(1000)
+          await flushMicrotasks()
+
+          assert.strictEqual(
+            trackingStation.stationInfo?.firmwareStatus,
+            OCPP20FirmwareStatusEnumType.InstallationFailed
+          )
+        })
+      })
+
+      await it('should leave stationInfo.firmwareStatus as Installed on happy-path completion', async t => {
+        const { sentRequests, station: trackingStation } = createMockStationWithRequestTracking()
+        const service = new OCPP20IncomingRequestService()
+
+        const request: OCPP20UpdateFirmwareRequest = {
+          firmware: {
+            location: 'https://firmware.example.com/update.bin',
+            retrieveDateTime: new Date('2020-01-01T00:00:00.000Z'),
+          },
+          requestId: 240,
+        }
+        const response: OCPP20UpdateFirmwareResponse = {
+          status: UpdateFirmwareStatusEnumType.Accepted,
+        }
+
+        await withMockTimers(t, ['setTimeout'], async () => {
+          service.emit(
+            OCPP20IncomingRequestCommand.UPDATE_FIRMWARE,
+            trackingStation,
+            request,
+            response
+          )
+          await flushMicrotasks()
+          t.mock.timers.tick(2000)
+          await flushMicrotasks()
+          t.mock.timers.tick(1000)
+          await flushMicrotasks()
+
+          assert.strictEqual(sentRequests[3].payload.status, OCPP20FirmwareStatusEnumType.Installed)
+          assert.strictEqual(
+            trackingStation.stationInfo?.firmwareStatus,
+            OCPP20FirmwareStatusEnumType.Installed
+          )
+        })
+      })
+
+      await it('should NOT clobber a successor lifecycle firmwareStatus (supersession-with-emit race)', async t => {
+        // Locks the finally-block requestId-guard invariant: when T1 wakes up
+        // after a superseder T2 has claimed activeFirmwareUpdateRequestId,
+        // T1's finally must NOT overwrite T2's status. Mirrors the production
+        // path where the constructor's UPDATE_FIRMWARE listener launches T2
+        // on the AcceptedCanceled branch.
+        const { sentRequests, station: trackingStation } = createMockStationWithRequestTracking()
+        const service = new OCPP20IncomingRequestService()
+        const testable = createTestableIncomingRequestService(service)
+
+        const firstRequest: OCPP20UpdateFirmwareRequest = {
+          firmware: {
+            location: 'https://firmware.example.com/v1.bin',
+            retrieveDateTime: new Date('2020-01-01T00:00:00.000Z'),
+          },
+          requestId: 250,
+        }
+        const firstResponse: OCPP20UpdateFirmwareResponse = {
+          status: UpdateFirmwareStatusEnumType.Accepted,
+        }
+
+        await withMockTimers(t, ['setTimeout'], async () => {
+          service.emit(
+            OCPP20IncomingRequestCommand.UPDATE_FIRMWARE,
+            trackingStation,
+            firstRequest,
+            firstResponse
+          )
+          await flushMicrotasks()
+          assert.strictEqual(
+            sentRequests[0].payload.status,
+            OCPP20FirmwareStatusEnumType.Downloading
+          )
+
+          const secondRequest: OCPP20UpdateFirmwareRequest = {
+            firmware: {
+              location: 'https://firmware.example.com/v2.bin',
+              retrieveDateTime: new Date('2020-01-01T00:00:00.000Z'),
+            },
+            requestId: 251,
+          }
+          // Production sequence: handleRequestUpdateFirmware aborts T1 + returns
+          // AcceptedCanceled, then the base class emits UPDATE_FIRMWARE which
+          // launches T2's lifecycle. Replicate the emit here.
+          const secondResponse = testable.handleRequestUpdateFirmware(
+            trackingStation,
+            secondRequest
+          )
+          assert.strictEqual(secondResponse.status, UpdateFirmwareStatusEnumType.AcceptedCanceled)
+          service.emit(
+            OCPP20IncomingRequestCommand.UPDATE_FIRMWARE,
+            trackingStation,
+            secondRequest,
+            secondResponse
+          )
+          await flushMicrotasks()
+
+          // T2 wrote firmwareStatus='Downloading' synchronously at its start.
+          // T1's finally saw activeFirmwareUpdateRequestId === 251 !== 250 and
+          // skipped its reset. Without the guard, T1 would have written Idle.
+          assert.notStrictEqual(
+            trackingStation.stationInfo?.firmwareStatus,
+            OCPP20FirmwareStatusEnumType.Idle
+          )
+          assert.strictEqual(
+            trackingStation.stationInfo?.firmwareStatus,
+            OCPP20FirmwareStatusEnumType.Downloading
+          )
+        })
+      })
+
+      await it('should preserve InvalidSignature when signature verification fails (no clobber in finally)', async t => {
+        const { sentRequests, station: trackingStation } = createMockStationWithRequestTracking()
+        const service = new OCPP20IncomingRequestService()
+        const { OCPP20VariableManager } =
+          await import('../../../../src/charging-station/ocpp/2.0/OCPP20VariableManager.js')
+        const { AttributeEnumType, OCPP20ComponentName } =
+          await import('../../../../src/types/index.js')
+
+        OCPP20VariableManager.getInstance().setVariables(trackingStation, [
+          {
+            attributeType: AttributeEnumType.Actual,
+            attributeValue: 'true',
+            component: { name: OCPP20ComponentName.FirmwareCtrlr },
+            variable: { name: 'SimulateSignatureVerificationFailure' },
+          },
+        ])
+
+        const request: OCPP20UpdateFirmwareRequest = {
+          firmware: {
+            location: 'https://firmware.example.com/update.bin',
+            retrieveDateTime: new Date('2020-01-01T00:00:00.000Z'),
+            signature: 'dGVzdA==',
+          },
+          requestId: 260,
+        }
+        const response: OCPP20UpdateFirmwareResponse = {
+          status: UpdateFirmwareStatusEnumType.Accepted,
+        }
+
+        await withMockTimers(t, ['setTimeout'], async () => {
+          service.emit(
+            OCPP20IncomingRequestCommand.UPDATE_FIRMWARE,
+            trackingStation,
+            request,
+            response
+          )
+          await flushMicrotasks()
+          t.mock.timers.tick(2000)
+          await flushMicrotasks()
+          t.mock.timers.tick(500)
+          await flushMicrotasks()
+
+          assert.strictEqual(
+            sentRequests[2].payload.status,
+            OCPP20FirmwareStatusEnumType.InvalidSignature
+          )
+          assert.strictEqual(
+            trackingStation.stationInfo?.firmwareStatus,
+            OCPP20FirmwareStatusEnumType.InvalidSignature
+          )
+        })
+      })
+
+      await it('should preserve DownloadFailed after retries-exhausted exit (L01.FR.30 idempotence)', async t => {
+        const { sentRequests, station: trackingStation } = createMockStationWithRequestTracking()
+        const service = new OCPP20IncomingRequestService()
+
+        const request: OCPP20UpdateFirmwareRequest = {
+          firmware: {
+            location: 'not-a-valid-url',
+            retrieveDateTime: new Date('2020-01-01T00:00:00.000Z'),
+          },
+          requestId: 270,
+          retries: 1,
+          retryInterval: 2,
+        }
+        const response: OCPP20UpdateFirmwareResponse = {
+          status: UpdateFirmwareStatusEnumType.Accepted,
+        }
+
+        await withMockTimers(t, ['setTimeout'], async () => {
+          service.emit(
+            OCPP20IncomingRequestCommand.UPDATE_FIRMWARE,
+            trackingStation,
+            request,
+            response
+          )
+          await flushMicrotasks()
+          // Initial Downloading delay + retry interval + retry Downloading + retry delay
+          t.mock.timers.tick(2000)
+          await flushMicrotasks()
+          t.mock.timers.tick(2000)
+          await flushMicrotasks()
+          t.mock.timers.tick(2000)
+          await flushMicrotasks()
+
+          const lastFirmwareNotification = sentRequests
+            .filter(req => req.command === OCPP20RequestCommand.FIRMWARE_STATUS_NOTIFICATION)
+            .at(-1)
+          assert.strictEqual(
+            lastFirmwareNotification?.payload.status,
+            OCPP20FirmwareStatusEnumType.DownloadFailed
+          )
+          assert.strictEqual(
+            trackingStation.stationInfo?.firmwareStatus,
+            OCPP20FirmwareStatusEnumType.DownloadFailed
+          )
+        })
+      })
+    })
   })
 })

--- a/tests/helpers/TestLifecycleHelpers.ts
+++ b/tests/helpers/TestLifecycleHelpers.ts
@@ -30,6 +30,7 @@ import { mock } from 'node:test'
 import type { ChargingStation } from '../../src/charging-station/index.js'
 import type { MockChargingStationOptions } from '../charging-station/helpers/StationHelpers.js'
 
+import { OCPP20VariableManager } from '../../src/charging-station/ocpp/2.0/OCPP20VariableManager.js'
 import { createMockChargingStation } from '../charging-station/helpers/StationHelpers.js'
 import { MockIdTagsCache, MockSharedLRUCache } from '../charging-station/mocks/MockCaches.js'
 
@@ -346,6 +347,7 @@ export function standardCleanup (): void {
   }
   MockSharedLRUCache.resetInstance()
   MockIdTagsCache.resetInstance()
+  OCPP20VariableManager.getInstance().resetRuntimeOverrides()
 }
 
 /**


### PR DESCRIPTION
Closes #1969.

## Problem

`OCPP20IncomingRequestService.simulateFirmwareUpdateLifecycle` writes `chargingStation.stationInfo.firmwareStatus` at every status transition via `sendFirmwareStatusNotification`, but its `finally` block only cleared the per-station WeakMap state via `clearActiveFirmwareUpdate`. On exception or abort (supersession, `stop()`), `stationInfo.firmwareStatus` retained the last-emitted non-terminal value indefinitely (e.g. `'Downloading'`).

The `TriggerMessage(FirmwareStatusNotification)` reader in `handleRequestTriggerMessage` already cross-checks against `activeFirmwareUpdateRequestId`, but consumers of `hasFirmwareUpdateInProgress` (`handleRequestReset`, `isChargingStationIdle`, `isEvseIdle`) read `stationInfo.firmwareStatus` as authoritative — the data-model split was a latent hazard.

## OCPP 2.0.1 spec anchors

### L01.FR.24 (supersession)

Verbatim from `OCPP-2.0.1_edition3_part2_specification.md`, Table 193:

> **Precondition** — When a Charging Station is installing new Firmware OR is going to install new Firmware, but has received an UpdateFirmware command to install it at a later time AND the Charging Station receives a new UpdateFirmwareRequest
>
> **Requirement definition** — The Charging Station SHOULD cancel the ongoing firmware update AND respond with status AcceptedCanceled.
>
> **Note** — The Charging Station SHOULD NOT first check if the new firmware file exists, this way the CSMS will be able to cancel an ongoing firmware update without starting a new one. **The Charging Station may send a FirmwareStatusNotificationRequest with status DownloadFailed or InstallationFailed for the firmware update that has now been canceled.**

The lowercase `may` in the Note makes the terminal `*Failed` FirmwareStatusNotification on supersession **optional**. `L02.FR.15` Note omits the `*Failed` MAY clause entirely; the no-notification-from-finally behavior is safe for both L01 (Secure) and L02 (Non-Secure). Forward-compat with OCPP 2.1: `L02.FR.15` Note in OCPP 2.1 adds only a `Same as L01.FR.24` cross-reference tag (structural annotation), still no `*Failed` clause imported.

### FirmwareStatusEnumType (Idle restriction)

Verbatim from `OCPP-2.0.1_edition3_part2_specification.md`, FirmwareStatusEnumType (Part 2 data types):

> `Idle` — Charging Station is not performing firmware update related tasks. **Status Idle SHALL only be used as in a FirmwareStatusNotificationRequest that was triggered by TriggerMessageRequest.**

`Idle` as a persistent local state is therefore only valid before install starts — once the lifecycle has entered install (`stage = 'install'` after successful `Installing` notification), a clean abort must collapse to `InstallationFailed` (spec-recognized for the cancellation scenario per L01.FR.24 Note) rather than `Idle`. The `Idle` SHALL restriction is the exclusionary anchor (why not `Idle`); L01.FR.24 Note is the recognition anchor (why `InstallationFailed` is spec-blessed). The internal `stationInfo.firmwareStatus` field is a mirror of the last-sent notification value, and honoring the spec's `Idle` scope-restriction at the field level keeps the mirror semantically valid.

## Fix

Track lifecycle stage via a module-scope `type FirmwareStage = 'download' | 'install' | 'installed'` and a `Record<Exclude<FirmwareStage, 'installed'>, OCPP20FirmwareStatusEnumType>` failure-status mapping. Naming `stage` (not `phase`) avoids collision with the electrical `phase` terminology (`L1-N`/`L2-N`) elsewhere in the codebase. In the existing `finally`, reset `stationInfo.firmwareStatus` when the lifecycle did **not** reach `Installed`:

| Exit path | `stage` | `aborted` | Terminal value |
| --- | --- | --- | --- |
| Clean supersession/stop mid-download | `download` | `true` | `Idle` |
| Clean supersession/stop mid-install | `install` | `true` | `InstallationFailed` |
| Exception during download | `download` | `false` | `DownloadFailed` |
| Exception during install | `install` | `false` | `InstallationFailed` |
| Retries-exhausted `DownloadFailed` emitted from try | `download` | `false` | *(preserved — `isExplicitTerminal` skips)* |
| `InvalidSignature` emitted from try | `download` | `false` | *(preserved — `isExplicitTerminal` skips)* |
| Successor lifecycle (T2) has already claimed `activeFirmwareUpdateRequestId` | any non-`installed` | any | *(preserved — `successorClaimed` skips)* |
| Happy path completion | `installed` | any | *(untouched — remains `Installed`)* |

### Compile-time-exhaustive failure-stage mapping

```ts
type FirmwareStage = 'download' | 'install' | 'installed'

const FIRMWARE_STAGE_FAILURE_STATUS = {
  download: OCPP20FirmwareStatusEnumType.DownloadFailed,
  install: OCPP20FirmwareStatusEnumType.InstallationFailed,
} as const satisfies Record<Exclude<FirmwareStage, 'installed'>, OCPP20FirmwareStatusEnumType>
```

- `Exclude<FirmwareStage, 'installed'>` narrows the key type to failure-eligible stages only — no unreachable entry.
- `as const satisfies Record<...>` enforces exhaustive coverage: adding a failure-eligible stage without a mapping fails compilation.
- SCREAMING_SNAKE_CASE naming matches the codebase convention for private module-scope `Record` lookup tables (mirrors `PHASE_FAMILY` / `PHASE_RANK` in `CoherentMeterValueBuilder`).

### Stage-tracker invariant

`stage` advances **only on actual advancement** — never on error/abort branches. Two placements only:

```ts
await this.sendFirmwareStatusNotification(chargingStation, OCPP20FirmwareStatusEnumType.Installing, requestId)
stage = 'install'
// ... sleep + checkAborted ...
await this.sendFirmwareStatusNotification(chargingStation, OCPP20FirmwareStatusEnumType.Installed, requestId)
stage = 'installed'
```

If the `Installing` `await` rejects, `stage` remains `'download'` → `DownloadFailed`. If the `Installed` `await` rejects, `stage` was already `'install'` → `InstallationFailed`. If a supersession fires during an awaited sleep, `abortController.signal.aborted === true` combines with the stage: download-phase → `Idle`; install-phase → `InstallationFailed`.

### Supersession-race guard

In production, supersession spawns a T2 lifecycle via the constructor's `UPDATE_FIRMWARE` listener, which fires on both `Accepted` AND `AcceptedCanceled` responses. If T1 is blocked on a non-abort-aware `await requestHandler(...)` when supersession fires, T2 launches and claims `activeFirmwareUpdateRequestId` before T1's `finally` runs. The finally mirrors `clearActiveFirmwareUpdate`'s requestId-supersession pattern:

```ts
} finally {
  // ... spec-anchor + rationale comment ...
  const activeRequestId =
    this.stationsState.get(chargingStation)?.activeFirmwareUpdateRequestId
  const successorClaimed = activeRequestId != null && activeRequestId !== requestId
  const currentStatus = chargingStation.stationInfo?.firmwareStatus
  const isExplicitTerminal =
    currentStatus === OCPP20FirmwareStatusEnumType.DownloadFailed ||
    currentStatus === OCPP20FirmwareStatusEnumType.InstallationFailed ||
    currentStatus === OCPP20FirmwareStatusEnumType.InvalidSignature
  if (
    stage !== 'installed' &&
    !successorClaimed &&
    !isExplicitTerminal &&
    chargingStation.stationInfo != null
  ) {
    chargingStation.stationInfo.firmwareStatus =
      abortController.signal.aborted && stage === 'download'
        ? OCPP20FirmwareStatusEnumType.Idle
        : FIRMWARE_STAGE_FAILURE_STATUS[stage]
  }
  // Guarantee cleanup on every exit path (happy, abort, throw): without
  // this, a thrown await would leave activeFirmwareUpdateAbortController
  // set and any subsequent UpdateFirmware.req would abort a non-existent
  // in-progress update while the station stays stuck.
  this.clearActiveFirmwareUpdate(chargingStation, requestId)
}
```

Design constraints honoured:
- `finally` does not emit a `FirmwareStatusNotification` — field reset only, per L01.FR.24 Note (`may` is optional) + L02.FR.15 (no clause at all).
- `sendFirmwareStatusNotification`, `hasFirmwareUpdateInProgress`, `clearActiveFirmwareUpdate` are **unchanged**.
- Existing `finally` statement order unchanged; pre-existing "Guarantee cleanup..." comment preserved **verbatim**; `clearActiveFirmwareUpdate(chargingStation, requestId)` still the last statement.
- Scope: `simulateFirmwareUpdateLifecycle` + module-scope `FirmwareStage` type + `FIRMWARE_STAGE_FAILURE_STATUS` mapping + the matching test file + one line added to `standardCleanup` test helper for `OCPP20VariableManager` singleton state reset (fixes latent test-isolation trap, unrelated to #1969 but discovered during review). No OCPP 1.6 changes (companion issues #1972/#1973 blocked by #1963, out of scope).

## Test coverage

8 new tests under a new `stationInfo.firmwareStatus reset on exit (issue #1969)` describe block:

| # | Scenario | Trigger | Expected `stationInfo.firmwareStatus` after `finally` |
| --- | --- | --- | --- |
| 1 | Clean abort mid-download | Second `handleRequestUpdateFirmware` supersedes while first is between `Downloading` and `Downloaded` | `Idle` |
| 2 | Clean abort mid-install | Second `handleRequestUpdateFirmware` supersedes while first is between `Installing` and `Installed` | `InstallationFailed` |
| 3 | Exception during download | Mock `requestHandler` rejects on the `Downloaded` FirmwareStatusNotification | `DownloadFailed` |
| 4 | Exception during install | Mock `requestHandler` rejects on the `Installed` FirmwareStatusNotification (after `stage = 'install'`) | `InstallationFailed` |
| 5 | Happy path preserved | Full lifecycle to `Installed` | `Installed` *(untouched)* |
| 6 | Supersession-with-emit race | Second `handleRequestUpdateFirmware` + explicit `service.emit(UPDATE_FIRMWARE, ..., AcceptedCanceled)` replicating the production T2-launch path | `Downloading` *(T2 preserved; T1's finally skipped by `successorClaimed`)* |
| 7 | InvalidSignature preservation | `SimulateSignatureVerificationFailure=true` triggers the L01.FR.03 emit path | `InvalidSignature` *(preserved by `isExplicitTerminal`)* |
| 8 | Retries-exhausted `DownloadFailed` idempotence | Invalid location + `retries: 1` exhausts the L01.FR.30 retry loop | `DownloadFailed` *(preserved by `isExplicitTerminal`)* |

All 8 pass. Full suite: **2963 pass / 0 fail / 6 skipped**.

## Verification gates

| Gate | Result |
| --- | --- |
| `pnpm format` | exit 0 |
| `pnpm typecheck` | 0 errors |
| `pnpm lint` | 0 errors |
| `pnpm test` | 2963 pass / 0 fail / 6 skipped |
| `pnpm build` | exit 0 |

## Follow-up (out of scope)

**#1979** filed — pre-existing L01.FR.26 SHALL violation in `handleRequestTriggerMessage`'s `FirmwareStatusNotification` case: the trigger returns `Idle` instead of the last-sent status when the last-sent was a non-`Installed` terminal (`DownloadFailed`, `InvalidSignature`, `InstallationFailed`, `InstallVerificationFailed`). Root cause: no persistence of "last-sent notification" — `hasFirmwareUpdateInProgress` is used as a gate but is an "is-in-progress" predicate, not a "last-sent-status" projection. Full concrete fix design (interface addition + `sendFirmwareStatusNotification` touch + trigger handler rewrite + 4 test scenarios) in #1979. Independent of #1969; requires the "NO other changes" scope constraint of this PR to be lifted.

## Diff footprint

- `src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts`: `FirmwareStage` type + `FIRMWARE_STAGE_FAILURE_STATUS` `Record<Exclude<..>, ..>` with `satisfies`, stage tracker + init, 2 stage transitions, finally reset block with 3-guard + spec-anchor comment covering L01.FR.24 + L02.FR.15 + FirmwareStatusEnumType Idle restriction.
- `tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-UpdateFirmware.test.ts`: 8 tests in new describe block.
- `tests/helpers/TestLifecycleHelpers.ts`: 1 line added to `standardCleanup` — `OCPP20VariableManager.getInstance().resetRuntimeOverrides()` — to reset the per-station variable override singleton between tests (all mock stations share a hardcoded `hashId`; without the reset, per-station variable overrides leak).

## Review history

Seven internal review rounds; each round applied fixes for every VALID finding.

- **v1** — initial fix (stage tracker + basic `stage !== 'installed'` finally reset). Oracle + Explore concurred on a MAJOR race hazard: supersession launches T2 via the `AcceptedCanceled` branch of the constructor listener.
- **v2** — added `successorClaimed` guard (mirrors `clearActiveFirmwareUpdate`'s requestId-supersession pattern) + `isExplicitTerminal` guard (preserves `InvalidSignature`/`DownloadFailed`/`InstallationFailed` emitted from inside try) + 3 tests (race with emit, InvalidSignature preservation, retries-exhausted idempotence).
- **v3** — type alias moved to module scope; `finally` comment compressed; `activeRequestId` destructured; PR-review references stripped from test comment.
- **v4** — renamed `phase` → `stage` (Oracle: `phase` collides with electrical `phase` in the same file); replaced nested ternary with `Record<FirmwareStage, ...>` + `satisfies`; added L02.FR.15 clarification (Librarian: L02 lacks L01.FR.24's `*Failed` MAY clause); corrected commit body `(MAY)` → `optional`; filed #1979 with concrete fix design for pre-existing L01.FR.26 gap.
- **v5** — renamed `firmwareStageTerminal` → `FIRMWARE_STAGE_FAILURE_STATUS` (Explore + Oracle concurrence: SCREAMING_SNAKE_CASE for private module-scope `Record` lookup tables per codebase norm); tightened Record type to `Record<Exclude<FirmwareStage, 'installed'>, ...>` (remove unreachable `installed` entry, preserve compile-time exhaustiveness over failure-eligible key set).
- **v6** — Oracle rewrote the finally comment; test comment de-anchored from line numbers (all line numbers removed from source, tests, PR body, and issue #1979 body — symbol-name references only, since line numbers drift on every insertion). Applied Librarian F2 spec-strict fix: `Idle` restricted to download-phase clean aborts (per FirmwareStatusEnumType definition), install-phase clean aborts now collapse to `InstallationFailed`. Applied Explore F1.7: `OCPP20VariableManager.getInstance().resetRuntimeOverrides()` added to `standardCleanup`.
- **v7** — Oracle + Librarian concurred (2/2) on two spec-precision findings. Applied: (a) finally comment now cites `FirmwareStatusEnumType.Idle` SHALL restriction as the exclusionary anchor for why `Idle` cannot be a persistent local state after install starts + L01.FR.24 Note as the recognition anchor for `InstallationFailed` being spec-blessed for cancellation (rather than the prior imprecise cite of MAY-clause-alone for field-value justification, which conflated notification-emission permission with local-state-value permission); (b) Test 2 title extended from `(L01.FR.24 MAY)` to `(Idle TriggerMessage-only; L01.FR.24 MAY)` to reflect the dual anchor. Explore performed full audit of `standardCleanup` — 163 test-file call sites, 11 direct `OCPP20VariableManager` consumers — zero cross-test hazards, sub-microsecond perf impact, all safe. Librarian re-verified byte-exact spec quotes for `FirmwareStatusEnumType.Idle`/`InstallationFailed`/`DownloadFailed` and OCPP 2.1 forward-compat — no drift.