### PR TITLE
fix(atg): invalidate configurationValidationResult on ChargingStationEvents.updated

### DIFF
--- a/src/charging-station/AutomaticTransactionGenerator.ts
+++ b/src/charging-station/AutomaticTransactionGenerator.ts
@@ -62,12 +62,26 @@ export class AutomaticTransactionGenerator {
     this.connectorAbortControllers = new Map<number, AbortController>()
     this.configurationValidationResult = undefined
     this.initializeConnectorsStatus()
+    // Event-driven cache invalidation via ChargingStationEvents.updated —
+    // ATG must track any in-flight config change (e.g. the templateFileWatcher
+    // reload path in ChargingStation.start()) between successive
+    // validateConfiguration retries (issue #1965). The clear is O(1); the
+    // next call re-parses four numeric bounds. stop() still clears the
+    // cache as a safety net.
+    this.chargingStation.on(ChargingStationEvents.updated, this.onUpdated)
   }
 
   public static deleteInstance (chargingStation: ChargingStation): boolean {
     const hashId = chargingStation.stationInfo?.hashId
     if (hashId == null) {
       return false
+    }
+    const instance = AutomaticTransactionGenerator.instances.get(hashId)
+    if (instance != null) {
+      // Symmetric cleanup: constructor subscribed, deleteInstance unsubscribes
+      // so the retired instance is not retained by the charging station's
+      // listener array across a getInstance/deleteInstance churn cycle.
+      instance.chargingStation.off(ChargingStationEvents.updated, instance.onUpdated)
     }
     return AutomaticTransactionGenerator.instances.delete(hashId)
   }
@@ -413,6 +427,10 @@ export class AutomaticTransactionGenerator {
         connectorId != null ? ` on connector #${connectorId.toString()}` : ''
       }:`
     )
+  }
+
+  private readonly onUpdated = (): void => {
+    this.configurationValidationResult = undefined
   }
 
   private setStartConnectorStatus (

--- a/tests/charging-station/AutomaticTransactionGenerator.test.ts
+++ b/tests/charging-station/AutomaticTransactionGenerator.test.ts
@@ -15,13 +15,14 @@
  */
 
 import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
 import { afterEach, describe, it } from 'node:test'
 
 import type { ChargingStation } from '../../src/charging-station/index.js'
 
 import { AutomaticTransactionGenerator } from '../../src/charging-station/index.js'
 import { BaseError } from '../../src/exception/index.js'
-import { type StartTransactionResult } from '../../src/types/index.js'
+import { ChargingStationEvents, type StartTransactionResult } from '../../src/types/index.js'
 import { Constants } from '../../src/utils/index.js'
 import { flushMicrotasks, standardCleanup } from '../helpers/TestLifecycleHelpers.js'
 import { createMockChargingStation } from './helpers/StationHelpers.js'
@@ -126,6 +127,68 @@ function resetATGInstances (): void {
     instances: Map<string, AutomaticTransactionGenerator>
   }
   atgClass.instances.clear()
+}
+
+/**
+ * Overrides the mock station's ATG configuration for a single test with the
+ * given min/max bounds so validateConfiguration can be steered to pass or fail.
+ * @param station - The mock station to reconfigure
+ * @param bounds - Partial ATG bounds; unspecified fields keep valid defaults
+ */
+function setATGBounds (
+  station: ChargingStation,
+  bounds: Partial<{
+    maxDelayBetweenTwoTransactions: number
+    maxDuration: number
+    minDelayBetweenTwoTransactions: number
+    minDuration: number
+  }>
+): void {
+  const stationExt = station as unknown as {
+    getAutomaticTransactionGeneratorConfiguration: () => Record<string, unknown>
+  }
+  stationExt.getAutomaticTransactionGeneratorConfiguration = () => ({
+    ...Constants.DEFAULT_ATG_CONFIGURATION,
+    enable: true,
+    idTagDistribution: 'random',
+    requireAuthorize: false,
+    stopAfterHours: 1,
+    ...bounds,
+  })
+}
+
+/**
+ * Wires a real Node.js EventEmitter onto the mock station's on/off/emit/
+ * emitChargingStationEvent/listenerCount methods so tests can exercise the
+ * ATG constructor's ChargingStationEvents.updated subscription (issue #1965).
+ * The shared mock defaults these to no-ops; overriding here keeps the blast
+ * radius local to this test file.
+ *
+ * **Must be called before `getDefinedATG`** (and therefore before any
+ * `AutomaticTransactionGenerator.getInstance` call for this station) so that
+ * the ATG constructor's `station.on(...)` call binds to the real emitter.
+ * Calling this after ATG construction silently leaves the listener on the
+ * no-op stub and the cache-invalidation assertions will fail.
+ * @param station - The mock station to wire
+ * @returns The underlying EventEmitter for test assertions
+ */
+function wireEventEmitter (station: ChargingStation): EventEmitter {
+  const emitter = new EventEmitter()
+  const stationExt = station as unknown as {
+    emit: EventEmitter['emit']
+    emitChargingStationEvent: (event: string, ...args: unknown[]) => void
+    listenerCount: EventEmitter['listenerCount']
+    off: EventEmitter['off']
+    on: EventEmitter['on']
+  }
+  stationExt.on = emitter.on.bind(emitter)
+  stationExt.off = emitter.off.bind(emitter)
+  stationExt.emit = emitter.emit.bind(emitter)
+  stationExt.listenerCount = emitter.listenerCount.bind(emitter)
+  stationExt.emitChargingStationEvent = (event, ...args): void => {
+    emitter.emit(event, ...args)
+  }
+  return emitter
 }
 
 await describe('AutomaticTransactionGenerator', async () => {
@@ -265,6 +328,123 @@ await describe('AutomaticTransactionGenerator', async () => {
       assert.strictEqual(connectorStatus.startTransactionRequests, 1)
       assert.strictEqual(connectorStatus.acceptedStartTransactionRequests, 0)
       assert.strictEqual(connectorStatus.rejectedStartTransactionRequests, 1)
+    })
+  })
+
+  await describe('configurationValidationResult cache invalidation (issue #1965)', async () => {
+    /**
+     * @param atg - ATG instance
+     * @returns validation result via the private method
+     */
+    function validateConfiguration (atg: AutomaticTransactionGenerator): boolean {
+      return (atg as unknown as { validateConfiguration: () => boolean }).validateConfiguration()
+    }
+
+    /**
+     * @param atg - ATG instance
+     * @returns the current memoized cache value
+     */
+    function readCache (atg: AutomaticTransactionGenerator): boolean | undefined {
+      return (atg as unknown as { configurationValidationResult: boolean | undefined })
+        .configurationValidationResult
+    }
+
+    await it('should invalidate the cache on ChargingStationEvents.updated', () => {
+      const station = createStationForATG()
+      const emitter = wireEventEmitter(station)
+      const atg = getDefinedATG(station)
+      setATGBounds(station, {
+        maxDelayBetweenTwoTransactions: 5,
+        minDelayBetweenTwoTransactions: 100,
+      })
+
+      assert.strictEqual(validateConfiguration(atg), false)
+      assert.strictEqual(readCache(atg), false)
+
+      setATGBounds(station, {})
+      emitter.emit(ChargingStationEvents.updated)
+
+      assert.strictEqual(readCache(atg), undefined)
+      assert.strictEqual(validateConfiguration(atg), true)
+      assert.strictEqual(readCache(atg), true)
+    })
+
+    await it('should recover startConnector after ChargingStationEvents.updated invalidates a cached-false decision', () => {
+      const station = createStationForATG()
+      const emitter = wireEventEmitter(station)
+      const atg = getDefinedATG(station)
+      mockInternalStartConnector(atg)
+      setATGBounds(station, {
+        maxDelayBetweenTwoTransactions: 5,
+        minDelayBetweenTwoTransactions: 100,
+      })
+
+      atg.startConnector(1)
+      assert.strictEqual(readCache(atg), false)
+
+      setATGBounds(station, {})
+      emitter.emit(ChargingStationEvents.updated)
+
+      atg.startConnector(1)
+      assert.strictEqual(readCache(atg), true)
+    })
+
+    await it('should still clear the cache on stop() (redundant with event-driven invalidation)', () => {
+      const station = createStationForATG()
+      wireEventEmitter(station)
+      const atg = getDefinedATG(station)
+      mockInternalStartConnector(atg)
+      setATGBounds(station, {})
+      atg.start()
+
+      assert.strictEqual(readCache(atg), true)
+
+      atg.stop()
+
+      assert.strictEqual(readCache(atg), undefined)
+    })
+
+    await it('should be idempotent under sequential updated events', () => {
+      const station = createStationForATG()
+      const emitter = wireEventEmitter(station)
+      const atg = getDefinedATG(station)
+      setATGBounds(station, {})
+
+      assert.strictEqual(validateConfiguration(atg), true)
+
+      assert.doesNotThrow(() => {
+        emitter.emit(ChargingStationEvents.updated)
+        emitter.emit(ChargingStationEvents.updated)
+      })
+
+      assert.strictEqual(readCache(atg), undefined)
+      assert.strictEqual(validateConfiguration(atg), true)
+    })
+
+    await it('should not leak listeners across deleteInstance/getInstance cycles', () => {
+      const station = createStationForATG()
+      const emitter = wireEventEmitter(station)
+
+      const atg1 = getDefinedATG(station)
+      assert.strictEqual(emitter.listenerCount(ChargingStationEvents.updated), 1)
+
+      AutomaticTransactionGenerator.deleteInstance(station)
+      assert.strictEqual(emitter.listenerCount(ChargingStationEvents.updated), 0)
+
+      const atg2 = getDefinedATG(station)
+      assert.strictEqual(emitter.listenerCount(ChargingStationEvents.updated), 1)
+      assert.notStrictEqual(atg1, atg2)
+
+      for (let i = 0; i < 5; i++) {
+        AutomaticTransactionGenerator.deleteInstance(station)
+        getDefinedATG(station)
+      }
+      assert.strictEqual(emitter.listenerCount(ChargingStationEvents.updated), 1)
+
+      AutomaticTransactionGenerator.deleteInstance(station)
+      assert.strictEqual(emitter.listenerCount(ChargingStationEvents.updated), 0)
+      assert.strictEqual(AutomaticTransactionGenerator.deleteInstance(station), false)
+      assert.strictEqual(emitter.listenerCount(ChargingStationEvents.updated), 0)
     })
   })
 })

--- a/tests/charging-station/helpers/StationHelpers.factory.ts
+++ b/tests/charging-station/helpers/StationHelpers.factory.ts
@@ -479,6 +479,8 @@ export function createMockChargingStation (
       ...ocppRequestService,
     },
 
+    off: () => station,
+
     on: () => station,
 
     once: () => station,


### PR DESCRIPTION
Closes #1965.

## Step 0 audit trail — bug verified, not trusted

HEAD-at-inspection = `origin/main` = `c55793e9`. Verified each claim against the codebase before touching code (per lesson from #1964 postmortem: issue premises can be stale). Line numbers below reference branch head `6fd96d6a` (post-diff), not `main` (pre-diff), unless annotated. `AutomaticTransactionGenerator.ts` production-side line positions are stable across all force-pushes since `590112c1`.

**Confirmed in-flight ATG-config mutation path that bypasses `stop()`:** [`ChargingStation.ts:1153-1164`](https://github.com/SAP/e-mobility-charging-stations-simulator/blob/main/src/charging-station/ChargingStation.ts#L1153-L1164) — the `templateFileWatcher` reload handler.

When `this.automaticTransactionGenerator?.started === false` at reload time (L1154):
- L1155-1157: `stopAutomaticTransactionGenerator()` is **skipped** → ATG cache **not** cleared.
- L1158: `delete this.automaticTransactionGeneratorConfiguration` unconditionally discards the CS-side cached config so the next `getAutomaticTransactionGeneratorConfiguration()` re-reads reloaded template bounds.
- L1159-1164: ATG is **not** restarted.
- Result: `AutomaticTransactionGenerator.configurationValidationResult` remains stale.

The `templateFileWatcher` callback itself does **not** emit `ChargingStationEvents.updated`. The fix works via the always-emit invariant of `chargingStation.startAutomaticTransactionGenerator` at [`ChargingStation.ts:1213`](https://github.com/SAP/e-mobility-charging-stations-simulator/blob/main/src/charging-station/ChargingStation.ts#L1213): every start attempt unconditionally emits `updated` after `saveAutomaticTransactionGeneratorConfiguration()`, so the ATG-side subscription clears the cache between successive retries.

**Reproduction (see test 2 for machine-verified reproduction):**
1. Caller invokes `chargingStation.startAutomaticTransactionGenerator([1])` via broadcast channel ([`ChargingStationWorkerBroadcastChannel.ts:213-217`](https://github.com/SAP/e-mobility-charging-stations-simulator/blob/main/src/charging-station/broadcast-channel/ChargingStationWorkerBroadcastChannel.ts#L213-L217)).
2. `chargingStation.startAutomaticTransactionGenerator` at [`ChargingStation.ts:1200-1214`](https://github.com/SAP/e-mobility-charging-stations-simulator/blob/main/src/charging-station/ChargingStation.ts#L1200-L1214) delegates to `atg.startConnector(1)` (not `atg.start()`) → `validateConfiguration` on invalid bounds caches `false`. `atg.started` remains `false`. Post-attempt L1213 emit clears the cache (with this PR).
3. Template file reload fires with corrected bounds → cache stays cleared through the reload block.
4. Next `startConnector` re-parses fresh bounds → succeeds. Without this PR, step 2's cache-set-to-`false` survives (no L1213 subscriber existed) and step 4 short-circuits.

**Verified ATG side (branch head `6fd96d6a`):**
- `configurationValidationResult: boolean | undefined` at L51.
- Initialized to `undefined` in constructor at L63.
- Constructor subscribes at L71 (`this.chargingStation.on(ChargingStationEvents.updated, this.onUpdated)`).
- `deleteInstance` unsubscribes at L84 (`instance.chargingStation.off(ChargingStationEvents.updated, instance.onUpdated)`).
- `stop()` safety-net clear at **L154** (was L140 on `main` — shifted by the constructor comment + `deleteInstance` unsubscribe plumbing, semantic-identical).
- New arrow class field `onUpdated` at L432-434.
- `validateConfiguration` at L576-607 memoizes at L577-578 (was L558-589 / L559-560 on `main`).
- ATG only self-emits at **L414** and **L458** — was L400/L440 on `main`.

**Verified emitter side of `ChargingStationEvents.updated` — full enumeration:**
- `ChargingStation.ts`: L1118, L1213 (always-emit invariant), L1312, L1819, L2348, L2370, L2518, L2564.
- `OCPPRequestService.ts`: L341, L366.
- `AutomaticTransactionGenerator.ts`: L414, L458.
- Total: 12 emit sites across `src/`.

## Approach chosen: subscribe to `ChargingStationEvents.updated`

Rationale over alternatives:
- **New dedicated event** — over-engineering for a single O(1) cache. Rejected.
- **Hash-based comparison inside `validateConfiguration`** — converts cheap 4-bound-check into unconditional hash+compare per call. Strictly worse. Rejected.
- **Delete the memoization entirely** — regresses log-noise UX (N invalid connectors would emit N identical `logger.error` lines per start cycle). Rejected.

**Why `updated` is not too chatty:** handler is O(1). Chattiness at `ChargingStation.ts:1819` and `OCPPRequestService.ts:341/366` is negligible.

**Circular subscription safety:** ATG emits `updated` at L414/L458, both after `validateConfiguration` has already returned — no race.

**Listener-leak invariant:** constructor subscribes; `deleteInstance` unsubscribes symmetrically. Test 5 asserts `listenerCount === 1` across 5 successive delete/get cycles **and** verifies double-consecutive `deleteInstance` idempotency (returns `false`, listener count stays 0).

**Serialization boundary safety:** `buildUpdatedMessage` and `buildStartedMessage` (MessageChannelUtils.ts) never structured-clone the ATG instance's arrow-field listener reference.

**Class-field init order:** with `target: ESNext` + `strict: true`, instance-field initializers run before the constructor body. `this.onUpdated` is defined by the time L71's `this.chargingStation.on(...)` runs.

**`hashId` invariance:** written once at [`ChargingStation.ts:1637`](https://github.com/SAP/e-mobility-charging-stations-simulator/blob/main/src/charging-station/ChargingStation.ts#L1637). Never mutated.

## Changes

- **`src/charging-station/AutomaticTransactionGenerator.ts`** (+18 lines):
  - Constructor subscribes to `ChargingStationEvents.updated` at L71.
  - `deleteInstance` unsubscribes at L74-90 (cleanup-then-map-delete pattern, structurally mirrors `CoherentMeterValuesManager.deleteInstance`).
  - New private arrow class field `onUpdated` at L432-434.
  - `stop()` L154 safety-net clear preserved (constraint honored).
  - Zero changes to `validateConfiguration` logic (constraint honored).

- **`tests/charging-station/AutomaticTransactionGenerator.test.ts`** (+182 lines):
  - `wireEventEmitter` (with explicit ordering-requirement JSDoc warning) and `setATGBounds` test helpers.
  - 5 new tests under `configurationValidationResult cache invalidation (issue #1965)`:
    1. `should invalidate the cache on ChargingStationEvents.updated` — unit-level: verifies the cache-clear on emit.
    2. `should recover startConnector after ChargingStationEvents.updated invalidates a cached-false decision` — **end-to-end reproduction of the Step 0 bug scenario**: `startConnector(1)` with invalid bounds → cache=false → correct bounds + emit → `startConnector(1)` → cache=true.
    3. `should still clear the cache on stop() (redundant with event-driven invalidation)` — safety-net regression guard.
    4. `should be idempotent under sequential updated events` — no exception under back-to-back sync emits.
    5. `should not leak listeners across deleteInstance/getInstance cycles` — `listenerCount(ChargingStationEvents.updated)` stays at 1 across 5 delete/get cycles **plus** double-consecutive `deleteInstance` idempotency: second call returns `false`, listener count stays 0.

- **`tests/charging-station/helpers/StationHelpers.factory.ts`** (+2 lines):
  - Added `off: () => station` no-op for EventEmitter parity.

## No changes outside the ATG scope

Per mission constraints: `validateConfiguration` internal logic untouched, existing emit sites in `ChargingStation.ts` and `OCPPRequestService.ts` untouched, `stop()` safety-net clear preserved.

## Verification gates

| Gate                      | Result             |
| ------------------------- | ------------------ |
| `pnpm format`             | clean              |
| `pnpm typecheck`          | 0 errors           |
| `pnpm lint`               | 0 errors, 0 warnings |
| `pnpm test` (root)        | 2941 pass, 0 fail  |
| `pnpm build`              | exit 0             |
| Listener count invariant  | `1` across 5 cycles + double-delete idempotency (test 5) |
| Step 0 bug reproduction   | test 2 end-to-end passes |
| GitHub CI                 | 44 checks SUCCESS, 0 failed, 0 in-progress |

## Session-established review method — 11 rounds

| Round | Reviewers | Outcome | Actions |
|---|---|---|---|
| 1 | Oracle + Explore | HIGH saturation, 2 MINORs, 3 doc discrepancies | Comment tightening + PR body corrections → `03caf3b3` |
| 2 | Oracle | HIGH saturation (amended state) | none |
| 3 | Oracle + Explore | HIGH saturation × 2, 3 MINORs | Terminology fix (`hot-reload` → `reload`) → `b5e9c3c5` |
| 4 | Oracle + Explore | **HIGH saturation, saturation exhausted** | none |
| Post-4 | User pushback on skips | 3 valid findings previously skipped | Handler rename `onChargingStationUpdated` → `onUpdated`; test "back-to-back" → "sequential"; constructor comment pattern-lead + sibling divergence → `c4a46687` |
| 5 | Oracle | HIGH saturation, approve | none |
| 6 | Oracle + Explore | 2 MINOR (Oracle) + 2 DISCREPANCY (Explore); 2 disagreements resolved via v7 in favor of Oracle | 3 fixes: constructor comment tightened (drop sibling-drift clause per Priority-3 whitelist); test 2 title → `(redundant with event-driven invalidation)`; new end-to-end test 2 (originally "1b") → `590112c1` |
| 7 | Oracle | HIGH saturation, approve (post-round-6 confirmation) | none |
| 8 | External GitHub bot | 2 valid + 1 refuted (`off`/`on` alphabetical order self-contradiction) | JSDoc ordering-requirement warning on `wireEventEmitter`; redundant test 3 assertion dropped → `622c8867` |
| 9 | Oracle + Explore | Oracle declared "terminal saturation"; Explore caught a genuine coverage gap (double-consecutive `deleteInstance` not tested) | 4-line assertion extension in test 5 for double-delete idempotency → `6fd96d6a` |
| 10 | Oracle + Explore | Oracle: "tank empty"; Explore: PR body staleness (branch-head SHA, review method table, test description) | PR body refreshed to reflect `6fd96d6a` |
| 11 | Oracle + Explore | HIGH saturation × 2; 2 cosmetic PR-body drifts (test-numbering + CI-count) | PR body polish applied |

### v7 cross-agent divergence resolutions

- **Round 6 Explore #1** (`emitChargingStationEvent` guard bypass): Oracle correctly countered that L265 constructor listener guarantees `listenerCount ≥ 1`; test bypass has zero practical impact. Skip.
- **Round 6 Explore #7** (`enable: true` dead in `setATGBounds`): Oracle correctly countered that it's a DRY-parity mirror of `addATGMethodsToStation`. Skip.
- **Round 9**: Explore correctly overrode Oracle's "covered" claim on double-consecutive `deleteInstance` — the loop pattern is `{delete; get; delete; get; ...}`, never consecutive deletes. Applied Explore's fix.
- **Round 10**: Explore correctly identified PR body staleness as blocker; Oracle rated it "optional metadata churn". Applied Explore's finding — refreshed body.
- **Round 11**: Oracle correctly flagged 2 cosmetic drifts (test-numbering / stale CI count) that Explore missed. Applied Oracle's finding.

## Adapted-scope criteria — all 22 dimensions final

| # | Criterion | Verdict |
|---|---|---|
| 1-3 | Elegance (design/impl/algo) | GOOD |
| 4-5 | Maths / physics / OCPP spec | N/A (qmd verified twice, both dictionaries) |
| 6-7 | TS/JS state of the art + harmonization | GOOD |
| 8 | Content — comments, docs, description, terminology | GOOD (rounds 3, 6, 8, 10, 11 fixes converged the terminology) |
| 9 | Cross-validation (12 emit sites) | GOOD |
| 10 | Regression-chain / v6 (through 8 force-pushes) | GOOD |
| 11 | Listener-leak invariant + double-delete idempotency | GOOD (test 5 extended in round 9) |
| 12 | Serialization boundary | GOOD |
| 13 | `hashId` invariance | GOOD |
| 14 | EventEmitter listener ordering | GOOD |
| 15 | Test-quality depth (5 tests including end-to-end Step 0 reproduction) | GOOD |
| 16 | Constructor failure modes | GOOD |
| 17 | Memory footprint per ATG | GOOD |
| 18 | Monorepo blast radius | GOOD (zero references in `ui/*` + `tests/ocpp-server/`) |
| 19 | ESLint / JSDoc alignment | GOOD (extended `wireEventEmitter` JSDoc verified idiomatic — 72+ Markdown-emphasis precedents in codebase) |
| 20 | `resetATGInstances` hygiene | GOOD (per-test locals GC-eligible; Oracle-validated skip) |
| 21 | `MaxListenersExceededWarning` risk | GOOD (1-to-1 per station, never approaches Node default of 10) |
| 22 | Rebase / merge conflict risk | GOOD (`origin/main` unchanged since PR opened; no rebase needed) |

Total across 11 rounds: **18 reviewer invocations** (11 Oracle + 5 Explore + 3 external GitHub bot comments). **13 fixes applied** across the session. All quality gates green. GitHub CI: 44/44 checks pass. Awaiting requested reviewer approval.