### PR TITLE
fix(ocpp): drive FirmwareStatusNotification trigger from last-sent notification (L01.FR.26)

### DIFF
--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -262,6 +262,11 @@ const FIRMWARE_STAGE_FAILURE_STATUS = {
   install: OCPP20FirmwareStatusEnumType.InstallationFailed,
 } as const satisfies Record<Exclude<FirmwareStage, 'installed'>, OCPP20FirmwareStatusEnumType>
 
+interface LastFirmwareStatusNotification {
+  requestId: number
+  status: OCPP20FirmwareStatusEnumType
+}
+
 interface OCPP20StationState {
   activeFirmwareUpdateAbortController?: AbortController
   activeFirmwareUpdateRequestId?: number
@@ -270,6 +275,7 @@ interface OCPP20StationState {
   activeLogUploadStatus?: UploadLogStatusEnumType
   certSigningRetryManager?: OCPP20CertSigningRetryManager
   isDrainingSecurityEvents: boolean
+  lastFirmwareStatusNotification?: LastFirmwareStatusNotification
   preInoperativeConnectorStatuses: Map<number, OCPP20ConnectorStatusEnumType>
   reportDataCache: Map<number, ReportDataType[]>
   securityEventQueue: QueuedSecurityEvent[]
@@ -574,22 +580,24 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
               .catch(errorHandler)
             break
           case MessageTriggerEnumType.FirmwareStatusNotification: {
-            const stationState = this.stationsState.get(chargingStation)
-            const requestId = stationState?.activeFirmwareUpdateRequestId
-            const firmwareStatus =
-              requestId != null && this.hasFirmwareUpdateInProgress(chargingStation)
-                ? (chargingStation.stationInfo?.firmwareStatus as OCPP20FirmwareStatusEnumType)
-                : OCPP20FirmwareStatusEnumType.Idle
+            // L01.FR.25 & L02.FR.16 — last-sent = Installed → { status: Idle }.
+            // L01.FR.26 & L02.FR.17 — last-sent ≠ Installed → { requestId, status: <last-sent> }.
+            // L01.FR.20 & L02.FR.14 — requestId mandatory unless status = Idle.
+            // Fresh station (no notification ever sent): Idle (spec-silent precondition,
+            // consistent with FirmwareStatusEnumType.Idle §3.33 "trigger-only" restriction).
+            const lastSent = this.stationsState.get(chargingStation)?.lastFirmwareStatusNotification
+            const payload: OCPP20FirmwareStatusNotificationRequest =
+              lastSent == null || lastSent.status === OCPP20FirmwareStatusEnumType.Installed
+                ? { status: OCPP20FirmwareStatusEnumType.Idle }
+                : { requestId: lastSent.requestId, status: lastSent.status }
             chargingStation.ocppRequestService
               .requestHandler<
                 OCPP20FirmwareStatusNotificationRequest,
                 OCPP20FirmwareStatusNotificationResponse
-              >(
-                chargingStation,
-                OCPP20RequestCommand.FIRMWARE_STATUS_NOTIFICATION,
-                { requestId, status: firmwareStatus },
-                { skipBufferingOnError: true, triggerMessage: true }
-              )
+              >(chargingStation, OCPP20RequestCommand.FIRMWARE_STATUS_NOTIFICATION, payload, {
+                skipBufferingOnError: true,
+                triggerMessage: true,
+              })
               .catch(errorHandler)
             break
           }
@@ -3536,6 +3544,12 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService {
   ): Promise<OCPP20FirmwareStatusNotificationResponse> {
     if (chargingStation.stationInfo != null) {
       chargingStation.stationInfo.firmwareStatus = status
+    }
+    // L01.FR.26 & L02.FR.17 last-sent projection: persistent source of truth for the
+    // trigger case, distinct from `stationInfo.firmwareStatus` (state-machine field reset by #1976).
+    this.getOrCreateStationState(chargingStation).lastFirmwareStatusNotification = {
+      requestId,
+      status,
     }
     return chargingStation.ocppRequestService.requestHandler<
       OCPP20FirmwareStatusNotificationRequest,

--- a/src/charging-station/ocpp/2.0/__testable__/index.ts
+++ b/src/charging-station/ocpp/2.0/__testable__/index.ts
@@ -27,6 +27,8 @@ import type {
   OCPP20DataTransferResponse,
   OCPP20DeleteCertificateRequest,
   OCPP20DeleteCertificateResponse,
+  OCPP20FirmwareStatusEnumType,
+  OCPP20FirmwareStatusNotificationResponse,
   OCPP20GetBaseReportRequest,
   OCPP20GetBaseReportResponse,
   OCPP20GetInstalledCertificateIdsRequest,
@@ -259,6 +261,12 @@ interface TestableOCPP20IncomingRequestService {
     presentedIdToken: OCPP20IdTokenType,
     presentedGroupIdToken?: OCPP20IdTokenType
   ) => boolean
+
+  sendFirmwareStatusNotification: (
+    chargingStation: ChargingStation,
+    status: OCPP20FirmwareStatusEnumType,
+    requestId: number
+  ) => Promise<OCPP20FirmwareStatusNotificationResponse>
 }
 
 /**
@@ -308,6 +316,7 @@ export function createTestableIncomingRequestService (
     handleRequestUnlockConnector: serviceImpl.handleRequestUnlockConnector.bind(service),
     handleRequestUpdateFirmware: serviceImpl.handleRequestUpdateFirmware.bind(service),
     isAuthorizedToStopTransaction: serviceImpl.isAuthorizedToStopTransaction.bind(service),
+    sendFirmwareStatusNotification: serviceImpl.sendFirmwareStatusNotification.bind(service),
   }
 }
 

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-TriggerMessage.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-TriggerMessage.test.ts
@@ -7,6 +7,7 @@ import assert from 'node:assert/strict'
 import { afterEach, beforeEach, describe, it, mock } from 'node:test'
 
 import type {
+  OCPP20FirmwareStatusNotificationRequest,
   OCPP20MeterValuesRequest,
   OCPP20StatusNotificationRequest,
   OCPP20TriggerMessageRequest,
@@ -19,6 +20,7 @@ import { createTestableIncomingRequestService } from '../../../../src/charging-s
 import { OCPP20IncomingRequestService } from '../../../../src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.js'
 import {
   MessageTriggerEnumType,
+  OCPP20FirmwareStatusEnumType,
   OCPP20IncomingRequestCommand,
   OCPP20MeasurandEnumType,
   OCPP20ReadingContextEnumType,
@@ -650,5 +652,143 @@ await describe('F06 - TriggerMessage', async () => {
 
       assert.strictEqual(rejectingMock.mock.callCount(), 1)
     })
+  })
+
+  await describe('F06 - FirmwareStatusNotification trigger last-sent semantics (L01.FR.20/25/26, L02.FR.14/16/17)', async () => {
+    let incomingRequestServiceForListener: OCPP20IncomingRequestService
+    let mockStation: MockChargingStation
+    let requestHandlerMock: ReturnType<typeof mock.fn>
+    let testableService: ReturnType<typeof createTestableIncomingRequestService>
+
+    beforeEach(() => {
+      ;({ mockStation, requestHandlerMock } = createTriggerMessageStation())
+      incomingRequestServiceForListener = new OCPP20IncomingRequestService()
+      testableService = createTestableIncomingRequestService(incomingRequestServiceForListener)
+    })
+
+    /**
+     * Emit TRIGGER_MESSAGE(FirmwareStatusNotification) with an Accepted response and
+     * capture the resulting requestHandler payload.
+     * @returns The captured request handler payload and the options object it was invoked with
+     */
+    function captureTriggeredFirmwareStatusPayload (): {
+      options: RequestParams
+      payload: OCPP20FirmwareStatusNotificationRequest
+    } {
+      const request: OCPP20TriggerMessageRequest = {
+        requestedMessage: MessageTriggerEnumType.FirmwareStatusNotification,
+      }
+      const response: OCPP20TriggerMessageResponse = {
+        status: TriggerMessageStatusEnumType.Accepted,
+      }
+      incomingRequestServiceForListener.emit(
+        OCPP20IncomingRequestCommand.TRIGGER_MESSAGE,
+        mockStation,
+        request,
+        response
+      )
+      assert.strictEqual(requestHandlerMock.mock.callCount(), 1)
+      const args = requestHandlerMock.mock.calls[0].arguments as [
+        unknown,
+        string,
+        OCPP20FirmwareStatusNotificationRequest,
+        RequestParams
+      ]
+      const [, command, payload, options] = args
+      assert.strictEqual(command, OCPP20RequestCommand.FIRMWARE_STATUS_NOTIFICATION)
+      return { options, payload }
+    }
+
+    /**
+     * Persist a last-sent FirmwareStatusNotification via the real code path, then
+     * reset the mock's call history so subsequent capture assertions see only the
+     * trigger-fired emission.
+     * @param status - The FirmwareStatusNotification status to persist
+     * @param requestId - The requestId to persist
+     */
+    async function seedLastFirmwareStatusNotification (
+      status: OCPP20FirmwareStatusEnumType,
+      requestId: number
+    ): Promise<void> {
+      await testableService.sendFirmwareStatusNotification(mockStation, status, requestId)
+      requestHandlerMock.mock.resetCalls()
+    }
+
+    await it('should emit { requestId, status: DownloadFailed } after DownloadFailed (L01.FR.26)', async () => {
+      await seedLastFirmwareStatusNotification(OCPP20FirmwareStatusEnumType.DownloadFailed, 42)
+
+      const { options, payload } = captureTriggeredFirmwareStatusPayload()
+
+      assert.deepStrictEqual(payload, {
+        requestId: 42,
+        status: OCPP20FirmwareStatusEnumType.DownloadFailed,
+      })
+      assert.strictEqual(options.skipBufferingOnError, true)
+      assert.strictEqual(options.triggerMessage, true)
+    })
+
+    await it('should emit { requestId, status: InvalidSignature } after InvalidSignature (L01.FR.26)', async () => {
+      await seedLastFirmwareStatusNotification(OCPP20FirmwareStatusEnumType.InvalidSignature, 7)
+
+      const { payload } = captureTriggeredFirmwareStatusPayload()
+
+      assert.deepStrictEqual(payload, {
+        requestId: 7,
+        status: OCPP20FirmwareStatusEnumType.InvalidSignature,
+      })
+    })
+
+    await it('should emit { requestId, status: InstallationFailed } after InstallationFailed (L01.FR.26)', async () => {
+      await seedLastFirmwareStatusNotification(OCPP20FirmwareStatusEnumType.InstallationFailed, 99)
+
+      const { payload } = captureTriggeredFirmwareStatusPayload()
+
+      assert.deepStrictEqual(payload, {
+        requestId: 99,
+        status: OCPP20FirmwareStatusEnumType.InstallationFailed,
+      })
+    })
+
+    await it('should emit { status: Idle } after Installed (L01.FR.25 regression)', async () => {
+      await seedLastFirmwareStatusNotification(OCPP20FirmwareStatusEnumType.Installed, 42)
+
+      const { payload } = captureTriggeredFirmwareStatusPayload()
+
+      assert.deepStrictEqual(payload, { status: OCPP20FirmwareStatusEnumType.Idle })
+      assert.strictEqual(payload.requestId, undefined)
+    })
+
+    await it('should emit { status: Idle } on a fresh station (no notification ever sent)', () => {
+      const { payload } = captureTriggeredFirmwareStatusPayload()
+
+      assert.deepStrictEqual(payload, { status: OCPP20FirmwareStatusEnumType.Idle })
+      assert.strictEqual(payload.requestId, undefined)
+    })
+
+    const nonInstalledStatuses: OCPP20FirmwareStatusEnumType[] = [
+      OCPP20FirmwareStatusEnumType.DownloadFailed,
+      OCPP20FirmwareStatusEnumType.DownloadPaused,
+      OCPP20FirmwareStatusEnumType.DownloadScheduled,
+      OCPP20FirmwareStatusEnumType.Downloaded,
+      OCPP20FirmwareStatusEnumType.Downloading,
+      OCPP20FirmwareStatusEnumType.InstallRebooting,
+      OCPP20FirmwareStatusEnumType.InstallScheduled,
+      OCPP20FirmwareStatusEnumType.InstallVerificationFailed,
+      OCPP20FirmwareStatusEnumType.InstallationFailed,
+      OCPP20FirmwareStatusEnumType.Installing,
+      OCPP20FirmwareStatusEnumType.InvalidSignature,
+      OCPP20FirmwareStatusEnumType.SignatureVerified,
+    ]
+    for (const [index, status] of nonInstalledStatuses.entries()) {
+      const requestId = 1000 + index
+      await it(`should echo { requestId: ${requestId.toString()}, status: ${status} } (L01.FR.20 & L01.FR.26)`, async () => {
+        await seedLastFirmwareStatusNotification(status, requestId)
+
+        const { payload } = captureTriggeredFirmwareStatusPayload()
+
+        assert.strictEqual(payload.status, status)
+        assert.strictEqual(payload.requestId, requestId)
+      })
+    }
   })
 })


### PR DESCRIPTION
Closes #1979.

## Bug

`OCPP20IncomingRequestService`, in the `FirmwareStatusNotification` case of the `TRIGGER_MESSAGE` listener, gated the emitted `FirmwareStatusNotification` on `activeFirmwareUpdateRequestId != null && hasFirmwareUpdateInProgress()` and fell back to `Idle` otherwise. `hasFirmwareUpdateInProgress` returns `false` for every terminal firmware status (`DownloadFailed`, `InvalidSignature`, `InstallationFailed`, `InstallVerificationFailed`, `Installed`). After any non-`Installed` terminal was emitted from `simulateFirmwareUpdateLifecycle`, an incoming `TriggerMessage(FirmwareStatusNotification)` returned `Idle` instead of the last-sent status — a SHALL violation of L01.FR.26 (and its L02.FR.17 mirror).

## OCPP spec anchors

Verbatim from `OCPP-2.0.1_edition3_part2_specification.md`:

- **L01.FR.25** (Table 193): *"Charging Station receives a TriggerMessageRequest for FirmwareStatusNotification AND last sent FirmwareStatusNotificationRequest had status = Installed"* → *"Charging Station SHALL return a FirmwareStatusNotificationRequest with status = Idle."*
- **L01.FR.26** (Table 193): *"Charging Station receives a TriggerMessageRequest for FirmwareStatusNotification AND last sent FirmwareStatusNotificationRequest had NOT status Installed"* → *"Charging Station SHALL return a FirmwareStatusNotificationRequest with the last sent status."* — **the violated SHALL**.
- **L01.FR.20** (Table 193): *"The field requestId in FirmwareStatusNotificationRequest is mandatory, unless status = Idle."*
- **FirmwareStatusEnumType** (§ 3.33), value `Idle`: *"Charging Station is not performing firmware update related tasks. Status Idle SHALL only be used as in a FirmwareStatusNotificationRequest that was triggered by TriggerMessageRequest."*
- **L02.FR.16 / L02.FR.17** (Table 195, Non-Secure Firmware): mirror L01.FR.25 / L01.FR.26 byte-for-byte (verified verbatim). **L02.FR.14** mirrors L01.FR.20 byte-for-byte. The single unified trigger path in `OCPP20IncomingRequestService` covers both use cases, so this fix satisfies L01 and L02 in one change.

## Fix (three touchpoints, ~15 SLOC net)

1. **Extend `OCPP20StationState`** with an optional `lastFirmwareStatusNotification: { requestId: number; status: OCPP20FirmwareStatusEnumType }` (alphabetized).
2. **Persist inside `sendFirmwareStatusNotification`** immediately after the existing `stationInfo.firmwareStatus = status` assignment — every emission path writes it.
3. **Replace the `FirmwareStatusNotification` trigger case body** with a last-sent-driven emit:
   - `lastSent == null` OR `lastSent.status === Installed` → `{ status: Idle }` (L01.FR.25 + fresh station)
   - else → `{ requestId: lastSent.requestId, status: lastSent.status }` (L01.FR.26)

The trigger case body uses a typed local `payload: OCPP20FirmwareStatusNotificationRequest` — control-flow narrowing on the `Installed` discriminant gives a clean typed result without the `as OCPP20FirmwareStatusNotificationRequest` cast that appeared in the issue's design sketch.

## Dual-source rationale (deliberate, documented)

`stationInfo.firmwareStatus` is retained. Its three downstream consumers — `handleRequestReset` firmware-update rejection ([L2336](src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts#L2336)), `isChargingStationIdle` ([L3304](src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts#L3304)), `isEvseIdle` ([L3319](src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts#L3319)) — all use `hasFirmwareUpdateInProgress`, an **"is an update currently running?" predicate**, not an "L01.FR.26 last-sent projection". The two projections are orthogonal:

| Source | Semantics | Consumers |
| --- | --- | --- |
| `stationInfo.firmwareStatus` | "in-progress" predicate via `hasFirmwareUpdateInProgress` (non-terminals only) | Reset gate, station-idle, EVSE-idle |
| `lastFirmwareStatusNotification` | "last-sent" projection (L01.FR.25 / L01.FR.26 / L02.FR.16 / L02.FR.17) | `TriggerMessage(FirmwareStatusNotification)` |

Unifying them is out of scope for this L01.FR.26 fix and would change reset-gate / idle-predicate behavior. The dual-source is anchored at the persistence site by an inline OCPP spec comment.

## Test coverage

Added to [`tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-TriggerMessage.test.ts`](tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-TriggerMessage.test.ts) under new describe `F06 - FirmwareStatusNotification trigger last-sent semantics (L01.FR.20/25/26, L02.FR.14/16/17)`. State is seeded through the real `sendFirmwareStatusNotification` code path via the testable interface, then the trigger event is emitted and the resulting request-handler payload is asserted.

| # | Scenario | Assertion | Anchor |
| - | -------- | --------- | ------ |
| 1 | Post-`DownloadFailed` (retries exhausted) | `{ requestId: 42, status: DownloadFailed }` + `skipBufferingOnError` + `triggerMessage` | L01.FR.26 |
| 2 | Post-`InvalidSignature` | `{ requestId: 7, status: InvalidSignature }` | L01.FR.26 |
| 3 | Post-`InstallationFailed` | `{ requestId: 99, status: InstallationFailed }` | L01.FR.26 |
| 4 | Post-`Installed` (happy path) | `{ status: Idle }` (no `requestId`) | L01.FR.25 regression |
| 5 | Fresh station (no notification ever sent) | `{ status: Idle }` (no `requestId`) | Fresh-boot semantics |
| 6 | L01.FR.20 guard across every non-`Installed` status + `Installed` + fresh | `requestId` present iff status ≠ `Idle` | L01.FR.20 |

## Verification gates

- `pnpm format` — clean on edited files
- `pnpm typecheck` — 0 errors
- `pnpm lint` — 0 new errors
- `pnpm test` — **2974 pass / 0 fail** (6 pre-existing skipped)
- `pnpm build` — exit 0
- Grep sanity: `lastFirmwareStatusNotification` appears in exactly **3 places** (interface declaration, trigger read, `sendFirmwareStatusNotification` write)
- `hasFirmwareUpdateInProgress` body: **unchanged**
- `simulateFirmwareUpdateLifecycle`: **untouched** (diff scan: 0 hits)

## Related work

- Follow-up from #1976 (spec-depth review that surfaced this L01.FR.26 gap while the `firmwareStatus` reset semantics were being anchored).
- Uses the `stationsState` `WeakMap` pattern established by #1962.