### PR TITLE
chore(gitignore): ignore user-local ev-profiles JSON files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ src/assets/config*.json
 src/scripts/scriptConfig.json
 src/assets/*idtags*.json
 !src/assets/idtags-template.json
+src/assets/ev-profiles*.json
+!src/assets/ev-profiles-template.json
 src/assets/configs-docker/*.json
 mikro-orm.config*.ts
 !mikro-orm.config-template.ts


### PR DESCRIPTION
## Problem

`src/assets/ev-profiles.json` is a user-local instance of the coherent MeterValues EV profiles pool (consumed when `coherentMeterValues=true` per README). It has no `.gitignore` entry, so it surfaces as untracked noise in `git status` on any local setup that follows the README instructions.

The repository already ignores the two semantically identical pairs — user-mutable local instance alongside a committed template:

| Pair | Ignore pattern | Committed template negation |
|---|---|---|
| Config | `src/assets/config*.json` | `!src/assets/config-template.json` |
| IdTags | `src/assets/*idtags*.json` | `!src/assets/idtags-template.json` |
| **EV Profiles** | *(missing)* | `ev-profiles-template.json` (tracked) |

## Fix

Add the third pair to `.gitignore`, placed adjacent to the `idtags` pair (semantic siblings):

```
src/assets/ev-profiles*.json
!src/assets/ev-profiles-template.json
```

Two-line minimal diff. No code change. No documentation change (README already references `src/assets/ev-profiles-template.json` as the canonical template starting point).

## Verification

`git check-ignore -v`:

- `src/assets/ev-profiles.json` → matched by `.gitignore:7:src/assets/ev-profiles*.json` ✓ ignored
- `src/assets/ev-profiles-template.json` → NOT ignored (negation) ✓ still tracked

`git ls-files --error-unmatch src/assets/ev-profiles-template.json` → template still tracked, no accidental un-tracking.

No test references the tracked/untracked state of `src/assets/ev-profiles.json` (tests in `tests/charging-station/meter-values/EvProfiles.test.ts` use `mkdtempSync` + `/nonexistent/path` fixtures).

## Impact

- `git status` clean on any developer setup that runs the coherent MeterValues path with a local `ev-profiles.json`.
- No behavior change at runtime — `.gitignore` is metadata only.
- No files newly excluded from tracking that were previously tracked.