### PR TITLE
fix(ocpp): cancel deferred OCPP 1.6 firmware setTimeout on stop()

### DIFF
--- a/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
@@ -107,7 +107,9 @@ import {
   type UnlockConnectorResponse,
 } from '../../../types/index.js'
 import {
+  clampToSafeTimerValue,
   Configuration,
+  Constants,
   convertToDate,
   convertToInt,
   convertToIntOrNaN,
@@ -142,16 +144,26 @@ const moduleName = 'OCPP16IncomingRequestService'
 /**
  * Per-station lifecycle state carried on {@link OCPP16IncomingRequestService}.
  *
- * As of #1963 this interface is intentionally empty. Companion PRs will
- * populate this interface with their own fields:
+ * Populated incrementally as companion PRs land. Fields currently
+ * present:
+ * - `deferredFirmwareUpdateTimer` (#1972).
+ *
+ * Companion PRs still pending will add their own fields:
  * - #1971 (GetDiagnostics supersession): `activeDiagnosticsAbortController`,
  *   `activeDiagnosticsRequestId`;
- * - #1972 (deferred firmware `setTimeout` cancel): firmware timer handle;
  * - #1973 (trigger cross-check): `activeDiagnosticsRequestId` (shared with
  *   #1971), `activeFirmwareUpdateRequestId`.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- populated by companion PRs #1971 / #1972 / #1973
-interface OCPP16StationState {}
+interface OCPP16StationState {
+  /**
+   * `setTimeout` handle for the deferred `updateFirmwareSimulation`
+   * scheduled by the `UPDATE_FIRMWARE` event listener when the incoming
+   * request carries a future `retrieveDate`. Released by
+   * {@link OCPP16IncomingRequestService.cancelDeferredFirmwareUpdate}
+   * on stop, supersession, or normal fire (#1972).
+   */
+  deferredFirmwareUpdateTimer?: NodeJS.Timeout
+}
 
 /**
  * OCPP 1.6 Incoming Request Service - handles and processes all incoming requests
@@ -605,24 +617,44 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
             )
           })
         } else {
-          // Unref: fire-and-forget deferred firmware update must not
-          // block node.js exit.
-          setTimeout(() => {
+          // Fire-and-forget deferred update: setTimeout(...).unref() keeps
+          // the pending timer from blocking node.js exit. The handle is
+          // stored on OCPP16StationState so stop() cancels it via
+          // resetStationState (#1972); the schedule site supersedes any
+          // prior pending timer via the same helper, and the callback
+          // clears the handle before the awaited simulation so
+          // resetStationState never targets a fired timer.
+          const stationState = this.getOrCreateStationState(chargingStation)
+          this.cancelDeferredFirmwareUpdate(stationState)
+          // Clamp via canonical helper: a retrieveDate beyond
+          // Constants.MAX_SETINTERVAL_DELAY_MS would otherwise be silently
+          // reduced to 1 ms by Node and fire immediately.
+          const delayMs = retrieveDate.getTime() - now
+          const scheduleDelayMs = clampToSafeTimerValue(delayMs)
+          if (scheduleDelayMs !== delayMs) {
+            logger.warn(
+              `${chargingStation.logPrefix()} ${moduleName}.constructor: UpdateFirmware retrieveDate delay ${delayMs.toString()} ms exceeds ${Constants.MAX_SETINTERVAL_DELAY_MS.toString()} ms, clamping to ${scheduleDelayMs.toString()} ms`
+            )
+          }
+          stationState.deferredFirmwareUpdateTimer = setTimeout(() => {
+            delete stationState.deferredFirmwareUpdateTimer
             this.updateFirmwareSimulation(chargingStation).catch((error: unknown) => {
               logger.error(
                 `${chargingStation.logPrefix()} ${moduleName}.constructor: UpdateFirmware simulation error:`,
                 error
               )
             })
-          }, retrieveDate.getTime() - now).unref()
+          }, scheduleDelayMs).unref()
         }
       }
     )
   }
 
   /**
-   * @returns Fresh empty state — companion PRs (#1971 / #1972 / #1973)
-   *   populate fields via declaration merging on {@link OCPP16StationState}.
+   * @returns Fresh state with all optional {@link OCPP16StationState}
+   *   fields unset. Fields are lazily assigned by the request handlers
+   *   that own them (see {@link OCPP16StationState}); companion PRs
+   *   (#1971 / #1973) will populate their own fields on first use.
    */
   protected override createStationState (): OCPP16StationState {
     return {}
@@ -642,16 +674,32 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
   }
 
   /**
-   * Companion PRs (#1971 / #1972 / #1973) will populate this method with
-   * release logic paired with the {@link OCPP16StationState} fields they
-   * add. They MUST follow the abort-before-clear ordering documented on
-   * {@link OCPP20IncomingRequestService.resetStationState}: abort in-flight
-   * signals BEFORE clearing controller references, cancel timers BEFORE
-   * the base template deletes the entry.
-   * @param _stationState - Per-station state (currently empty; unused).
+   * Release resources held by the per-station state. Called by the
+   * inherited `stop()` template BEFORE the base deletes the WeakMap
+   * entry. Follow the abort-before-clear / cancel-before-delete
+   * ordering documented on
+   * {@link OCPP20IncomingRequestService.resetStationState}: abort
+   * in-flight signals BEFORE clearing controller references, cancel
+   * timers BEFORE the base template deletes the entry.
+   *
+   * Companion PRs (#1971 GetDiagnostics supersession, #1973 trigger
+   * cross-check) will extend this method with their own field releases.
+   * @param stationState - Per-station state to release.
    */
-  protected override resetStationState (_stationState: OCPP16StationState): void {
-    /* no-op: OCPP 1.6 carries no state fields yet (see companion PRs) */
+  protected override resetStationState (stationState: OCPP16StationState): void {
+    this.cancelDeferredFirmwareUpdate(stationState)
+  }
+
+  /**
+   * Cancels the deferred `updateFirmwareSimulation` timer and clears
+   * the handle (#1972). No-op when no timer is pending.
+   * @param stationState - Per-station state carrying the timer handle.
+   */
+  private cancelDeferredFirmwareUpdate (stationState: OCPP16StationState): void {
+    if (stationState.deferredFirmwareUpdateTimer != null) {
+      clearTimeout(stationState.deferredFirmwareUpdateTimer)
+      delete stationState.deferredFirmwareUpdateTimer
+    }
   }
 
   private composeCompositeSchedule (

--- a/tests/charging-station/ocpp/1.6/OCPP16IncomingRequestService-Firmware.test.ts
+++ b/tests/charging-station/ocpp/1.6/OCPP16IncomingRequestService-Firmware.test.ts
@@ -7,6 +7,7 @@
 import assert from 'node:assert/strict'
 import { afterEach, beforeEach, describe, it, mock } from 'node:test'
 
+import type { ChargingStation } from '../../../../src/charging-station/index.js'
 import type { GetDiagnosticsRequest } from '../../../../src/types/index.js'
 
 import { OCPP16IncomingRequestService } from '../../../../src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.js'
@@ -17,6 +18,7 @@ import {
   type OCPP16UpdateFirmwareRequest,
   type OCPP16UpdateFirmwareResponse,
 } from '../../../../src/types/index.js'
+import { Constants, logger } from '../../../../src/utils/index.js'
 import {
   flushMicrotasks,
   standardCleanup,
@@ -266,6 +268,284 @@ await describe('OCPP16IncomingRequestService — Firmware', async () => {
       await flushMicrotasks()
 
       // Assert: test passes if no unhandled rejection was thrown
+    })
+  })
+
+  // #1972: deferred UpdateFirmware timer lifecycle on OCPP16StationState
+  await describe('UPDATE_FIRMWARE deferred timer lifecycle', async () => {
+    interface OCPP16StationStateShape {
+      deferredFirmwareUpdateTimer?: NodeJS.Timeout
+    }
+
+    interface PlumbingAccess {
+      stationsState: WeakMap<ChargingStation, OCPP16StationStateShape>
+    }
+
+    const asPlumbing = (service: OCPP16IncomingRequestService): PlumbingAccess =>
+      service as unknown as PlumbingAccess
+
+    let listenerService: OCPP16IncomingRequestService
+    let updateFirmwareMock: ReturnType<typeof mock.fn>
+
+    beforeEach(() => {
+      listenerService = new OCPP16IncomingRequestService()
+      updateFirmwareMock = mock.method(
+        listenerService as unknown as {
+          updateFirmwareSimulation: (chargingStation: unknown) => Promise<void>
+        },
+        'updateFirmwareSimulation',
+        mock.fn(async () => Promise.resolve())
+      )
+    })
+
+    afterEach(() => {
+      standardCleanup()
+    })
+
+    await it('should store the deferred timer handle on OCPP16StationState when retrieveDate is in the future', async t => {
+      // Arrange
+      const { station } = createOCPP16ListenerStation('listener-timer-store')
+      const request: OCPP16UpdateFirmwareRequest = {
+        location: 'ftp://localhost/firmware.bin',
+        retrieveDate: new Date(Date.now() + 60_000),
+      }
+      const response: OCPP16UpdateFirmwareResponse = {}
+
+      // Act & Assert
+      await withMockTimers(t, ['setTimeout'], () => {
+        listenerService.emit(
+          OCPP16IncomingRequestCommand.UPDATE_FIRMWARE,
+          station,
+          request,
+          response
+        )
+
+        const state = asPlumbing(listenerService).stationsState.get(station)
+        assert.notStrictEqual(state, undefined)
+        assert.notStrictEqual(state?.deferredFirmwareUpdateTimer, undefined)
+      })
+    })
+
+    await it('should cancel the deferred timer on stop() and never fire updateFirmwareSimulation', async t => {
+      // Arrange
+      const { station } = createOCPP16ListenerStation('listener-timer-stop')
+      const request: OCPP16UpdateFirmwareRequest = {
+        location: 'ftp://localhost/firmware.bin',
+        retrieveDate: new Date(Date.now() + 60_000),
+      }
+      const response: OCPP16UpdateFirmwareResponse = {}
+
+      // Act & Assert
+      await withMockTimers(t, ['setTimeout'], async () => {
+        listenerService.emit(
+          OCPP16IncomingRequestCommand.UPDATE_FIRMWARE,
+          station,
+          request,
+          response
+        )
+
+        const plumbing = asPlumbing(listenerService)
+        assert.strictEqual(plumbing.stationsState.has(station), true)
+
+        listenerService.stop(station)
+        assert.strictEqual(plumbing.stationsState.has(station), false)
+
+        t.mock.timers.tick(120_000)
+        await flushMicrotasks()
+
+        assert.strictEqual(updateFirmwareMock.mock.callCount(), 0)
+      })
+    })
+
+    await it('should self-clear the deferred timer handle when the callback fires on schedule', async t => {
+      // Arrange
+      const { station } = createOCPP16ListenerStation('listener-timer-self-clear')
+      const request: OCPP16UpdateFirmwareRequest = {
+        location: 'ftp://localhost/firmware.bin',
+        retrieveDate: new Date(Date.now() + 100),
+      }
+      const response: OCPP16UpdateFirmwareResponse = {}
+
+      // Act & Assert
+      await withMockTimers(t, ['setTimeout'], async () => {
+        listenerService.emit(
+          OCPP16IncomingRequestCommand.UPDATE_FIRMWARE,
+          station,
+          request,
+          response
+        )
+
+        const plumbing = asPlumbing(listenerService)
+        assert.notStrictEqual(
+          plumbing.stationsState.get(station)?.deferredFirmwareUpdateTimer,
+          undefined
+        )
+
+        t.mock.timers.tick(200)
+        await flushMicrotasks()
+
+        assert.strictEqual(updateFirmwareMock.mock.callCount(), 1)
+        assert.strictEqual(
+          plumbing.stationsState.get(station)?.deferredFirmwareUpdateTimer,
+          undefined
+        )
+      })
+    })
+
+    await it('should cancel the previous deferred timer when re-scheduled before it fires', async t => {
+      // Arrange
+      const { station } = createOCPP16ListenerStation('listener-timer-reschedule')
+      const firstRequest: OCPP16UpdateFirmwareRequest = {
+        location: 'ftp://localhost/firmware.bin',
+        retrieveDate: new Date(Date.now() + 60_000),
+      }
+      const secondRequest: OCPP16UpdateFirmwareRequest = {
+        location: 'ftp://localhost/firmware.bin',
+        retrieveDate: new Date(Date.now() + 30_000),
+      }
+      const response: OCPP16UpdateFirmwareResponse = {}
+
+      // Act & Assert
+      await withMockTimers(t, ['setTimeout'], async () => {
+        listenerService.emit(
+          OCPP16IncomingRequestCommand.UPDATE_FIRMWARE,
+          station,
+          firstRequest,
+          response
+        )
+        listenerService.emit(
+          OCPP16IncomingRequestCommand.UPDATE_FIRMWARE,
+          station,
+          secondRequest,
+          response
+        )
+
+        t.mock.timers.tick(31_000)
+        await flushMicrotasks()
+        assert.strictEqual(updateFirmwareMock.mock.callCount(), 1)
+
+        t.mock.timers.tick(60_000)
+        await flushMicrotasks()
+        assert.strictEqual(updateFirmwareMock.mock.callCount(), 1)
+      })
+    })
+
+    await it('should isolate deferred timers between stations - stop(A) must not cancel B', async t => {
+      // Arrange
+      const { station: stationA } = createOCPP16ListenerStation('listener-timer-iso-a')
+      const { station: stationB } = createOCPP16ListenerStation('listener-timer-iso-b')
+      const request: OCPP16UpdateFirmwareRequest = {
+        location: 'ftp://localhost/firmware.bin',
+        retrieveDate: new Date(Date.now() + 60_000),
+      }
+      const response: OCPP16UpdateFirmwareResponse = {}
+
+      // Act & Assert
+      await withMockTimers(t, ['setTimeout'], async () => {
+        listenerService.emit(
+          OCPP16IncomingRequestCommand.UPDATE_FIRMWARE,
+          stationA,
+          request,
+          response
+        )
+        listenerService.emit(
+          OCPP16IncomingRequestCommand.UPDATE_FIRMWARE,
+          stationB,
+          request,
+          response
+        )
+
+        const plumbing = asPlumbing(listenerService)
+        assert.strictEqual(plumbing.stationsState.has(stationA), true)
+        assert.strictEqual(plumbing.stationsState.has(stationB), true)
+
+        listenerService.stop(stationA)
+        assert.strictEqual(plumbing.stationsState.has(stationA), false)
+        assert.strictEqual(plumbing.stationsState.has(stationB), true)
+        assert.notStrictEqual(
+          plumbing.stationsState.get(stationB)?.deferredFirmwareUpdateTimer,
+          undefined
+        )
+
+        t.mock.timers.tick(70_000)
+        await flushMicrotasks()
+
+        assert.strictEqual(updateFirmwareMock.mock.callCount(), 1)
+      })
+    })
+
+    await it('should self-clear the deferred timer handle even when updateFirmwareSimulation rejects', async t => {
+      // Arrange
+      const { station } = createOCPP16ListenerStation('listener-timer-defer-reject')
+      const rejectingMock = mock.method(
+        listenerService as unknown as {
+          updateFirmwareSimulation: (chargingStation: unknown) => Promise<void>
+        },
+        'updateFirmwareSimulation',
+        mock.fn(async () => Promise.reject(new Error('deferred firmware simulation error')))
+      )
+      const request: OCPP16UpdateFirmwareRequest = {
+        location: 'ftp://localhost/firmware.bin',
+        retrieveDate: new Date(Date.now() + 100),
+      }
+      const response: OCPP16UpdateFirmwareResponse = {}
+
+      // Act & Assert
+      await withMockTimers(t, ['setTimeout'], async () => {
+        listenerService.emit(
+          OCPP16IncomingRequestCommand.UPDATE_FIRMWARE,
+          station,
+          request,
+          response
+        )
+
+        t.mock.timers.tick(200)
+        await flushMicrotasks()
+        await flushMicrotasks()
+
+        assert.strictEqual(rejectingMock.mock.callCount(), 1)
+        assert.strictEqual(
+          asPlumbing(listenerService).stationsState.get(station)?.deferredFirmwareUpdateTimer,
+          undefined
+        )
+      })
+    })
+
+    await it('should clamp retrieveDate delay to Node setTimeout 32-bit maximum and warn', async t => {
+      // Arrange
+      const { station } = createOCPP16ListenerStation('listener-timer-clamp')
+      const warnSpy = t.mock.method(logger, 'warn')
+      // MAX_SETINTERVAL_DELAY_MS + 1000 ms drift buffer: Date.now() is not
+      // mocked, so a 1 s cushion avoids flake if the listener re-samples
+      // Date.now() a few ms later and delayMs drops to exactly MAX.
+      const request: OCPP16UpdateFirmwareRequest = {
+        location: 'ftp://localhost/firmware.bin',
+        retrieveDate: new Date(Date.now() + Constants.MAX_SETINTERVAL_DELAY_MS + 1000),
+      }
+      const response: OCPP16UpdateFirmwareResponse = {}
+
+      // Act & Assert
+      await withMockTimers(t, ['setTimeout'], () => {
+        listenerService.emit(
+          OCPP16IncomingRequestCommand.UPDATE_FIRMWARE,
+          station,
+          request,
+          response
+        )
+
+        assert.strictEqual(warnSpy.mock.callCount(), 1)
+        const warnMessage = warnSpy.mock.calls[0].arguments[0] as unknown as string
+        assert.match(
+          warnMessage,
+          new RegExp(
+            `exceeds ${Constants.MAX_SETINTERVAL_DELAY_MS.toString()} ms, clamping to ${Constants.MAX_SETINTERVAL_DELAY_MS.toString()} ms`
+          )
+        )
+        assert.notStrictEqual(
+          asPlumbing(listenerService).stationsState.get(station)?.deferredFirmwareUpdateTimer,
+          undefined
+        )
+      })
     })
   })
 })


### PR DESCRIPTION
Closes #1972.

## Problem

The OCPP 1.6 `UPDATE_FIRMWARE` event listener schedules `updateFirmwareSimulation` via `setTimeout(...).unref()` when `retrieveDate` is in the future. `.unref()` stops the timer from blocking process exit, but the callback still fires after `stop()`: if the station restarts, the deferred simulation runs against the new connection and can emit `FirmwareStatusNotification` messages the CSMS did not request. This violates the "during ... the update process" scoping of the FirmwareStatusNotification MUST in OCPP 1.6 §5.19 / errata §3.47 for a lifecycle the CSMS never initiated.

## Fix

Consume the shared per-station state infrastructure landed by PR #1983 (issue #1963). No new plumbing.

- Store the timer handle on `OCPP16StationState.deferredFirmwareUpdateTimer`.
- Add a private `cancelDeferredFirmwareUpdate(stationState)` helper that guards, cancels, and releases the handle.
- Call it from both the schedule site (to supersede a prior pending schedule) and from `resetStationState` (invoked by the inherited `stop()` template before the base deletes the `WeakMap` entry — abort-before-clear / cancel-before-delete ordering documented on `OCPP20IncomingRequestService.resetStationState`).
- Self-clear the handle inside the `setTimeout` callback **before** awaiting `updateFirmwareSimulation`, so `resetStationState` never targets a fired timer.
- Clamp the scheduled delay via the canonical `clampToSafeTimerValue` helper (`src/utils/Utils.ts:501`) and warn when the CSMS-provided `retrieveDate` exceeds `Constants.MAX_SETINTERVAL_DELAY_MS`; without the clamp Node silently reduces the delay to 1 ms and fires immediately.

## Touchpoints

| Region                                                                                                                                       | Change                                                                                                                                                                                                              |
| -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [\`OCPP16StationState\` interface + JSDoc](src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts#L144-L166)                           | Add \`deferredFirmwareUpdateTimer?: NodeJS.Timeout\`. Drop the \`@typescript-eslint/no-empty-object-type\` eslint-disable. Interface header no longer lists #1972 as a pending consumer.                            |
| [\`UPDATE_FIRMWARE\` event listener](src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts#L602-L650)                                 | Immediate branch unchanged. Deferred branch: lazy-init state, call helper to supersede any prior schedule, clamp delay via \`clampToSafeTimerValue\` with warn on overshoot, store handle, self-clear in callback before the awaited simulation, keep \`.unref()\`. |
| [\`resetStationState\`](src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts#L676-L691)                                              | Replace no-op with a single call to \`this.cancelDeferredFirmwareUpdate(stationState)\`.                                                                                                                            |
| [\`cancelDeferredFirmwareUpdate\` helper](src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts#L693-L703)                            | New private helper: guarded \`clearTimeout\` + \`delete stationState.deferredFirmwareUpdateTimer\`. Harmonises with \`ChargingStation.clearIntervalFlushMessageBuffer\` and \`OCPP16ServiceUtils\` cleanup pattern. |

Minor consistency touch on the [\`createStationState\` JSDoc](src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts#L653-L661) so it no longer lists \`#1972\` alongside the still-pending companion PRs.

## Reference pattern

Mirrors the OCPP 2.0.1 approach — `OCPP20IncomingRequestService.resetStationState` cancels `certSigningRetryManager?.cancelRetryTimer()` at [L1088](src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts#L1088), landed in commit `c0b25553`. A raw `NodeJS.Timeout` handle managed by a private helper is sufficient for a single-slot deferred firmware timer; the retry-manager class exists for multi-attempt cert-signing, a different problem shape. Delay clamping reuses the shared `clampToSafeTimerValue` utility already consumed by `ChargingStation.ts`, `OCPP16ServiceUtils.ts`, and `OCPP20ServiceUtils.ts`.

## Tests

Seven new tests in the existing `OCPP16IncomingRequestService-Firmware.test.ts` under `describe('UPDATE_FIRMWARE deferred timer lifecycle', ...)`, using the file's established `withMockTimers(t, ['setTimeout'], ...)` pattern:

1. **Timer stored on schedule** — dispatching `UpdateFirmware(retrieveDate = now + 60_000)` sets `state.deferredFirmwareUpdateTimer`.
2. **Timer cancelled on `stop()`** — `stop()` before the fake clock advances cancels the timer, deletes the `WeakMap` entry, and `updateFirmwareSimulation` is never invoked even after the clock passes `retrieveDate`.
3. **Timer self-clears on normal fire** — `state.deferredFirmwareUpdateTimer` is `undefined` after the callback runs.
4. **Re-schedule cancels previous** — dispatching two consecutive `UpdateFirmware` requests fires the simulation exactly once (the second timer's).
5. **Two-station isolation** — `stop(A)` does not cancel `B`'s pending timer.
6. **Self-clear under rejection** — when the deferred `updateFirmwareSimulation` rejects, the handle is still cleared before the `.catch` observes the rejection.
7. **retrieveDate delay clamping** — a `retrieveDate` beyond `Constants.MAX_SETINTERVAL_DELAY_MS` (plus a 1 s drift buffer for the un-mocked `Date.now()`) is clamped and `logger.warn` is emitted with the exact `exceeds ${MAX} ms, clamping to ${MAX} ms` shape.

Zero pre-existing test edits.

## Companion issues still open

- #1971 — `handleRequestGetDiagnostics` supersession semantics + abort infrastructure.
- #1973 — `TriggerMessage` cases for `DiagnosticsStatusNotification` / `FirmwareStatusNotification` cross-checking authoritative in-progress signals.

Both will populate additional fields on the same `OCPP16StationState` interface and add their own field releases to `resetStationState`.

## Verification

- \`pnpm format\` — clean.
- \`pnpm typecheck\` — 0 errors.
- \`pnpm lint\` — 0 errors on edited files; the \`no-empty-object-type\` eslint-disable is removed.
- \`pnpm test\` — 0 failures across the full test suite (7 new tests pass, 6 pre-existing skips unchanged).
- \`pnpm build\` — exit 0.
- Grep sanity: \`deferredFirmwareUpdateTimer\` appears in 3 code regions (interface, schedule site, helper); \`resetStationState\` delegates to the helper. One \`setTimeout(\` real call in the file at the schedule site with the handle stored on state; \`clampToSafeTimerValue\` is the canonical utility (5 sibling call sites), no magic number duplicated.

## Review rounds

Five parallel-reviewer rounds (Oracle × 2 + Explore each round). All valid findings applied:

- JSDoc originally attributed the scheduling to \`handleRequestUpdateFirmware\` (the payload validator); corrected to the \`UPDATE_FIRMWARE\` event listener registered in the constructor.
- \`state\` → \`stationState\` local naming to match the OCPP 2.0.1 dominant convention.
- Duplicate \`clearTimeout\` + release logic extracted into \`cancelDeferredFirmwareUpdate\` helper (DRY; called from both schedule supersession and reset).
- Field release uses \`delete\` (harmonises with \`ChargingStation.ts\` / \`OCPP16ServiceUtils.ts\` timer cleanup pattern).
- Comment density at the schedule site consolidated into two upfront rationale blocks (7 + 3 lines) and helper JSDoc trimmed to 3 lines to match sibling density.
- \`(#1972)\` suffix dropped from the test describe title to match sibling describe naming.
- Log source identifier kept as \`\${moduleName}.constructor:\` — round-3 finding revealed this is the established convention for constructor-registered listeners across the file (L329-L409) and \`OCPP20IncomingRequestService.ts\` (L439-L591).
- \`unref'd\` contraction rewritten as \`setTimeout(...).unref()\` in the consolidated comment (unique in codebase per round-3 grep).
- Added a 6th test asserting the deferred callback's self-clear happens even when \`updateFirmwareSimulation\` rejects.
- Added a 7th test covering the \`retrieveDate\` delay clamp path.
- **Round 4 BLOCKER fix — DRY / single-source-of-truth**: inline \`Math.min(delayMs, 2_147_483_647)\` replaced with the canonical \`clampToSafeTimerValue()\` helper (\`src/utils/Utils.ts:501\`) and the shared \`Constants.MAX_SETINTERVAL_DELAY_MS\` (\`src/utils/Constants.ts:141\`). Aligns with 5 other call sites.
- **Round 5 — boundary test hardened**: the 7th test's boundary value was raised from the raw literal \`2_147_483_648\` (MAX + 1 ms, flake-prone against un-mocked \`Date.now()\` drift) to \`Constants.MAX_SETINTERVAL_DELAY_MS + 1000\` (symbolic reference + 1 s drift buffer, matches the \`Utils.test.ts:548\` symbolic pattern). Regex tightened from \`/exceeds \\d+ ms, clamping to \\d+ ms/\` to reference the exact clamped value.

Findings audited and NOT applied, with rationale:

- **In-flight simulation abort post-stop** (Oracle 1 round 2). Round 3 verification confirmed \`updateFirmwareSimulation\` is already gated by \`checkChargingStationState(chargingStation, ...)\` at \`OCPP16IncomingRequestService.ts:1912\` — a fired-then-stopped simulation short-circuits before any OCPP notification. Not a defect.
- **Drop \`if != null\` guard before \`clearTimeout\`** (Explore round 2). Grep across \`src/charging-station/\` shows the guard IS the codebase convention (\`AbstractUIServer.ts:298\`, \`ChargingStation.ts:1349\`, \`OCPP16ServiceUtils.ts:1003\`). The finding is contra-codebase.
- **Hoist \`PlumbingAccess\` to shared helper** (rounds 2-3). Both reviewers explicitly marked as "defer at 2 consumers, reconsider at 3+". Not a defect at current scale.
- **\`@spec\` annotations on new tests** (Explore round 3). The convention \`@spec §X.Y — TC_NNN_CS\` is reserved for OCPP spec compliance test cases; these tests target internal timer lifecycle, not spec compliance. Traceability is provided by the describe-level \`// #1972:\` comment.
- **Helper naming \`cancel*\` vs \`resetActive*\`** (Explore round 3). Deliberate divergence justified by the different operation (timer cancellation vs. field nulling); both reviewers explicitly said no action required.
- **Pre-existing \`.constructor:\` log source on 7 other listeners** (Oracle 2 + Explore round 3). This IS the codebase convention (identical usage in \`OCPP20IncomingRequestService.ts\` L439-L591); changing it would rewrite the convention codebase-wide.
- **OCPP 2.0.1 helper co-location** (Oracle 1 + Explore round 3). Impossible to apply: \`perfectionist.configs['recommended-natural']\` (via \`perfectionist/sort-classes\`) mandates alphabetical ordering within class-member groups. Placing \`resetActiveFirmwareUpdateState\` right after \`resetStationState\` (L1085) violates the \`authorizeToken\` < \`resetActive*\` alphabetical rule and triggers a lint error. The current placement at L3377/L3382 is linter-enforced.
- **Warn log method label \`.constructor:\` on the clamp branch** (Explore round 4). Reproduces exactly the round-2 error that round 3 corrected — the warn fires inside the same constructor-registered \`UPDATE_FIRMWARE\` listener as the surrounding \`.catch(logger.error)\` calls, all of which correctly use \`.constructor:\` per the file's established convention.
- **\`createLoggerMocks\` helper vs raw \`t.mock.method(logger, 'warn')\`** (Explore round 5). Both patterns coexist in the test suite; the PR's usage matches the precedent at \`UIMetricsEndpoint.test.ts:503\`. Explore itself concluded "not a lint error and consistent with at least one other test file".
- **Extract \`Constants.MAX_SETINTERVAL_DELAY_MS\` to a local \`const\` in the warn message** (Explore round 5). Explore acknowledged "semantically correct, not a lint error". Extracting a single-use interpolation into a local const does not materially improve readability of a 3-interpolation message.
- **Warn readability (\`2147483647\` unformatted vs \`~24.85 days\`)** (Oracle 2 round 5). Explicitly marked as polish "Not requested; do not fix now".
- **§5.19 SHOULD deviation on clamp fire** (Oracle 2 round 5). Accepted per round 3: simulator context, warn logged, alternative (Node's 1 ms silent coercion) is strictly worse; spec §5.19 uses SHOULD, not MUST.