### PR TITLE
fix(ocpp): cross-check OCPP 1.6 trigger cases against per-station lifecycle flags

### DIFF
--- a/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
@@ -144,25 +144,59 @@ const moduleName = 'OCPP16IncomingRequestService'
 /**
  * Per-station lifecycle state carried on {@link OCPP16IncomingRequestService}.
  *
- * Populated incrementally as companion PRs land. Fields currently
- * present:
- * - `deferredFirmwareUpdateTimer` (#1972).
- *
- * Companion PRs still pending will add their own fields:
- * - #1971 (GetDiagnostics supersession): `activeDiagnosticsAbortController`,
- *   `activeDiagnosticsRequestId`;
- * - #1973 (trigger cross-check): `activeDiagnosticsRequestId` (shared with
- *   #1971), `activeFirmwareUpdateRequestId`.
+ * OCPP 1.6 core-profile `GetDiagnostics.req` and `UpdateFirmware.req`
+ * payloads do not carry a `requestId` (unlike OCPP 2.0.1 `GetLog` /
+ * `UpdateFirmware`, and unlike the OCPP 1.6 Security-Extension
+ * `SignedUpdateFirmware` variant which the simulator does not
+ * implement), so lifecycle progress is tracked with boolean flags
+ * rather than requestId-presence sentinels.
  */
 interface OCPP16StationState {
   /**
-   * `setTimeout` handle for the deferred `updateFirmwareSimulation`
+   * `setTimeout` handle for a deferred `updateFirmwareSimulation`
    * scheduled by the `UPDATE_FIRMWARE` event listener when the incoming
    * request carries a future `retrieveDate`. Released by
    * {@link OCPP16IncomingRequestService.cancelDeferredFirmwareUpdate}
-   * on stop, supersession, or normal fire (#1972).
+   * on stop, supersession, or normal fire.
    */
   deferredFirmwareUpdateTimer?: NodeJS.Timeout
+  /**
+   * `true` while a diagnostics upload lifecycle is active (from the
+   * FTP upload branch of `handleRequestGetDiagnostics` entry to its
+   * terminal status emission or exception unwind). Read at two sites:
+   * 1. The `TriggerMessage(DiagnosticsStatusNotification)` case: emits
+   *    `Idle` unless the flag is set, so a stale
+   *    `stationInfo.diagnosticsStatus` left at `Uploading` after an
+   *    exception unwind does not leak to the CSMS, per OCPP 1.6 §4.4 /
+   *    §7.24 (Idle when not busy uploading diagnostics).
+   * 2. `handleRequestGetDiagnostics`'s FTP-branch entry guard:
+   *    early-returns the empty `GetDiagnostics.conf` payload when a
+   *    prior lifecycle is still in flight, preventing concurrent FTP
+   *    uploads from racing on the same
+   *    `${chargingStationId}_logs.tar.gz` archive filename and
+   *    emitting duplicate `DiagnosticsStatusNotification` progress
+   *    messages to the CSMS.
+   */
+  diagnosticsUploadInProgress?: boolean
+  /**
+   * `true` while a firmware update lifecycle is active (from
+   * `updateFirmwareSimulation` entry to its terminal status emission
+   * or exception unwind). Read at three sites:
+   * 1. The `TriggerMessage(FirmwareStatusNotification)` case: emits
+   *    `Idle` unless the flag is set and `stationInfo.firmwareStatus`
+   *    is in the §4.5 / §7.25 pass-through set, so a stale non-terminal
+   *    status left by an exception unwind does not leak to the CSMS.
+   * 2. `handleRequestUpdateFirmware`'s re-entry guard: warn-logs and
+   *    returns the empty `UpdateFirmware.conf` payload when a
+   *    concurrent request arrives (OCPP 1.6 `UpdateFirmware.conf` has
+   *    no fields to signal rejection to the CSMS).
+   * 3. `updateFirmwareSimulation`'s entry guard: early-returns before
+   *    the try/finally when a prior lifecycle is still in flight,
+   *    preventing duplicate `FirmwareStatusNotification` progress
+   *    messages if the base-class event dispatcher fans out a second
+   *    invocation before the first completes.
+   */
+  firmwareUpdateInProgress?: boolean
 }
 
 /**
@@ -423,7 +457,19 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
               )
               .catch(errorHandler)
             break
-          case OCPP16MessageTrigger.DiagnosticsStatusNotification:
+          case OCPP16MessageTrigger.DiagnosticsStatusNotification: {
+            // §4.4 + §7.24: Idle when not busy uploading diagnostics.
+            // Cross-check the per-station lifecycle flag so a stale
+            // stationInfo.diagnosticsStatus (e.g. left at 'Uploading'
+            // after an exception unwind of the FTP path) does not
+            // leak to the CSMS.
+            const diagnosticsInProgress =
+              this.stationsState.get(chargingStation)?.diagnosticsUploadInProgress === true
+            const diagnosticsStatus = chargingStation.stationInfo?.diagnosticsStatus
+            const diagnosticsTriggerStatus =
+              diagnosticsInProgress && diagnosticsStatus === OCPP16DiagnosticsStatus.Uploading
+                ? OCPP16DiagnosticsStatus.Uploading
+                : OCPP16DiagnosticsStatus.Idle
             chargingStation.ocppRequestService
               .requestHandler<
                 OCPP16DiagnosticsStatusNotificationRequest,
@@ -431,21 +477,28 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
               >(
                 chargingStation,
                 OCPP16RequestCommand.DIAGNOSTICS_STATUS_NOTIFICATION,
-                {
-                  // §4.4 + §7.24: Idle when not busy uploading diagnostics
-                  status:
-                    chargingStation.stationInfo?.diagnosticsStatus ===
-                    OCPP16DiagnosticsStatus.Uploading
-                      ? OCPP16DiagnosticsStatus.Uploading
-                      : OCPP16DiagnosticsStatus.Idle,
-                },
-                {
-                  triggerMessage: true,
-                }
+                { status: diagnosticsTriggerStatus },
+                { triggerMessage: true }
               )
               .catch(errorHandler)
             break
-          case OCPP16MessageTrigger.FirmwareStatusNotification:
+          }
+          case OCPP16MessageTrigger.FirmwareStatusNotification: {
+            // §4.5 + §7.25: Idle when not busy downloading/installing
+            // firmware. Cross-check the per-station lifecycle flag so
+            // a stale stationInfo.firmwareStatus (e.g. left at
+            // 'Downloading' after an exception unwind of
+            // updateFirmwareSimulation) does not leak to the CSMS.
+            const firmwareInProgress =
+              this.stationsState.get(chargingStation)?.firmwareUpdateInProgress === true
+            const firmwareStatus = chargingStation.stationInfo?.firmwareStatus
+            const firmwareTriggerStatus =
+              firmwareInProgress &&
+              (firmwareStatus === OCPP16FirmwareStatus.Downloading ||
+                firmwareStatus === OCPP16FirmwareStatus.Downloaded ||
+                firmwareStatus === OCPP16FirmwareStatus.Installing)
+                ? firmwareStatus
+                : OCPP16FirmwareStatus.Idle
             chargingStation.ocppRequestService
               .requestHandler<
                 OCPP16FirmwareStatusNotificationRequest,
@@ -453,23 +506,12 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
               >(
                 chargingStation,
                 OCPP16RequestCommand.FIRMWARE_STATUS_NOTIFICATION,
-                {
-                  // §4.5 + §7.25: Idle when not busy downloading/installing firmware
-                  status:
-                    chargingStation.stationInfo?.firmwareStatus ===
-                      OCPP16FirmwareStatus.Downloading ||
-                    chargingStation.stationInfo?.firmwareStatus ===
-                      OCPP16FirmwareStatus.Downloaded ||
-                    chargingStation.stationInfo?.firmwareStatus === OCPP16FirmwareStatus.Installing
-                      ? chargingStation.stationInfo.firmwareStatus
-                      : OCPP16FirmwareStatus.Idle,
-                },
-                {
-                  triggerMessage: true,
-                }
+                { status: firmwareTriggerStatus },
+                { triggerMessage: true }
               )
               .catch(errorHandler)
             break
+          }
           case OCPP16MessageTrigger.Heartbeat:
             chargingStation.ocppRequestService
               .requestHandler<OCPP16HeartbeatRequest, OCPP16HeartbeatResponse>(
@@ -620,10 +662,10 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
           // Fire-and-forget deferred update: setTimeout(...).unref() keeps
           // the pending timer from blocking node.js exit. The handle is
           // stored on OCPP16StationState so stop() cancels it via
-          // resetStationState (#1972); the schedule site supersedes any
-          // prior pending timer via the same helper, and the callback
-          // clears the handle before the awaited simulation so
-          // resetStationState never targets a fired timer.
+          // resetStationState; the schedule site supersedes any prior
+          // pending timer via the same helper, and the callback clears
+          // the handle before the awaited simulation so resetStationState
+          // never targets a fired timer.
           const stationState = this.getOrCreateStationState(chargingStation)
           this.cancelDeferredFirmwareUpdate(stationState)
           // Clamp via canonical helper: a retrieveDate beyond
@@ -653,8 +695,7 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
   /**
    * @returns Fresh state with all optional {@link OCPP16StationState}
    *   fields unset. Fields are lazily assigned by the request handlers
-   *   that own them (see {@link OCPP16StationState}); companion PRs
-   *   (#1971 / #1973) will populate their own fields on first use.
+   *   that own them (see {@link OCPP16StationState}).
    */
   protected override createStationState (): OCPP16StationState {
     return {}
@@ -681,9 +722,6 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
    * {@link OCPP20IncomingRequestService.resetStationState}: abort
    * in-flight signals BEFORE clearing controller references, cancel
    * timers BEFORE the base template deletes the entry.
-   *
-   * Companion PRs (#1971 GetDiagnostics supersession, #1973 trigger
-   * cross-check) will extend this method with their own field releases.
    * @param stationState - Per-station state to release.
    */
   protected override resetStationState (stationState: OCPP16StationState): void {
@@ -692,7 +730,7 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
 
   /**
    * Cancels the deferred `updateFirmwareSimulation` timer and clears
-   * the handle (#1972). No-op when no timer is pending.
+   * the handle. No-op when no timer is pending.
    * @param stationState - Per-station state carrying the timer handle.
    */
   private cancelDeferredFirmwareUpdate (stationState: OCPP16StationState): void {
@@ -1206,6 +1244,14 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
     const uri = new URL(location)
     if (uri.protocol.startsWith('ftp:')) {
       let ftpClient: Client | undefined
+      const stationState = this.getOrCreateStationState(chargingStation)
+      if (stationState.diagnosticsUploadInProgress === true) {
+        logger.warn(
+          `${chargingStation.logPrefix()} ${moduleName}.handleRequestGetDiagnostics: skipped, a diagnostics upload lifecycle is already in flight`
+        )
+        return OCPP16Constants.OCPP_RESPONSE_EMPTY
+      }
+      stationState.diagnosticsUploadInProgress = true
       try {
         const logConfiguration = Configuration.getConfigurationSection<LogConfiguration>(
           ConfigurationSection.log
@@ -1308,6 +1354,8 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
             { errorResponse }
           ) ?? errorResponse
         )
+      } finally {
+        delete stationState.diagnosticsUploadInProgress
       }
     } else {
       logger.warn(
@@ -1845,11 +1893,7 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
       return OCPP16Constants.OCPP_RESPONSE_EMPTY
     }
     commandPayload.retrieveDate = convertToDate(commandPayload.retrieveDate) ?? new Date()
-    if (
-      chargingStation.stationInfo?.firmwareStatus === OCPP16FirmwareStatus.Downloading ||
-      chargingStation.stationInfo?.firmwareStatus === OCPP16FirmwareStatus.Downloaded ||
-      chargingStation.stationInfo?.firmwareStatus === OCPP16FirmwareStatus.Installing
-    ) {
+    if (this.stationsState.get(chargingStation)?.firmwareUpdateInProgress === true) {
       logger.warn(
         `${chargingStation.logPrefix()} ${moduleName}.handleRequestUpdateFirmware: Cannot simulate firmware update: firmware update is already in progress`
       )
@@ -1918,116 +1962,128 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
       )
       return
     }
-    for (const { connectorId, connectorStatus } of chargingStation.iterateConnectors(true)) {
-      if (connectorStatus.transactionStarted === false) {
-        await sendAndSetConnectorStatus(chargingStation, {
-          connectorId,
-          status: OCPP16ChargePointStatus.Unavailable,
-        } as OCPP16StatusNotificationRequest)
-      }
-    }
-    await chargingStation.ocppRequestService.requestHandler<
-      OCPP16FirmwareStatusNotificationRequest,
-      OCPP16FirmwareStatusNotificationResponse
-    >(chargingStation, OCPP16RequestCommand.FIRMWARE_STATUS_NOTIFICATION, {
-      status: OCPP16FirmwareStatus.Downloading,
-    })
-    if (chargingStation.stationInfo != null) {
-      chargingStation.stationInfo.firmwareStatus = OCPP16FirmwareStatus.Downloading
-    }
-    if (
-      chargingStation.stationInfo?.firmwareUpgrade?.failureStatus ===
-      OCPP16FirmwareStatus.DownloadFailed
-    ) {
-      await sleep(secondsToMilliseconds(randomInt(minDelay, maxDelay + 1)))
-      await chargingStation.ocppRequestService.requestHandler<
-        OCPP16FirmwareStatusNotificationRequest,
-        OCPP16FirmwareStatusNotificationResponse
-      >(chargingStation, OCPP16RequestCommand.FIRMWARE_STATUS_NOTIFICATION, {
-        status: chargingStation.stationInfo.firmwareUpgrade.failureStatus,
-      })
-      chargingStation.stationInfo.firmwareStatus =
-        chargingStation.stationInfo.firmwareUpgrade.failureStatus
+    const stationState = this.getOrCreateStationState(chargingStation)
+    if (stationState.firmwareUpdateInProgress === true) {
+      logger.warn(
+        `${chargingStation.logPrefix()} ${moduleName}.updateFirmwareSimulation: skipped, a firmware update lifecycle is already in flight`
+      )
       return
     }
-    await sleep(secondsToMilliseconds(randomInt(minDelay, maxDelay + 1)))
-    await chargingStation.ocppRequestService.requestHandler<
-      OCPP16FirmwareStatusNotificationRequest,
-      OCPP16FirmwareStatusNotificationResponse
-    >(chargingStation, OCPP16RequestCommand.FIRMWARE_STATUS_NOTIFICATION, {
-      status: OCPP16FirmwareStatus.Downloaded,
-    })
-    if (chargingStation.stationInfo != null) {
-      chargingStation.stationInfo.firmwareStatus = OCPP16FirmwareStatus.Downloaded
-    }
-    let wasTransactionsStarted = false
-    let transactionsStarted: boolean
-    do {
-      const runningTransactions = chargingStation.getNumberOfRunningTransactions()
-      if (runningTransactions > 0) {
-        const waitTime = secondsToMilliseconds(15)
-        logger.debug(
-          `${chargingStation.logPrefix()} ${moduleName}.updateFirmwareSimulation: ${runningTransactions.toString()} transaction(s) in progress, waiting ${formatDurationMilliSeconds(
-            waitTime
-          )} before continuing firmware update simulation`
-        )
-        await sleep(waitTime)
-        transactionsStarted = true
-        wasTransactionsStarted = true
-      } else {
-        for (const { connectorId, connectorStatus } of chargingStation.iterateConnectors(true)) {
-          if (connectorStatus.status !== OCPP16ChargePointStatus.Unavailable) {
-            await sendAndSetConnectorStatus(chargingStation, {
-              connectorId,
-              status: OCPP16ChargePointStatus.Unavailable,
-            } as OCPP16StatusNotificationRequest)
-          }
+    stationState.firmwareUpdateInProgress = true
+    try {
+      for (const { connectorId, connectorStatus } of chargingStation.iterateConnectors(true)) {
+        if (connectorStatus.transactionStarted === false) {
+          await sendAndSetConnectorStatus(chargingStation, {
+            connectorId,
+            status: OCPP16ChargePointStatus.Unavailable,
+          } as OCPP16StatusNotificationRequest)
         }
-        transactionsStarted = false
       }
-    } while (transactionsStarted)
-    !wasTransactionsStarted &&
-      (await sleep(secondsToMilliseconds(randomInt(minDelay, maxDelay + 1))))
-    if (!checkChargingStationState(chargingStation, chargingStation.logPrefix())) {
-      return
-    }
-    await chargingStation.ocppRequestService.requestHandler<
-      OCPP16FirmwareStatusNotificationRequest,
-      OCPP16FirmwareStatusNotificationResponse
-    >(chargingStation, OCPP16RequestCommand.FIRMWARE_STATUS_NOTIFICATION, {
-      status: OCPP16FirmwareStatus.Installing,
-    })
-    if (chargingStation.stationInfo != null) {
-      chargingStation.stationInfo.firmwareStatus = OCPP16FirmwareStatus.Installing
-    }
-    if (
-      chargingStation.stationInfo?.firmwareUpgrade?.failureStatus ===
-      OCPP16FirmwareStatus.InstallationFailed
-    ) {
+      await chargingStation.ocppRequestService.requestHandler<
+        OCPP16FirmwareStatusNotificationRequest,
+        OCPP16FirmwareStatusNotificationResponse
+      >(chargingStation, OCPP16RequestCommand.FIRMWARE_STATUS_NOTIFICATION, {
+        status: OCPP16FirmwareStatus.Downloading,
+      })
+      if (chargingStation.stationInfo != null) {
+        chargingStation.stationInfo.firmwareStatus = OCPP16FirmwareStatus.Downloading
+      }
+      if (
+        chargingStation.stationInfo?.firmwareUpgrade?.failureStatus ===
+        OCPP16FirmwareStatus.DownloadFailed
+      ) {
+        await sleep(secondsToMilliseconds(randomInt(minDelay, maxDelay + 1)))
+        await chargingStation.ocppRequestService.requestHandler<
+          OCPP16FirmwareStatusNotificationRequest,
+          OCPP16FirmwareStatusNotificationResponse
+        >(chargingStation, OCPP16RequestCommand.FIRMWARE_STATUS_NOTIFICATION, {
+          status: chargingStation.stationInfo.firmwareUpgrade.failureStatus,
+        })
+        chargingStation.stationInfo.firmwareStatus =
+          chargingStation.stationInfo.firmwareUpgrade.failureStatus
+        return
+      }
       await sleep(secondsToMilliseconds(randomInt(minDelay, maxDelay + 1)))
       await chargingStation.ocppRequestService.requestHandler<
         OCPP16FirmwareStatusNotificationRequest,
         OCPP16FirmwareStatusNotificationResponse
       >(chargingStation, OCPP16RequestCommand.FIRMWARE_STATUS_NOTIFICATION, {
-        status: chargingStation.stationInfo.firmwareUpgrade.failureStatus,
+        status: OCPP16FirmwareStatus.Downloaded,
       })
-      chargingStation.stationInfo.firmwareStatus =
-        chargingStation.stationInfo.firmwareUpgrade.failureStatus
-      return
-    }
-    await sleep(secondsToMilliseconds(randomInt(minDelay, maxDelay + 1)))
-    await chargingStation.ocppRequestService.requestHandler<
-      OCPP16FirmwareStatusNotificationRequest,
-      OCPP16FirmwareStatusNotificationResponse
-    >(chargingStation, OCPP16RequestCommand.FIRMWARE_STATUS_NOTIFICATION, {
-      status: OCPP16FirmwareStatus.Installed,
-    })
-    if (chargingStation.stationInfo != null) {
-      chargingStation.stationInfo.firmwareStatus = OCPP16FirmwareStatus.Installed
-    }
-    if (chargingStation.stationInfo?.firmwareUpgrade?.reset === true) {
+      if (chargingStation.stationInfo != null) {
+        chargingStation.stationInfo.firmwareStatus = OCPP16FirmwareStatus.Downloaded
+      }
+      let wasTransactionsStarted = false
+      let transactionsStarted: boolean
+      do {
+        const runningTransactions = chargingStation.getNumberOfRunningTransactions()
+        if (runningTransactions > 0) {
+          const waitTime = secondsToMilliseconds(15)
+          logger.debug(
+            `${chargingStation.logPrefix()} ${moduleName}.updateFirmwareSimulation: ${runningTransactions.toString()} transaction(s) in progress, waiting ${formatDurationMilliSeconds(
+              waitTime
+            )} before continuing firmware update simulation`
+          )
+          await sleep(waitTime)
+          transactionsStarted = true
+          wasTransactionsStarted = true
+        } else {
+          for (const { connectorId, connectorStatus } of chargingStation.iterateConnectors(true)) {
+            if (connectorStatus.status !== OCPP16ChargePointStatus.Unavailable) {
+              await sendAndSetConnectorStatus(chargingStation, {
+                connectorId,
+                status: OCPP16ChargePointStatus.Unavailable,
+              } as OCPP16StatusNotificationRequest)
+            }
+          }
+          transactionsStarted = false
+        }
+      } while (transactionsStarted)
+      !wasTransactionsStarted &&
+        (await sleep(secondsToMilliseconds(randomInt(minDelay, maxDelay + 1))))
+      if (!checkChargingStationState(chargingStation, chargingStation.logPrefix())) {
+        return
+      }
+      await chargingStation.ocppRequestService.requestHandler<
+        OCPP16FirmwareStatusNotificationRequest,
+        OCPP16FirmwareStatusNotificationResponse
+      >(chargingStation, OCPP16RequestCommand.FIRMWARE_STATUS_NOTIFICATION, {
+        status: OCPP16FirmwareStatus.Installing,
+      })
+      if (chargingStation.stationInfo != null) {
+        chargingStation.stationInfo.firmwareStatus = OCPP16FirmwareStatus.Installing
+      }
+      if (
+        chargingStation.stationInfo?.firmwareUpgrade?.failureStatus ===
+        OCPP16FirmwareStatus.InstallationFailed
+      ) {
+        await sleep(secondsToMilliseconds(randomInt(minDelay, maxDelay + 1)))
+        await chargingStation.ocppRequestService.requestHandler<
+          OCPP16FirmwareStatusNotificationRequest,
+          OCPP16FirmwareStatusNotificationResponse
+        >(chargingStation, OCPP16RequestCommand.FIRMWARE_STATUS_NOTIFICATION, {
+          status: chargingStation.stationInfo.firmwareUpgrade.failureStatus,
+        })
+        chargingStation.stationInfo.firmwareStatus =
+          chargingStation.stationInfo.firmwareUpgrade.failureStatus
+        return
+      }
       await sleep(secondsToMilliseconds(randomInt(minDelay, maxDelay + 1)))
-      await chargingStation.reset(OCPP16StopTransactionReason.REBOOT)
+      await chargingStation.ocppRequestService.requestHandler<
+        OCPP16FirmwareStatusNotificationRequest,
+        OCPP16FirmwareStatusNotificationResponse
+      >(chargingStation, OCPP16RequestCommand.FIRMWARE_STATUS_NOTIFICATION, {
+        status: OCPP16FirmwareStatus.Installed,
+      })
+      if (chargingStation.stationInfo != null) {
+        chargingStation.stationInfo.firmwareStatus = OCPP16FirmwareStatus.Installed
+      }
+      if (chargingStation.stationInfo?.firmwareUpgrade?.reset === true) {
+        await sleep(secondsToMilliseconds(randomInt(minDelay, maxDelay + 1)))
+        await chargingStation.reset(OCPP16StopTransactionReason.REBOOT)
+      }
+    } finally {
+      delete stationState.firmwareUpdateInProgress
     }
   }
 }

--- a/tests/charging-station/ocpp/1.6/OCPP16IncomingRequestService-Firmware.test.ts
+++ b/tests/charging-station/ocpp/1.6/OCPP16IncomingRequestService-Firmware.test.ts
@@ -12,13 +12,14 @@ import type { GetDiagnosticsRequest } from '../../../../src/types/index.js'
 
 import { OCPP16IncomingRequestService } from '../../../../src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.js'
 import {
+  ConfigurationSection,
   OCPP16FirmwareStatus,
   OCPP16IncomingRequestCommand,
   OCPP16StandardParametersKey,
   type OCPP16UpdateFirmwareRequest,
   type OCPP16UpdateFirmwareResponse,
 } from '../../../../src/types/index.js'
-import { Constants, logger } from '../../../../src/utils/index.js'
+import { Configuration, Constants, logger } from '../../../../src/utils/index.js'
 import {
   flushMicrotasks,
   standardCleanup,
@@ -101,6 +102,79 @@ await describe('OCPP16IncomingRequestService — Firmware', async () => {
       assert.notStrictEqual(response, undefined)
       assert.strictEqual(Object.keys(response).length, 0)
     })
+
+    await it('should clear diagnosticsUploadInProgress in the finally block when the FTP branch returns early on missing log file', async t => {
+      // Arrange: enable FirmwareManagement so the FTP branch is entered,
+      // then force the early return path inside the try block by returning
+      // a log configuration with no file. This exercises the finally clause
+      // through a non-throwing exit path.
+      const { incomingRequestService, station, testableService } = context
+      upsertConfigurationKey(
+        station,
+        OCPP16StandardParametersKey.SupportedFeatureProfiles,
+        'Core,FirmwareManagement'
+      )
+      t.mock.method(Configuration, 'getConfigurationSection', (section: ConfigurationSection) => {
+        if (section === ConfigurationSection.log) {
+          return { file: undefined }
+        }
+        return {}
+      })
+
+      const request: GetDiagnosticsRequest = {
+        location: 'ftp://localhost/diagnostics',
+      }
+
+      // Act
+      const response = await testableService.handleRequestGetDiagnostics(station, request)
+
+      // Assert
+      assert.strictEqual(Object.keys(response).length, 0)
+      const plumbing = incomingRequestService as unknown as {
+        stationsState: WeakMap<ChargingStation, { diagnosticsUploadInProgress?: boolean }>
+      }
+      assert.strictEqual(
+        plumbing.stationsState.get(station)?.diagnosticsUploadInProgress,
+        undefined
+      )
+    })
+
+    await it('should skip the diagnostics FTP upload when diagnosticsUploadInProgress is already set (concurrent invocation safety)', async t => {
+      // Regression guard: two concurrent GetDiagnostics.req arriving via
+      // the base-class dispatcher's fire-and-forget WebSocket message
+      // handling must not spawn concurrent FTP uploads racing on the same
+      // ${chargingStationId}_logs.tar.gz archive filename or emit
+      // duplicate DiagnosticsStatusNotification progress messages to the
+      // CSMS.
+
+      // Arrange
+      const { incomingRequestService, station, testableService } = context
+      upsertConfigurationKey(
+        station,
+        OCPP16StandardParametersKey.SupportedFeatureProfiles,
+        'Core,FirmwareManagement'
+      )
+      const plumbing = incomingRequestService as unknown as {
+        getOrCreateStationState: (cs: ChargingStation) => { diagnosticsUploadInProgress?: boolean }
+        stationsState: WeakMap<ChargingStation, { diagnosticsUploadInProgress?: boolean }>
+      }
+      plumbing.getOrCreateStationState(station).diagnosticsUploadInProgress = true
+      const warnSpy = t.mock.method(logger, 'warn')
+
+      // Act
+      const response = await testableService.handleRequestGetDiagnostics(station, {
+        location: 'ftp://localhost/diagnostics',
+      })
+
+      // Assert
+      assert.strictEqual(Object.keys(response).length, 0)
+      assert.strictEqual(plumbing.stationsState.get(station)?.diagnosticsUploadInProgress, true)
+      const warnMessages = warnSpy.mock.calls.map(call => call.arguments[0] as unknown as string)
+      assert.ok(
+        warnMessages.some(m => m.includes('a diagnostics upload lifecycle is already in flight')),
+        `expected an "already in flight" warning, got: ${JSON.stringify(warnMessages)}`
+      )
+    })
   })
 
   // §6.4: UpdateFirmware
@@ -142,7 +216,42 @@ await describe('OCPP16IncomingRequestService — Firmware', async () => {
       assert.strictEqual(Object.keys(response).length, 0)
     })
 
-    await it('should return empty response when firmware update is already in progress', () => {
+    await it('should return empty response and log the "already in progress" warning when firmwareUpdateInProgress is set', t => {
+      // Arrange
+      const { incomingRequestService, station, testableService } = context
+      upsertConfigurationKey(
+        station,
+        OCPP16StandardParametersKey.SupportedFeatureProfiles,
+        'Core,FirmwareManagement'
+      )
+      const plumbing = incomingRequestService as unknown as {
+        getOrCreateStationState: (cs: ChargingStation) => { firmwareUpdateInProgress?: boolean }
+      }
+      plumbing.getOrCreateStationState(station).firmwareUpdateInProgress = true
+      const warnSpy = t.mock.method(logger, 'warn')
+
+      // Act
+      const response = testableService.handleRequestUpdateFirmware(station, {
+        location: 'ftp://localhost/firmware.bin',
+        retrieveDate: new Date(),
+      })
+
+      // Assert
+      assert.strictEqual(Object.keys(response).length, 0)
+      const warnMessages = warnSpy.mock.calls.map(call => call.arguments[0] as unknown as string)
+      assert.ok(
+        warnMessages.some(m => m.includes('firmware update is already in progress')),
+        `expected an "already in progress" warning, got: ${JSON.stringify(warnMessages)}`
+      )
+    })
+
+    await it('should NOT log the "already in progress" warning when stationInfo.firmwareStatus is stale but firmwareUpdateInProgress is unset', t => {
+      // Regression guard: a stale stationInfo.firmwareStatus left at
+      // Downloading / Downloaded / Installing by a prior exception unwind
+      // must not suppress a legitimate new UpdateFirmware.req. The
+      // authoritative predicate is firmwareUpdateInProgress on the
+      // per-station state, not stationInfo.
+
       // Arrange
       const { station, testableService } = context
       upsertConfigurationKey(
@@ -153,6 +262,7 @@ await describe('OCPP16IncomingRequestService — Firmware', async () => {
       if (station.stationInfo != null) {
         station.stationInfo.firmwareStatus = OCPP16FirmwareStatus.Downloading
       }
+      const warnSpy = t.mock.method(logger, 'warn')
 
       // Act
       const response = testableService.handleRequestUpdateFirmware(station, {
@@ -161,8 +271,12 @@ await describe('OCPP16IncomingRequestService — Firmware', async () => {
       })
 
       // Assert
-      assert.notStrictEqual(response, undefined)
       assert.strictEqual(Object.keys(response).length, 0)
+      const warnMessages = warnSpy.mock.calls.map(call => call.arguments[0] as unknown as string)
+      assert.ok(
+        warnMessages.every(m => !m.includes('firmware update is already in progress')),
+        `expected no "already in progress" warning, got: ${JSON.stringify(warnMessages)}`
+      )
     })
   })
 
@@ -271,7 +385,7 @@ await describe('OCPP16IncomingRequestService — Firmware', async () => {
     })
   })
 
-  // #1972: deferred UpdateFirmware timer lifecycle on OCPP16StationState
+  // Deferred UpdateFirmware timer lifecycle on OCPP16StationState
   await describe('UPDATE_FIRMWARE deferred timer lifecycle', async () => {
     interface OCPP16StationStateShape {
       deferredFirmwareUpdateTimer?: NodeJS.Timeout

--- a/tests/charging-station/ocpp/1.6/OCPP16IncomingRequestService-TriggerMessage.test.ts
+++ b/tests/charging-station/ocpp/1.6/OCPP16IncomingRequestService-TriggerMessage.test.ts
@@ -1,19 +1,28 @@
 /**
  * @file Tests for OCPP16IncomingRequestService TriggerMessage handler
  * @description Tests for TriggerMessage (§10.1) incoming request handler covering
- *   accepted triggers, unimplemented triggers, and feature profile validation
+ *   accepted triggers, unimplemented triggers, feature profile validation, and
+ *   the per-station lifecycle-flag cross-check that satisfies OCPP 1.6 §4.4 /
+ *   §7.24 (DiagnosticsStatusNotification Idle when not busy uploading) and
+ *   §4.5 / §7.25 (FirmwareStatusNotification Idle when not busy downloading /
+ *   installing).
  */
 
 import assert from 'node:assert/strict'
 import { afterEach, beforeEach, describe, it, mock } from 'node:test'
 
+import type { ChargingStation } from '../../../../src/charging-station/index.js'
 import type {
+  OCPP16DiagnosticsStatusNotificationRequest,
+  OCPP16FirmwareStatusNotificationRequest,
   OCPP16TriggerMessageRequest,
   OCPP16TriggerMessageResponse,
 } from '../../../../src/types/index.js'
 
 import { OCPP16IncomingRequestService } from '../../../../src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.js'
 import {
+  OCPP16DiagnosticsStatus,
+  OCPP16FirmwareStatus,
   OCPP16IncomingRequestCommand,
   OCPP16MessageTrigger,
   OCPP16RequestCommand,
@@ -21,7 +30,7 @@ import {
   OCPP16TriggerMessageStatus,
   OCPPVersion,
 } from '../../../../src/types/index.js'
-import { Constants } from '../../../../src/utils/index.js'
+import { Constants, logger } from '../../../../src/utils/index.js'
 import { flushMicrotasks, standardCleanup } from '../../../helpers/TestLifecycleHelpers.js'
 import { TEST_CHARGING_STATION_BASE_NAME } from '../../ChargingStationTestConstants.js'
 import { createMockChargingStation } from '../../helpers/StationHelpers.js'
@@ -303,6 +312,329 @@ await describe('OCPP16IncomingRequestService — TriggerMessage', async () => {
       await flushMicrotasks()
 
       assert.strictEqual(rejectingMock.mock.callCount(), 1)
+    })
+  })
+
+  // OCPP 1.6 §4.4 / §7.24 (Diagnostics) and §4.5 / §7.25 (Firmware):
+  // the Charge Point SHALL only send status Idle after receipt of a
+  // TriggerMessage when it is not busy uploading diagnostics /
+  // downloading or installing firmware. These tests exercise the
+  // lifecycle-flag cross-check that collapses stale stationInfo
+  // values to Idle when no lifecycle is actually active.
+  await describe('lifecycle-flag cross-check', async () => {
+    interface OCPP16StationStateShape {
+      diagnosticsUploadInProgress?: boolean
+      firmwareUpdateInProgress?: boolean
+    }
+
+    interface PlumbingAccess {
+      getOrCreateStationState: (chargingStation: ChargingStation) => OCPP16StationStateShape
+      stationsState: WeakMap<ChargingStation, OCPP16StationStateShape>
+    }
+
+    const asPlumbing = (service: OCPP16IncomingRequestService): PlumbingAccess =>
+      service as unknown as PlumbingAccess
+
+    const emitTrigger = (
+      service: OCPP16IncomingRequestService,
+      station: ChargingStation,
+      trigger: OCPP16MessageTrigger
+    ): void => {
+      const request: OCPP16TriggerMessageRequest = { requestedMessage: trigger }
+      const response: OCPP16TriggerMessageResponse = {
+        status: OCPP16TriggerMessageStatus.ACCEPTED,
+      }
+      service.emit(OCPP16IncomingRequestCommand.TRIGGER_MESSAGE, station, request, response)
+    }
+
+    let service: OCPP16IncomingRequestService
+    let plumbing: PlumbingAccess
+    let station: ChargingStation
+    let requestHandlerMock: ReturnType<typeof mock.fn>
+
+    beforeEach(() => {
+      service = new OCPP16IncomingRequestService()
+      plumbing = asPlumbing(service)
+      ;({ requestHandlerMock, station } = createOCPP16ListenerStation('listener-lifecycle-flag'))
+    })
+
+    afterEach(() => {
+      standardCleanup()
+    })
+
+    await it('should emit Idle for DiagnosticsStatusNotification trigger when no upload is in progress', async () => {
+      emitTrigger(service, station, OCPP16MessageTrigger.DiagnosticsStatusNotification)
+      await flushMicrotasks()
+
+      assert.strictEqual(requestHandlerMock.mock.callCount(), 1)
+      const args = requestHandlerMock.mock.calls[0].arguments as [
+        unknown,
+        OCPP16RequestCommand,
+        OCPP16DiagnosticsStatusNotificationRequest,
+        ...unknown[]
+      ]
+      assert.strictEqual(args[1], OCPP16RequestCommand.DIAGNOSTICS_STATUS_NOTIFICATION)
+      assert.strictEqual(args[2].status, OCPP16DiagnosticsStatus.Idle)
+    })
+
+    await it('should emit Uploading for DiagnosticsStatusNotification trigger when upload is in progress', async () => {
+      plumbing.getOrCreateStationState(station).diagnosticsUploadInProgress = true
+      if (station.stationInfo != null) {
+        station.stationInfo.diagnosticsStatus = OCPP16DiagnosticsStatus.Uploading
+      }
+
+      emitTrigger(service, station, OCPP16MessageTrigger.DiagnosticsStatusNotification)
+      await flushMicrotasks()
+
+      assert.strictEqual(requestHandlerMock.mock.callCount(), 1)
+      const args = requestHandlerMock.mock.calls[0].arguments as [
+        unknown,
+        OCPP16RequestCommand,
+        OCPP16DiagnosticsStatusNotificationRequest,
+        ...unknown[]
+      ]
+      assert.strictEqual(args[1], OCPP16RequestCommand.DIAGNOSTICS_STATUS_NOTIFICATION)
+      assert.strictEqual(args[2].status, OCPP16DiagnosticsStatus.Uploading)
+    })
+
+    await it('should emit Idle for DiagnosticsStatusNotification when stationInfo is stale but lifecycle is not active', async () => {
+      // Regression guard: stationInfo.diagnosticsStatus is left at
+      // `Uploading` by a prior exception unwind that did not reset it,
+      // but the lifecycle flag correctly reports no active upload.
+      if (station.stationInfo != null) {
+        station.stationInfo.diagnosticsStatus = OCPP16DiagnosticsStatus.Uploading
+      }
+      assert.strictEqual(plumbing.stationsState.has(station), false)
+
+      emitTrigger(service, station, OCPP16MessageTrigger.DiagnosticsStatusNotification)
+      await flushMicrotasks()
+
+      assert.strictEqual(requestHandlerMock.mock.callCount(), 1)
+      const args = requestHandlerMock.mock.calls[0].arguments as [
+        unknown,
+        OCPP16RequestCommand,
+        OCPP16DiagnosticsStatusNotificationRequest,
+        ...unknown[]
+      ]
+      assert.strictEqual(args[2].status, OCPP16DiagnosticsStatus.Idle)
+    })
+
+    await it('should emit Idle for FirmwareStatusNotification trigger when no firmware update is in progress', async () => {
+      emitTrigger(service, station, OCPP16MessageTrigger.FirmwareStatusNotification)
+      await flushMicrotasks()
+
+      assert.strictEqual(requestHandlerMock.mock.callCount(), 1)
+      const args = requestHandlerMock.mock.calls[0].arguments as [
+        unknown,
+        OCPP16RequestCommand,
+        OCPP16FirmwareStatusNotificationRequest,
+        ...unknown[]
+      ]
+      assert.strictEqual(args[1], OCPP16RequestCommand.FIRMWARE_STATUS_NOTIFICATION)
+      assert.strictEqual(args[2].status, OCPP16FirmwareStatus.Idle)
+    })
+
+    const activeFirmwareStatuses: OCPP16FirmwareStatus[] = [
+      OCPP16FirmwareStatus.Downloading,
+      OCPP16FirmwareStatus.Downloaded,
+      OCPP16FirmwareStatus.Installing,
+    ]
+
+    for (const activeStatus of activeFirmwareStatuses) {
+      await it(`should emit ${activeStatus} for FirmwareStatusNotification trigger when lifecycle is active with ${activeStatus}`, async () => {
+        plumbing.getOrCreateStationState(station).firmwareUpdateInProgress = true
+        if (station.stationInfo != null) {
+          station.stationInfo.firmwareStatus = activeStatus
+        }
+
+        emitTrigger(service, station, OCPP16MessageTrigger.FirmwareStatusNotification)
+        await flushMicrotasks()
+
+        assert.strictEqual(requestHandlerMock.mock.callCount(), 1)
+        const args = requestHandlerMock.mock.calls[0].arguments as [
+          unknown,
+          OCPP16RequestCommand,
+          OCPP16FirmwareStatusNotificationRequest,
+          ...unknown[]
+        ]
+        assert.strictEqual(args[2].status, activeStatus)
+      })
+    }
+
+    await it('should emit Idle for FirmwareStatusNotification when stationInfo is stale but lifecycle is not active', async () => {
+      // Regression guard for the firmware-side stale stationInfo scenario.
+      if (station.stationInfo != null) {
+        station.stationInfo.firmwareStatus = OCPP16FirmwareStatus.Downloading
+      }
+      assert.strictEqual(plumbing.stationsState.has(station), false)
+
+      emitTrigger(service, station, OCPP16MessageTrigger.FirmwareStatusNotification)
+      await flushMicrotasks()
+
+      assert.strictEqual(requestHandlerMock.mock.callCount(), 1)
+      const args = requestHandlerMock.mock.calls[0].arguments as [
+        unknown,
+        OCPP16RequestCommand,
+        OCPP16FirmwareStatusNotificationRequest,
+        ...unknown[]
+      ]
+      assert.strictEqual(args[2].status, OCPP16FirmwareStatus.Idle)
+    })
+
+    await it('should emit Idle for FirmwareStatusNotification when lifecycle is active but stationInfo status is terminal (DownloadFailed)', async () => {
+      // §4.5 / §7.25: only Downloading / Downloaded / Installing carry over;
+      // any other value (including terminal failure statuses) collapses to Idle.
+      plumbing.getOrCreateStationState(station).firmwareUpdateInProgress = true
+      if (station.stationInfo != null) {
+        station.stationInfo.firmwareStatus = OCPP16FirmwareStatus.DownloadFailed
+      }
+
+      emitTrigger(service, station, OCPP16MessageTrigger.FirmwareStatusNotification)
+      await flushMicrotasks()
+
+      assert.strictEqual(requestHandlerMock.mock.callCount(), 1)
+      const args = requestHandlerMock.mock.calls[0].arguments as [
+        unknown,
+        OCPP16RequestCommand,
+        OCPP16FirmwareStatusNotificationRequest,
+        ...unknown[]
+      ]
+      assert.strictEqual(args[2].status, OCPP16FirmwareStatus.Idle)
+    })
+
+    await it('should clear firmwareUpdateInProgress in the finally block of updateFirmwareSimulation and then emit Idle on trigger', async () => {
+      // The `try/finally` around updateFirmwareSimulation's body guarantees
+      // firmwareUpdateInProgress is cleared on every exit path (happy,
+      // return, throw). We exercise the throw path by rejecting the first
+      // request emitted from inside the try block.
+      const rejectingHandler = mock.fn(async () =>
+        Promise.reject(new Error('simulated network error'))
+      )
+      const { station: rejectStation } = createMockChargingStation({
+        baseName: TEST_CHARGING_STATION_BASE_NAME,
+        connectorsCount: 2,
+        ocppRequestService: { requestHandler: rejectingHandler },
+        started: true,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_16 },
+        websocketPingInterval: Constants.DEFAULT_WS_PING_INTERVAL_SECONDS,
+      })
+
+      const invokeSimulation = (
+        service as unknown as {
+          updateFirmwareSimulation: (
+            chargingStation: ChargingStation,
+            maxDelay?: number,
+            minDelay?: number
+          ) => Promise<void>
+        }
+      ).updateFirmwareSimulation.bind(service)
+
+      await assert.rejects(invokeSimulation(rejectStation))
+
+      assert.strictEqual(
+        plumbing.stationsState.get(rejectStation)?.firmwareUpdateInProgress,
+        undefined
+      )
+
+      // Now that the flag is cleared, TriggerMessage(FirmwareStatusNotification)
+      // should collapse any lingering stationInfo status to Idle.
+      if (rejectStation.stationInfo != null) {
+        rejectStation.stationInfo.firmwareStatus = OCPP16FirmwareStatus.Downloading
+      }
+      const listenerHandlerMock = mock.fn((..._args: unknown[]) => Promise.resolve({}))
+      rejectStation.ocppRequestService.requestHandler =
+        listenerHandlerMock as typeof rejectStation.ocppRequestService.requestHandler
+      emitTrigger(service, rejectStation, OCPP16MessageTrigger.FirmwareStatusNotification)
+      await flushMicrotasks()
+
+      assert.strictEqual(listenerHandlerMock.mock.callCount(), 1)
+      const args = listenerHandlerMock.mock.calls[0].arguments as unknown as [
+        unknown,
+        OCPP16RequestCommand,
+        OCPP16FirmwareStatusNotificationRequest,
+        ...unknown[]
+      ]
+      assert.strictEqual(args[2].status, OCPP16FirmwareStatus.Idle)
+    })
+
+    await it('should skip updateFirmwareSimulation when firmwareUpdateInProgress is already set (concurrent invocation safety)', async t => {
+      // Regression guard: if the base-class event dispatcher fans out a
+      // second UPDATE_FIRMWARE emit while a prior lifecycle is still in
+      // flight, the second updateFirmwareSimulation invocation must
+      // early-return before entering the try/finally — otherwise duplicate
+      // FirmwareStatusNotification progress messages would reach the CSMS.
+
+      // Arrange
+      const requestHandlerSpy = mock.fn((..._args: unknown[]) => Promise.resolve({}))
+      const { station: concurrentStation } = createMockChargingStation({
+        baseName: TEST_CHARGING_STATION_BASE_NAME,
+        connectorsCount: 2,
+        ocppRequestService: { requestHandler: requestHandlerSpy },
+        started: true,
+        stationInfo: { ocppVersion: OCPPVersion.VERSION_16 },
+        websocketPingInterval: Constants.DEFAULT_WS_PING_INTERVAL_SECONDS,
+      })
+      plumbing.getOrCreateStationState(concurrentStation).firmwareUpdateInProgress = true
+      const warnSpy = t.mock.method(logger, 'warn')
+      const invokeSimulation = (
+        service as unknown as {
+          updateFirmwareSimulation: (
+            chargingStation: ChargingStation,
+            maxDelay?: number,
+            minDelay?: number
+          ) => Promise<void>
+        }
+      ).updateFirmwareSimulation.bind(service)
+
+      // Act
+      await invokeSimulation(concurrentStation)
+
+      // Assert
+      assert.strictEqual(requestHandlerSpy.mock.callCount(), 0)
+      assert.strictEqual(
+        plumbing.stationsState.get(concurrentStation)?.firmwareUpdateInProgress,
+        true
+      )
+      const warnMessages = warnSpy.mock.calls.map(call => call.arguments[0] as unknown as string)
+      assert.ok(
+        warnMessages.some(m => m.includes('a firmware update lifecycle is already in flight')),
+        `expected an "already in flight" warning, got: ${JSON.stringify(warnMessages)}`
+      )
+    })
+
+    await it('should isolate lifecycle flags across stations so a trigger on B is unaffected by A', async () => {
+      const { requestHandlerMock: handlerMockB, station: stationB } = createOCPP16ListenerStation(
+        'listener-lifecycle-flag-b'
+      )
+      plumbing.getOrCreateStationState(station).firmwareUpdateInProgress = true
+      if (station.stationInfo != null) {
+        station.stationInfo.firmwareStatus = OCPP16FirmwareStatus.Downloading
+      }
+      if (stationB.stationInfo != null) {
+        stationB.stationInfo.firmwareStatus = OCPP16FirmwareStatus.Downloading
+      }
+
+      emitTrigger(service, station, OCPP16MessageTrigger.FirmwareStatusNotification)
+      emitTrigger(service, stationB, OCPP16MessageTrigger.FirmwareStatusNotification)
+      await flushMicrotasks()
+
+      assert.strictEqual(requestHandlerMock.mock.callCount(), 1)
+      const argsA = requestHandlerMock.mock.calls[0].arguments as [
+        unknown,
+        OCPP16RequestCommand,
+        OCPP16FirmwareStatusNotificationRequest,
+        ...unknown[]
+      ]
+      assert.strictEqual(argsA[2].status, OCPP16FirmwareStatus.Downloading)
+
+      assert.strictEqual(handlerMockB.mock.callCount(), 1)
+      const argsB = handlerMockB.mock.calls[0].arguments as [
+        unknown,
+        OCPP16RequestCommand,
+        OCPP16FirmwareStatusNotificationRequest,
+        ...unknown[]
+      ]
+      assert.strictEqual(argsB[2].status, OCPP16FirmwareStatus.Idle)
     })
   })
 })

--- a/tests/charging-station/ocpp/OCPPIncomingRequestService-StationState.test.ts
+++ b/tests/charging-station/ocpp/OCPPIncomingRequestService-StationState.test.ts
@@ -1,8 +1,8 @@
 /**
  * @file Tests for OCPPIncomingRequestService per-station state plumbing (#1963)
  * @description Unit tests for the shared WeakMap + lazy-init + stop() template
- *   in `OCPPIncomingRequestService`, plus the OCPP 1.6 no-op `resetStationState`
- *   contract that companion PRs (#1971, #1972, #1973) will replace.
+ *   in `OCPPIncomingRequestService` and for the OCPP 1.6 `resetStationState`
+ *   contract.
  *
  * The OCPP 2.0.1 5-statement ordering invariant (abort firmware → abort log →
  * cancel retry → resetActiveFirmwareUpdateState → resetActiveLogUploadState)


### PR DESCRIPTION
Closes #1973

## Bug

Four related manifestations of the same anti-pattern (`stationInfo.*Status` treated as authoritative in-progress signal, or lifecycle-entry with no concurrent-invocation guard):

1. **Trigger stale-status leak** — the `TriggerMessage` handler cases for `DiagnosticsStatusNotification` and `FirmwareStatusNotification` read `stationInfo.diagnosticsStatus` / `stationInfo.firmwareStatus` directly. When an exception, abort, or lifecycle drift left the status at a stale non-terminal value, the trigger reported that stale value to the CSMS instead of `Idle`.
2. **`handleRequestUpdateFirmware` re-entry guard suppression** — the re-entry guard consulted `stationInfo.firmwareStatus`. A stale non-terminal value after an exception unwind suppressed legitimate new firmware update requests.
3. **`updateFirmwareSimulation` concurrent-invocation duplication** — the base-class event dispatcher fans out `UPDATE_FIRMWARE` emits unconditionally; the listener spawned `updateFirmwareSimulation` on every emit with no in-flight check, so a second `UpdateFirmware.req` spawned a concurrent `updateFirmwareSimulation` emitting duplicate `FirmwareStatusNotification` progress messages to the CSMS.
4. **`handleRequestGetDiagnostics` concurrent-invocation duplication** — two `GetDiagnostics.req` messages arriving close together produced concurrent `handleRequestGetDiagnostics` invocations. Both piped the same `${chargingStationId}_logs.tar.gz` archive filename, opened concurrent FTP clients, and emitted duplicate `DiagnosticsStatusNotification(Uploading)` per progress tick.

## Fix

Track lifecycle progress with two per-station boolean flags on `OCPP16StationState`:

- `diagnosticsUploadInProgress` — set at the top of the FTP branch of `handleRequestGetDiagnostics` (after the concurrent-invocation guard), cleared in a `finally` block that guarantees release on every exit path.
- `firmwareUpdateInProgress` — set at the top of `updateFirmwareSimulation`'s body (after the early-return guards and the concurrency check), cleared in a `finally` block wrapping the body.

Five consumers cross-check the flags:

1. `TriggerMessage(DiagnosticsStatusNotification)` case → emits `Idle` when no upload is active.
2. `TriggerMessage(FirmwareStatusNotification)` case → emits `Idle` unless the flag is set AND `stationInfo.firmwareStatus` is in the §4.5 / §7.25 pass-through set `{Downloading, Downloaded, Installing}`.
3. `handleRequestUpdateFirmware` re-entry guard → warn-logs and returns the empty `UpdateFirmware.conf` when the flag is set.
4. `updateFirmwareSimulation` entry guard → early-returns before the `try/finally` when the flag is already set.
5. `handleRequestGetDiagnostics` FTP-branch entry guard → early-returns the empty `GetDiagnostics.conf` payload when a prior lifecycle is still in flight.

## OCPP 1.6 spec anchors (verbatim, `OCPP-1.6-edition2 §4.4/§4.5/§7.24/§7.25`)

### §4.4 Diagnostics Status Notification

> Charge Point sends a notification to inform the Central System about the status of a diagnostics upload. The Charge Point SHALL send a DiagnosticsStatusNotification.req PDU to inform the Central System that the upload of diagnostics is busy or has finished successfully or failed. **The Charge Point SHALL only send the status Idle after receipt of a TriggerMessage for a Diagnostics Status Notification, when it is not busy uploading diagnostics.**

### §4.5 Firmware Status Notification

> A Charge Point sends notifications to inform the Central System about the progress of the firmware update. The Charge Point SHALL send a FirmwareStatusNotification.req PDU for informing the Central System about the progress of the downloading and installation of a firmware update. **The Charge Point SHALL only send the status Idle after receipt of a TriggerMessage for a Firmware Status Notification, when it is not busy downloading/installing firmware.**

### §7.24 DiagnosticsStatus — `Idle`

> **Charge Point is not performing diagnostics related tasks. Status Idle SHALL only be used as in a DiagnosticsStatusNotification.req that was triggered by a TriggerMessage.req**

### §7.25 FirmwareStatus — `Idle`

> **Charge Point is not performing firmware update related tasks. Status Idle SHALL only be used as in a FirmwareStatusNotification.req that was triggered by a TriggerMessage.req**

## Touchpoints (5 fix + 1 comment cleanup)

| # | File | Symbol | Anchor | Change |
|---|------|--------|----------|--------|
| 1 | `src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts` | `interface OCPP16StationState` | L154; new fields `diagnosticsUploadInProgress?: boolean` at L180 and `firmwareUpdateInProgress?: boolean` at L199. |
| 2 | same file | `handleRequestTriggerMessage` switch cases | `DiagnosticsStatusNotification` case at L460; `FirmwareStatusNotification` case at L486. |
| 3 | same file | `handleRequestGetDiagnostics` FTP branch | Entry guard at L1248; lifecycle set at L1254; `finally` clear at L1358. |
| 4 | same file | `handleRequestUpdateFirmware` re-entry guard | Guard at L1896. |
| 5 | same file | `updateFirmwareSimulation` | Entry guard at L1966; lifecycle set at L1972; `finally` clear at L2086. |
| 6 | `tests/charging-station/ocpp/OCPPIncomingRequestService-StationState.test.ts` | File JSDoc L1-15 | Codebase-wide anti-narration audit finding (see Round 8 below) — removed stale forward-reference "`no-op` contract that companion PRs (#1971, #1972, #1973) will replace" (factually stale: `resetStationState` no longer no-op since PR #1984; narratively "story of code" evolution phrasing that violates the project's documentation-timeliness convention). |

## Rationale — boolean flags rather than a synthetic `requestId`

OCPP 1.6 core-profile `GetDiagnostics.req` and `UpdateFirmware.req` payloads carry no `requestId`:

```console
$ grep -c requestId src/assets/json-schemas/ocpp/1.6/GetDiagnostics.json \
                   src/assets/json-schemas/ocpp/1.6/UpdateFirmware.json
0
0
```

OCPP 2.0.1 uses requestId-presence sentinels because its `GetLog` / `UpdateFirmware` payloads do carry `requestId`. Boolean flags are the minimal representation for OCPP 1.6 that expresses "is a lifecycle currently active?"

## Verification

- `pnpm format` — clean
- `pnpm typecheck` — 0 errors
- `pnpm lint` — 0 errors, 0 warnings on modified files
- `pnpm test` — **3014 pass / 0 fail / 6 skipped** (baseline 2999; **+15 net new tests**)

## Mechanical invariants (verified post-review @ `8846bd255`)

- `diagnosticsUploadInProgress` — 5 canonical usages (interface L180 / trigger read L467 / entry guard read L1248 / lifecycle set L1254 / finally clear L1358)
- `firmwareUpdateInProgress` — 6 canonical usages (interface L199 / trigger read L493 / re-entry guard L1896 / entry guard L1966 / lifecycle set L1972 / finally clear L2086)
- `deferredFirmwareUpdateTimer` — untouched from PR #1984
- Zero `#1971` / `#1972` / `#1973` / `#1984` PR-history evolution narration in the modified files
- Zero `as any` / `@ts-ignore` / `@ts-expect-error` / `!` non-null assertions in new code
- Diff scope: exactly 4 files vs `origin/main`

## Companion scope

- Supersession semantics for `GetDiagnostics` (abort-in-flight, `AbortController` plumbing) remain out of scope — tracked by open [#1971](https://github.com/SAP/e-mobility-charging-stations-simulator/issues/1971).
- OCPP 2.0.1 last-sent-driven trigger pattern shipped in [#1981](https://github.com/SAP/e-mobility-charging-stations-simulator/pull/1981) is the spec-quoting rigour reference.

## Review rounds — cumulative register

Eight rounds of review with ≥2 parallel reviewers each. **0 BLOCKER, 2 MAJOR (both [FIXED])**. Zero remaining [DEFERRED].

### Rounds 1-5

Six [FIXED] items (F1 `#1972` marker; F2 rapatriated → closes [#1988](https://github.com/SAP/e-mobility-charging-stations-simulator/issues/1988); F3 rapatriated → closes [#1989](https://github.com/SAP/e-mobility-charging-stations-simulator/issues/1989); F4 JSDoc scoping; O5-1 MAJOR firmware entry guard; multiple NIT touch-ups on PR body / commit title / test AAA labels). Six [REJECTED] with justification.

### Round 6

- **F6-1 [MAJOR]** — `handleRequestGetDiagnostics` entry guard added (mirror of O5-1). Rapatriated in-scope per user directive on bug-fix deferral policy.
- F6-2 [MINOR] — test count refreshed. F6-3 [REJECTED] — issue closing comment SHA non-critical.

### Round 7

- Oracle : zero new findings (exhaustive bug hunt on OCPP 1.6 handler surface — only two multi-phase status-emission lifecycles exist, both guarded).
- **F7-1 [NIT] `[FIXED]` @ `dd029a1ea`** — worktree noise: `package.json` / `pnpm-lock.yaml` in diff due to upstream `origin/main` having advanced with an `eslint-plugin-jsdoc ^63.0.11 → ^63.0.12` bump. Rebased onto latest `origin/main` (`6cacba312`) — diff now scoped strictly to fix + test files.

### Round 8 (codebase-wide anti-narration audit per user request)

Audit scope: 730 authored files (git-tracked, excluding `dist/`, `coverage/`, `logs/`, `CHANGELOG.md`, external OCPP spec docs `docs/ocpp*/`, OCPP JSON schemas, lockfiles, `.snap`).

Eight pattern groups grepped: (A) `companion PR` / `will (populate/extend/replace/consume/introduce)` / `still pending` / `deferred to follow-up` / `in a subsequent PR`; (B) past-tense evolution `was refactored/renamed/moved/added-in`, `previously (empty/contained)`, `no longer (empty/contained/needed)`, `used to (be/contain)`; (C) placeholder narration `eventually will`, `for now`, `temporarily`, `no-op contract`, `empty for now`, `initially empty/no-op/stub`; (D) forward-reference `(#XXXX)` + future-verb couplings; (E) JSDoc "incremental" / "will be" phrasing; (F) Python narration; (G) authored-markdown narration; (H) broad forward-reference `(pending/awaiting/scheduled/planned) (PR/commit/change/patch)`.

**Result**: **one violation** — `tests/charging-station/ocpp/OCPPIncomingRequestService-StationState.test.ts:4-5` — `[FIXED]` @ `8846bd255`. Both symptoms addressed: (1) stale factual claim (`resetStationState` no longer no-op since PR #1984 added `deferredFirmwareUpdateTimer` cancellation), (2) evolution narration `companion PRs (#1971, #1972, #1973) will replace` (the exact "story of code" phrasing pattern the audit targets).

All other `(#XXXX)` / `(issue #XXXX)` refs across the codebase (~16 hits inventoried) are brief traceability anchors documenting design context or bug-fix provenance, which is the project's established documentation convention — kept.

**Zero remaining violations codebase-wide.** Ready to squash.