### PR TITLE
fix(ocpp): implement OCPP 1.6 GetDiagnostics supersession via AbortController

### DIFF
--- a/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
+++ b/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts
@@ -153,6 +153,29 @@ const moduleName = 'OCPP16IncomingRequestService'
  */
 interface OCPP16StationState {
   /**
+   * `AbortController` scoped to the in-flight diagnostics FTP upload
+   * spawned by the FTP branch of `handleRequestGetDiagnostics`. Set
+   * synchronously with `diagnosticsUploadInProgress = true` at entry;
+   * released by the handler's `finally` clause via identity guard
+   * (comparison against the local variable) so a superseding
+   * request that has already overwritten the state reference is not
+   * clobbered by the superseded handler's late cleanup. Aborted from
+   * two sites:
+   * 1. `handleRequestGetDiagnostics`'s FTP-branch entry guard when a
+   *    superseding request arrives while a prior lifecycle is still
+   *    in flight. The `abort` listener closes the `basic-ftp` client,
+   *    which rejects the pending `uploadFrom` promise with
+   *    `User closed client during task`; the outer catch then emits
+   *    the terminal `DiagnosticsStatusNotification(UploadFailed)` per
+   *    OCPP 1.6 §4.4 / §7.24 (uncorrelated terminal — §6.17 does not
+   *    carry a `requestId`, so the temporal position tells the CSMS
+   *    which upload it belonged to).
+   * 2. {@link OCPP16IncomingRequestService.resetStationState} on
+   *    `stop()`, following the cancel-before-delete ordering documented
+   *    on {@link OCPP20IncomingRequestService.resetStationState}.
+   */
+  activeDiagnosticsAbortController?: AbortController
+  /**
    * `setTimeout` handle for a deferred `updateFirmwareSimulation`
    * scheduled by the `UPDATE_FIRMWARE` event listener when the incoming
    * request carries a future `retrieveDate`. Released by
@@ -169,13 +192,19 @@ interface OCPP16StationState {
    *    `stationInfo.diagnosticsStatus` left at `Uploading` after an
    *    exception unwind does not leak to the CSMS, per OCPP 1.6 §4.4 /
    *    §7.24 (Idle when not busy uploading diagnostics).
-   * 2. `handleRequestGetDiagnostics`'s FTP-branch entry guard:
-   *    early-returns the empty `GetDiagnostics.conf` payload when a
-   *    prior lifecycle is still in flight, preventing concurrent FTP
-   *    uploads from racing on the same
-   *    `${chargingStationId}_logs.tar.gz` archive filename and
-   *    emitting duplicate `DiagnosticsStatusNotification` progress
-   *    messages to the CSMS.
+   * 2. `handleRequestGetDiagnostics`'s FTP-branch entry guard: indicates
+   *    that a prior lifecycle is still in flight and therefore must be
+   *    aborted before the new one claims the state. The abort path
+   *    piggybacks on `activeDiagnosticsAbortController`; the flag stays
+   *    `true` synchronously across the abort-then-install handoff so
+   *    the trigger cross-check above cannot observe a false idle window
+   *    during supersession. Once the superseding handler resolves
+   *    (normally, via early return, or via exception) its
+   *    identity-guarded `finally` clears the flag — the superseded
+   *    handler's terminal `UploadFailed` emission may still be in
+   *    flight after that point, and a trigger arriving during that
+   *    narrow window will observe `Idle` (transport already closed by
+   *    `ftpClient?.close()`, per §4.4 "not busy uploading").
    */
   diagnosticsUploadInProgress?: boolean
   /**
@@ -679,7 +708,7 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
             )
           }
           stationState.deferredFirmwareUpdateTimer = setTimeout(() => {
-            delete stationState.deferredFirmwareUpdateTimer
+            stationState.deferredFirmwareUpdateTimer = undefined
             this.updateFirmwareSimulation(chargingStation).catch((error: unknown) => {
               logger.error(
                 `${chargingStation.logPrefix()} ${moduleName}.constructor: UpdateFirmware simulation error:`,
@@ -717,14 +746,19 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
   /**
    * Release resources held by the per-station state. Called by the
    * inherited `stop()` template BEFORE the base deletes the WeakMap
-   * entry. Follow the abort-before-clear / cancel-before-delete
-   * ordering documented on
+   * entry. Follow the cancel-before-delete ordering documented on
    * {@link OCPP20IncomingRequestService.resetStationState}: abort
-   * in-flight signals BEFORE clearing controller references, cancel
-   * timers BEFORE the base template deletes the entry.
+   * in-flight signals and cancel timers BEFORE the base template
+   * deletes the state entry. The AbortController reference itself
+   * is left in place — WeakMap eviction reclaims the state object,
+   * and any still-unwinding handler's identity-guarded `finally`
+   * (see {@link OCPP16StationState.activeDiagnosticsAbortController})
+   * clears the fields on the now-orphaned object without racing a
+   * successor.
    * @param stationState - Per-station state to release.
    */
   protected override resetStationState (stationState: OCPP16StationState): void {
+    stationState.activeDiagnosticsAbortController?.abort()
     this.cancelDeferredFirmwareUpdate(stationState)
   }
 
@@ -736,7 +770,7 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
   private cancelDeferredFirmwareUpdate (stationState: OCPP16StationState): void {
     if (stationState.deferredFirmwareUpdateTimer != null) {
       clearTimeout(stationState.deferredFirmwareUpdateTimer)
-      delete stationState.deferredFirmwareUpdateTimer
+      stationState.deferredFirmwareUpdateTimer = undefined
     }
   }
 
@@ -1246,11 +1280,30 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
       let ftpClient: Client | undefined
       const stationState = this.getOrCreateStationState(chargingStation)
       if (stationState.diagnosticsUploadInProgress === true) {
-        logger.warn(
-          `${chargingStation.logPrefix()} ${moduleName}.handleRequestGetDiagnostics: skipped, a diagnostics upload lifecycle is already in flight`
+        // Supersede the in-flight lifecycle: abort it so its
+        // `basic-ftp` client is closed and its awaited `uploadFrom`
+        // promise rejects with `User closed client during task`, which
+        // the outer catch converts into a terminal
+        // `DiagnosticsStatusNotification(UploadFailed)` per OCPP 1.6
+        // §4.4 / §7.24. The `finally` clause of the superseded handler
+        // is identity-guarded and therefore will not clobber the state
+        // fields this new lifecycle is about to claim.
+        logger.info(
+          `${chargingStation.logPrefix()} ${moduleName}.handleRequestGetDiagnostics: Canceled previous diagnostics upload`
         )
-        return OCPP16Constants.OCPP_RESPONSE_EMPTY
+        stationState.activeDiagnosticsAbortController?.abort()
       }
+      const abortController = new AbortController()
+      // `basic-ftp` v6 does not natively consume `AbortSignal`; the
+      // documented interruption path is `Client.close()`, which invokes
+      // `FtpContext.close()` and rejects the pending task with
+      // `User closed client during task`.
+      // See `basic-ftp` `Client.js` / `FtpContext.js`.
+      const abortListener = (): void => {
+        ftpClient?.close()
+      }
+      abortController.signal.addEventListener('abort', abortListener, { once: true })
+      stationState.activeDiagnosticsAbortController = abortController
       stationState.diagnosticsUploadInProgress = true
       try {
         const logConfiguration = Configuration.getConfigurationSection<LogConfiguration>(
@@ -1355,7 +1408,11 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
           ) ?? errorResponse
         )
       } finally {
-        delete stationState.diagnosticsUploadInProgress
+        abortController.signal.removeEventListener('abort', abortListener)
+        if (stationState.activeDiagnosticsAbortController === abortController) {
+          stationState.activeDiagnosticsAbortController = undefined
+          stationState.diagnosticsUploadInProgress = undefined
+        }
       }
     } else {
       logger.warn(
@@ -2083,7 +2140,7 @@ export class OCPP16IncomingRequestService extends OCPPIncomingRequestService<OCP
         await chargingStation.reset(OCPP16StopTransactionReason.REBOOT)
       }
     } finally {
-      delete stationState.firmwareUpdateInProgress
+      stationState.firmwareUpdateInProgress = undefined
     }
   }
 }

--- a/tests/charging-station/ocpp/1.6/OCPP16IncomingRequestService-Firmware.test.ts
+++ b/tests/charging-station/ocpp/1.6/OCPP16IncomingRequestService-Firmware.test.ts
@@ -1,7 +1,11 @@
 /**
  * @file Tests for OCPP16IncomingRequestService firmware handlers
- * @description Unit tests for OCPP 1.6 GetDiagnostics (§6.1) and UpdateFirmware (§6.4)
- *   incoming request handlers
+ * @description Unit tests for OCPP 1.6 GetDiagnostics (§6.1) guard and
+ *   early-exit paths (feature-profile guard, non-FTP protocol, missing
+ *   log file, finally cleanup on early exit), and UpdateFirmware (§6.4)
+ *   incoming request handlers. Supersession semantics for GetDiagnostics
+ *   are covered in
+ *   {@link file://./OCPP16IncomingRequestService-GetDiagnostics.test.ts}.
  */
 
 import assert from 'node:assert/strict'
@@ -136,43 +140,6 @@ await describe('OCPP16IncomingRequestService — Firmware', async () => {
       assert.strictEqual(
         plumbing.stationsState.get(station)?.diagnosticsUploadInProgress,
         undefined
-      )
-    })
-
-    await it('should skip the diagnostics FTP upload when diagnosticsUploadInProgress is already set (concurrent invocation safety)', async t => {
-      // Regression guard: two concurrent GetDiagnostics.req arriving via
-      // the base-class dispatcher's fire-and-forget WebSocket message
-      // handling must not spawn concurrent FTP uploads racing on the same
-      // ${chargingStationId}_logs.tar.gz archive filename or emit
-      // duplicate DiagnosticsStatusNotification progress messages to the
-      // CSMS.
-
-      // Arrange
-      const { incomingRequestService, station, testableService } = context
-      upsertConfigurationKey(
-        station,
-        OCPP16StandardParametersKey.SupportedFeatureProfiles,
-        'Core,FirmwareManagement'
-      )
-      const plumbing = incomingRequestService as unknown as {
-        getOrCreateStationState: (cs: ChargingStation) => { diagnosticsUploadInProgress?: boolean }
-        stationsState: WeakMap<ChargingStation, { diagnosticsUploadInProgress?: boolean }>
-      }
-      plumbing.getOrCreateStationState(station).diagnosticsUploadInProgress = true
-      const warnSpy = t.mock.method(logger, 'warn')
-
-      // Act
-      const response = await testableService.handleRequestGetDiagnostics(station, {
-        location: 'ftp://localhost/diagnostics',
-      })
-
-      // Assert
-      assert.strictEqual(Object.keys(response).length, 0)
-      assert.strictEqual(plumbing.stationsState.get(station)?.diagnosticsUploadInProgress, true)
-      const warnMessages = warnSpy.mock.calls.map(call => call.arguments[0] as unknown as string)
-      assert.ok(
-        warnMessages.some(m => m.includes('a diagnostics upload lifecycle is already in flight')),
-        `expected an "already in flight" warning, got: ${JSON.stringify(warnMessages)}`
       )
     })
   })

--- a/tests/charging-station/ocpp/1.6/OCPP16IncomingRequestService-GetDiagnostics.test.ts
+++ b/tests/charging-station/ocpp/1.6/OCPP16IncomingRequestService-GetDiagnostics.test.ts
@@ -1,0 +1,340 @@
+/**
+ * @file Tests for OCPP16IncomingRequestService GetDiagnostics supersession semantics
+ * @description Unit tests for OCPP 1.6 GetDiagnostics (§6.1) supersession
+ *   lifecycle backed by `activeDiagnosticsAbortController` on
+ *   `OCPP16StationState`. Exercises the entry guard's abort-then-install
+ *   pattern and the identity-guarded finally cleanup that lets a superseding
+ *   handler claim state fields without the superseded handler's late cleanup
+ *   clobbering them.
+ *
+ *   Test strategy: `basic-ftp` `Client` is not directly mockable in this
+ *   project — the import is module-scoped, there is no dependency-injection
+ *   seam, and `--experimental-test-module-mocks` is not enabled by the test
+ *   script. The FTP branch is instead exercised through the no-log-file
+ *   early-exit inside its `try` block (mocking
+ *   `Configuration.getConfigurationSection` so `logConfiguration.file` is
+ *   `undefined`). That path still claims state (`abortController` set,
+ *   `diagnosticsUploadInProgress = true`), enters the `try`, returns the empty
+ *   response, and runs `finally` — covering the entire state lifecycle without
+ *   touching the network. Supersession is verified by pre-populating
+ *   `stationState.activeDiagnosticsAbortController` on a spy
+ *   `AbortController` and asserting its `signal.aborted === true` after a
+ *   superseding dispatch returns; the peek-inside-the-try trick captures the
+ *   fresh controller before `finally` clears it.
+ */
+
+import assert from 'node:assert/strict'
+import { afterEach, beforeEach, describe, it } from 'node:test'
+
+import type { ChargingStation } from '../../../../src/charging-station/index.js'
+import type { OCPP16IncomingRequestService } from '../../../../src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.js'
+import type { GetDiagnosticsRequest } from '../../../../src/types/index.js'
+
+import { ConfigurationSection, OCPP16StandardParametersKey } from '../../../../src/types/index.js'
+import { Configuration } from '../../../../src/utils/index.js'
+import { standardCleanup } from '../../../helpers/TestLifecycleHelpers.js'
+import {
+  createOCPP16IncomingRequestTestContext,
+  type OCPP16IncomingRequestTestContext,
+  setMockRequestHandler,
+  upsertConfigurationKey,
+} from './OCPP16TestUtils.js'
+
+interface OCPP16StationStateShape {
+  activeDiagnosticsAbortController?: AbortController
+  diagnosticsUploadInProgress?: boolean
+}
+
+interface PlumbingAccess {
+  getOrCreateStationState: (chargingStation: ChargingStation) => OCPP16StationStateShape
+  stationsState: WeakMap<ChargingStation, OCPP16StationStateShape>
+}
+
+const asPlumbing = (service: OCPP16IncomingRequestService): PlumbingAccess =>
+  service as unknown as PlumbingAccess
+
+const enableFirmwareManagement = (station: ChargingStation): void => {
+  upsertConfigurationKey(
+    station,
+    OCPP16StandardParametersKey.SupportedFeatureProfiles,
+    'Core,FirmwareManagement'
+  )
+}
+
+const FTP_LOCATION = 'ftp://localhost/diagnostics'
+const HTTP_LOCATION = 'http://localhost/diagnostics'
+
+await describe('OCPP16IncomingRequestService — GetDiagnostics supersession', async () => {
+  let context: OCPP16IncomingRequestTestContext
+
+  beforeEach(() => {
+    context = createOCPP16IncomingRequestTestContext()
+  })
+
+  afterEach(() => {
+    standardCleanup()
+  })
+
+  await it('should claim activeDiagnosticsAbortController on entry and release both fields in the finally block', async t => {
+    // Arrange
+    const { incomingRequestService, station, testableService } = context
+    enableFirmwareManagement(station)
+    const plumbing = asPlumbing(incomingRequestService)
+
+    let midHandlerController: AbortController | undefined
+    let midHandlerInProgress: boolean | undefined
+    t.mock.method(Configuration, 'getConfigurationSection', (section: ConfigurationSection) => {
+      if (section === ConfigurationSection.log) {
+        const midState = plumbing.stationsState.get(station)
+        midHandlerController = midState?.activeDiagnosticsAbortController
+        midHandlerInProgress = midState?.diagnosticsUploadInProgress
+        return { file: undefined }
+      }
+      return {}
+    })
+
+    const request: GetDiagnosticsRequest = { location: FTP_LOCATION }
+
+    // Act
+    const response = await testableService.handleRequestGetDiagnostics(station, request)
+
+    // Assert — mid-handler state was claimed with a fresh, non-aborted controller
+    assert.strictEqual(Object.keys(response).length, 0)
+    assert.notStrictEqual(
+      midHandlerController,
+      undefined,
+      'activeDiagnosticsAbortController must be set before the log-configuration read'
+    )
+    assert.ok(midHandlerController instanceof AbortController)
+    assert.strictEqual(midHandlerController.signal.aborted, false)
+    assert.strictEqual(midHandlerInProgress, true)
+
+    // Assert — finally released both fields symmetrically
+    const finalState = plumbing.stationsState.get(station)
+    assert.strictEqual(finalState?.activeDiagnosticsAbortController, undefined)
+    assert.strictEqual(finalState?.diagnosticsUploadInProgress, undefined)
+  })
+
+  await it('should abort the prior in-flight controller and install a fresh controller when a superseding request arrives', async t => {
+    // Arrange — pre-populate an in-flight lifecycle so the next dispatch takes
+    // the supersession branch of the entry guard.
+    const { incomingRequestService, station, testableService } = context
+    enableFirmwareManagement(station)
+    const plumbing = asPlumbing(incomingRequestService)
+
+    const priorController = new AbortController()
+    const priorState = plumbing.getOrCreateStationState(station)
+    priorState.activeDiagnosticsAbortController = priorController
+    priorState.diagnosticsUploadInProgress = true
+
+    let midHandlerController: AbortController | undefined
+    t.mock.method(Configuration, 'getConfigurationSection', (section: ConfigurationSection) => {
+      if (section === ConfigurationSection.log) {
+        midHandlerController = plumbing.stationsState.get(station)?.activeDiagnosticsAbortController
+        return { file: undefined }
+      }
+      return {}
+    })
+
+    // Act
+    const response = await testableService.handleRequestGetDiagnostics(station, {
+      location: FTP_LOCATION,
+    })
+
+    // Assert — prior controller was aborted by the entry guard
+    assert.strictEqual(Object.keys(response).length, 0)
+    assert.strictEqual(
+      priorController.signal.aborted,
+      true,
+      'the prior in-flight AbortController must be signalled on supersession'
+    )
+
+    // Assert — a fresh, non-aborted controller replaced the prior one mid-handler
+    assert.notStrictEqual(midHandlerController, undefined)
+    assert.notStrictEqual(
+      midHandlerController,
+      priorController,
+      'the superseding handler must install a fresh AbortController'
+    )
+    assert.strictEqual(midHandlerController?.signal.aborted, false)
+
+    // Assert — finally released both fields (identity guard matched)
+    const finalState = plumbing.stationsState.get(station)
+    assert.strictEqual(finalState?.activeDiagnosticsAbortController, undefined)
+    assert.strictEqual(finalState?.diagnosticsUploadInProgress, undefined)
+  })
+
+  await it('should start subsequent dispatches with a fresh, non-aborted controller after a supersession', async t => {
+    // Arrange — pre-populate to force B to supersede A. Then a follow-up C
+    // dispatches on the clean state left by B's finally.
+    const { incomingRequestService, station, testableService } = context
+    enableFirmwareManagement(station)
+    const plumbing = asPlumbing(incomingRequestService)
+
+    const priorController = new AbortController()
+    const priorState = plumbing.getOrCreateStationState(station)
+    priorState.activeDiagnosticsAbortController = priorController
+    priorState.diagnosticsUploadInProgress = true
+
+    const observedControllers: (AbortController | undefined)[] = []
+    t.mock.method(Configuration, 'getConfigurationSection', (section: ConfigurationSection) => {
+      if (section === ConfigurationSection.log) {
+        observedControllers.push(
+          plumbing.stationsState.get(station)?.activeDiagnosticsAbortController
+        )
+        return { file: undefined }
+      }
+      return {}
+    })
+
+    // Act — B (supersedes A), then C (fresh)
+    await testableService.handleRequestGetDiagnostics(station, { location: FTP_LOCATION })
+    await testableService.handleRequestGetDiagnostics(station, { location: FTP_LOCATION })
+
+    // Assert — B and C each installed their own fresh controller, distinct from
+    // the pre-populated prior controller and from each other.
+    assert.strictEqual(observedControllers.length, 2)
+    const [duringB, duringC] = observedControllers
+    assert.notStrictEqual(duringB, undefined)
+    assert.notStrictEqual(duringC, undefined)
+    assert.notStrictEqual(duringB, priorController)
+    assert.notStrictEqual(duringC, priorController)
+    assert.notStrictEqual(
+      duringB,
+      duringC,
+      'each dispatch must install its own fresh AbortController'
+    )
+    assert.strictEqual(duringC?.signal.aborted, false)
+
+    const finalState = plumbing.stationsState.get(station)
+    assert.strictEqual(finalState?.activeDiagnosticsAbortController, undefined)
+    assert.strictEqual(finalState?.diagnosticsUploadInProgress, undefined)
+  })
+
+  await it('should abort activeDiagnosticsAbortController and delete the WeakMap entry on stop()', () => {
+    // Arrange — pre-populate an in-flight lifecycle, then stop.
+    const { incomingRequestService, station } = context
+    const plumbing = asPlumbing(incomingRequestService)
+    const inflightController = new AbortController()
+    const state = plumbing.getOrCreateStationState(station)
+    state.activeDiagnosticsAbortController = inflightController
+    state.diagnosticsUploadInProgress = true
+
+    // Act
+    incomingRequestService.stop(station)
+
+    // Assert — cancel-before-delete ordering: the signal must fire before the
+    // base template deletes the WeakMap entry, and the entry must be gone.
+    assert.strictEqual(
+      inflightController.signal.aborted,
+      true,
+      'stop() must signal the in-flight diagnostics AbortController'
+    )
+    assert.strictEqual(plumbing.stationsState.has(station), false)
+  })
+
+  await it('should not install activeDiagnosticsAbortController for non-FTP locations', async () => {
+    // Arrange — the else branch calls ocppRequestService.requestHandler to send
+    // DiagnosticsStatusNotification(UploadFailed); stub it out.
+    const { incomingRequestService, station, testableService } = context
+    enableFirmwareManagement(station)
+    setMockRequestHandler(station, async () => Promise.resolve({}))
+    const plumbing = asPlumbing(incomingRequestService)
+
+    // Act
+    const response = await testableService.handleRequestGetDiagnostics(station, {
+      location: HTTP_LOCATION,
+    })
+
+    // Assert — the AbortController plumbing lives inside the FTP branch only.
+    assert.strictEqual(Object.keys(response).length, 0)
+    const state = plumbing.stationsState.get(station)
+    assert.strictEqual(state?.activeDiagnosticsAbortController, undefined)
+    assert.strictEqual(state?.diagnosticsUploadInProgress, undefined)
+  })
+
+  await it('should keep diagnosticsUploadInProgress true across the supersession handoff so the trigger cross-check never sees false-idle', async t => {
+    // Arrange — pre-populate an in-flight lifecycle. During the superseding
+    // handler's try block (before finally clears state), the flag must remain
+    // true. The trigger cross-check at handleRequestTriggerMessage's
+    // DiagnosticsStatusNotification case reads exactly this predicate
+    // (`stationsState.get(chargingStation)?.diagnosticsUploadInProgress === true`);
+    // JS single-threaded semantics guarantee the read cannot interleave with a
+    // partial state mutation.
+    const { incomingRequestService, station, testableService } = context
+    enableFirmwareManagement(station)
+    const plumbing = asPlumbing(incomingRequestService)
+
+    const priorController = new AbortController()
+    const priorState = plumbing.getOrCreateStationState(station)
+    priorState.activeDiagnosticsAbortController = priorController
+    priorState.diagnosticsUploadInProgress = true
+
+    let midHandlerInProgress: boolean | undefined
+    t.mock.method(Configuration, 'getConfigurationSection', (section: ConfigurationSection) => {
+      if (section === ConfigurationSection.log) {
+        midHandlerInProgress = plumbing.stationsState.get(station)?.diagnosticsUploadInProgress
+        return { file: undefined }
+      }
+      return {}
+    })
+
+    // Act
+    await testableService.handleRequestGetDiagnostics(station, {
+      location: FTP_LOCATION,
+    })
+
+    // Assert — flag observed as true mid-handoff, cleared after finally.
+    assert.strictEqual(
+      midHandlerInProgress,
+      true,
+      'diagnosticsUploadInProgress must remain true across the supersession handoff'
+    )
+    assert.strictEqual(plumbing.stationsState.get(station)?.diagnosticsUploadInProgress, undefined)
+  })
+
+  await it('should isolate supersession state between stations so an abort on A does not touch B', async t => {
+    // Arrange — one shared service, two stations with independent state entries.
+    const { incomingRequestService, station: stationA, testableService } = context
+    const { station: stationB } = createOCPP16IncomingRequestTestContext({
+      baseName: 'get-diag-iso-b',
+    })
+    enableFirmwareManagement(stationA)
+
+    const plumbing = asPlumbing(incomingRequestService)
+    const priorAController = new AbortController()
+    const stateA = plumbing.getOrCreateStationState(stationA)
+    stateA.activeDiagnosticsAbortController = priorAController
+    stateA.diagnosticsUploadInProgress = true
+
+    const priorBController = new AbortController()
+    const stateB = plumbing.getOrCreateStationState(stationB)
+    stateB.activeDiagnosticsAbortController = priorBController
+    stateB.diagnosticsUploadInProgress = true
+
+    t.mock.method(Configuration, 'getConfigurationSection', (section: ConfigurationSection) => {
+      if (section === ConfigurationSection.log) {
+        return { file: undefined }
+      }
+      return {}
+    })
+
+    // Act — supersede A only.
+    await testableService.handleRequestGetDiagnostics(stationA, {
+      location: FTP_LOCATION,
+    })
+
+    // Assert — A aborted and cleaned.
+    assert.strictEqual(priorAController.signal.aborted, true)
+    const finalA = plumbing.stationsState.get(stationA)
+    assert.strictEqual(finalA?.activeDiagnosticsAbortController, undefined)
+    assert.strictEqual(finalA?.diagnosticsUploadInProgress, undefined)
+
+    // Assert — B fully untouched (controller reference preserved, not aborted).
+    assert.strictEqual(priorBController.signal.aborted, false)
+    const finalB = plumbing.stationsState.get(stationB)
+    assert.ok(finalB, 'station B state entry must survive station A supersession')
+    assert.strictEqual(finalB.activeDiagnosticsAbortController, priorBController)
+    assert.strictEqual(finalB.diagnosticsUploadInProgress, true)
+  })
+})


### PR DESCRIPTION
Closes #1971

## Bug

`OCPP16IncomingRequestService.handleRequestGetDiagnostics` at [`src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts`](../blob/fix/ocpp16-diagnostics-supersession-abort-controller/src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts) lacked supersession semantics. The entry guard added in PR #1987 detected an in-flight lifecycle via `diagnosticsUploadInProgress === true` and returned the empty `GetDiagnostics.conf` payload — this prevented concurrent FTP uploads racing on the same `${chargingStationId}_logs.tar.gz` archive filename but silently dropped the second request instead of aborting the old upload and starting a fresh one, and emitted no terminal `DiagnosticsStatusNotification(UploadFailed)` for the "superseded" attempt.

## Fix

Four touchpoints (post-fix line numbers on `fix/ocpp16-diagnostics-supersession-abort-controller` @ `cfbc3cc5f`):

| # | File | Symbol | Anchor | Change |
|---|------|--------|--------|--------|
| 1 | `src/charging-station/ocpp/1.6/OCPP16IncomingRequestService.ts` | `interface OCPP16StationState` | Field decl at L177 | Add `activeDiagnosticsAbortController?: AbortController` alphabetically above the existing `deferredFirmwareUpdateTimer` / `diagnosticsUploadInProgress` / `firmwareUpdateInProgress` fields. Update the JSDoc on `diagnosticsUploadInProgress` (L186-L208) to describe the new abort-then-install handoff instead of the removed skip-second semantic. |
| 2 | same file | `handleRequestGetDiagnostics` FTP-branch entry guard | Supersede at L1282-L1295; install fresh controller at L1296-L1307 | Refactor from skip-second early-return into abort-then-install: call `stationState.activeDiagnosticsAbortController?.abort()` on the prior controller, log `info` (`Canceled previous diagnostics upload`, matching the OCPP 2.0.1 supersession log convention), then construct a fresh `AbortController` and wire the abort listener before assigning it to state. `diagnosticsUploadInProgress` stays `true` across the abort-then-install handoff — the trigger cross-check never observes a false-idle window during supersession (per §4.4 / §7.24). |
| 3 | same file | `handleRequestGetDiagnostics` FTP flow + `finally` | Listener wire-up at L1300-L1305; identity-guarded cleanup at L1410-L1415 | `basic-ftp` v6 does not natively consume `AbortSignal` (verified: `"basic-ftp": "^6.0.1"` in `package.json`; the library's documented interruption path is `Client.close()`, which invokes `FtpContext.close()` and rejects the pending `uploadFrom` task with `User closed client during task`). The handler installs `signal.addEventListener('abort', () => ftpClient?.close(), { once: true })` before the try block, removes it in `finally`, and identity-guards the state cleanup so a superseded handler's late unwind cannot clobber the new lifecycle's state fields. The existing `catch` at L1390 already emits `DiagnosticsStatusNotification(UploadFailed)` for any thrown error, so a close-triggered rejection flows through unchanged — **no second emission needed**. |
| 4 | same file | `resetStationState` override | L760-L763 | Abort the in-flight controller **before** delegating to `cancelDeferredFirmwareUpdate`, following the cancel-before-delete ordering documented on `OCPP20IncomingRequestService.resetStationState`. The 1.6 body only aborts (does not clear controller references) — WeakMap eviction reclaims the state object, and any still-unwinding handler's identity-guarded `finally` clears the fields on the now-orphaned state object without racing a successor. |

## Design rationale — identity-guarded finally over microtask yield

The initial design sketch used a `setImmediate` yield after `abort()` to give the prior lifecycle's `finally` block a chance to clear its state fields before the new lifecycle claimed them. The shipped implementation replaces that with an **identity guard** inside `finally`:

```ts
finally {
  abortController.signal.removeEventListener('abort', abortListener)
  if (stationState.activeDiagnosticsAbortController === abortController) {
    stationState.activeDiagnosticsAbortController = undefined
    stationState.diagnosticsUploadInProgress = undefined
  }
}
```

Each handler captures its own local `abortController` reference. The superseded handler's `finally` compares that local reference against the state's current field; if a superseding handler has already overwritten the state, the identity check fails and the superseded handler's cleanup is a no-op. This removes the ordering dependency between the two handlers' async continuations entirely — no yield discipline, no timing assumption. Cleaner primitive; documented on both the interface JSDoc and the finally-clause comment.

## OCPP 1.6 spec anchors (verbatim from `docs/ocpp16/ocpp-1.6 edition 2.md`)

### §4.4 Diagnostics Status Notification (L880)

> Charge Point sends a notification to inform the Central System about the status of a diagnostics upload. The Charge Point SHALL send a DiagnosticsStatusNotification.req PDU to inform the Central System that the upload of diagnostics is busy or has finished successfully or failed. **The Charge Point SHALL only send the status Idle after receipt of a TriggerMessage for a Diagnostics Status Notification, when it is not busy uploading diagnostics.**

### §6.17 DiagnosticsStatusNotification.req (L1595-1599)

> This contains the field definition of the DiagnosticsStatusNotification.req PDU sent by the Charge Point to the Central System.
>
> | FIELD NAME | FIELD TYPE | CARD. | DESCRIPTION |
> |---|---|---|---|
> | status | DiagnosticsStatus | 1..1 | Required. This contains the status of the diagnostics upload. |

**Note:** OCPP 1.6 `DiagnosticsStatusNotification.req` does **not** carry a `requestId` field. The terminal `UploadFailed` notification for the superseded upload is uncorrelated by design; only its temporal position tells the CSMS which upload it belonged to. This is the concrete OCPP 1.6 vs 2.0.1 semantic asymmetry: 2.0.1 `LogStatusNotification` carries a `requestId` that can name-check the superseded attempt (`AcceptedCanceled` sentinel), 1.6 does not.

### §6.25 GetDiagnostics.req / §6.26 GetDiagnostics.conf (L1644-1654)

> \[§6.26\] This contains the field definition of the GetDiagnostics.conf PDU sent by the Charge Point to the Central System in response to a GetDiagnostics.req PDU.
>
> | FIELD NAME | FIELD TYPE | CARD. | DESCRIPTION |
> |---|---|---|---|
> | fileName | CiString255Type | 0..1 | **Optional. This contains the name of the file with diagnostic information that will be uploaded. This field is not present when no diagnostic information is available.** |

Anchor for "the superseding request's response contract stays as-is": the new lifecycle's `.conf` carries `fileName` on success (existing behavior at L1376); the superseded request's `.conf` was already sent when its handler entered the FTP branch, and is unaffected by the later abort. There is no `AcceptedCanceled` semantic in OCPP 1.6.

### §7.24 DiagnosticsStatus (L2035-2041)

> Enumeration. Status in DiagnosticsStatusNotification.req.
>
> | VALUE | DESCRIPTION |
> |---|---|
> | Idle | **Charge Point is not performing diagnostics related tasks. Status Idle SHALL only be used as in a DiagnosticsStatusNotification.req that was triggered by a TriggerMessage.req** |
> | Uploaded | Diagnostics information has been uploaded. |
> | **UploadFailed** | **Uploading of diagnostics failed.** |
> | Uploading | File is being uploaded. |

Anchor for the terminal notification emitted by the existing `catch` when the aborted `uploadFrom` rejects.

## Reference — OCPP 2.0.1 log-upload supersession pattern

Mirrors the shape of the 2.0.1 pattern shipped in commits:

- `29a8330f` — `fix(ocpp20): cross-check firmware status against active requestId in trigger` (trigger-side dual-gate)
- `ac6ed218` — `fix(ocpp20): apply dual-gate to LogStatusNotification trigger` (activeLogUploadRequestId + activeLogUploadStatus)
- `64f384fa` — `fix(ocpp20): implement log-upload supersession per OCPP 2.0.1 N01.FR.12`
- `be29b4c8` — `fix(ocpp20): add AbortController to log-upload lifecycle + canceled spelling` (activeLogUploadAbortController on OCPP20StationState)

The OCPP 1.6 shape differs on three axes:
1. **No `requestId`** in `DiagnosticsStatusNotification.req` (§6.17) → terminal notification is uncorrelated.
2. **No `AcceptedCanceled` semantic** in `GetDiagnostics.conf` (§6.26) → superseding request returns the standard `fileName`-carrying response.
3. **Boolean flag** (`diagnosticsUploadInProgress`) rather than `requestId`-presence sentinel — same rationale as the OCPP 1.6 flags introduced in PR #1987: `GetDiagnostics.req` payload carries no requestId.

The `logger.info(... Canceled previous diagnostics upload)` log at L1292 matches the OCPP 2.0.1 supersession log convention: `handleRequestGetLog: Canceled previous log upload (requestId ...)` at `OCPP20IncomingRequestService.ts:2202` and `handleRequestUpdateFirmware: Canceled previous firmware update (requestId ...)` at `OCPP20IncomingRequestService.ts:3221` also use `logger.info` + `Canceled previous ...`. The 1.6 message drops the `(requestId ...)` suffix because OCPP 1.6 `GetDiagnostics.req` carries no requestId.

**Log-message vocabulary rationale**: OCPP 1.6 §4.4 / §7.24 impose no vocabulary constraint on the `GetDiagnostics` supersession event (the spec is silent on concurrent `GetDiagnostics.req` handling). The verb "cancel" is adopted by analogy with (a) the OCPP 2.0.1 supersession peers cited above, and (b) the OCPP 1.6 security whitepaper §N01.FR.11 — which governs the structurally analogous `GetLog` (not `GetDiagnostics`) supersession and prescribes "cancel the ongoing log file upload AND respond with status AcceptedCanceled." The American-spelled `AcceptedCanceled` enum values shipped across the codebase confirm the spelling convention.

**State-cleanup idiom (R7-E-1 harmonization)**: This PR harmonizes the 1.6 file to use `stationState.field = undefined` for clearing optional lifecycle state fields, matching the OCPP 2.0.1 `resetActive*State` helpers' convention. Pre-existing `delete stationState.field` sites at L711 / L773 / L2143 (from PR #1984 / #1984 / #1987) are also updated in the same amend to preserve within-file uniformity; both idioms are semantically equivalent for `?:` optional fields under `strict: true` without `exactOptionalPropertyTypes`. The final result is 5/5 within-file uniformity in 1.6 AND cross-file consistency with 2.0.1's 5-site `= undefined` convention.

The entry guard from PR #1987 (skip-second) is now superseded by the abort-then-install pattern.

## Tests

New file: [`tests/charging-station/ocpp/1.6/OCPP16IncomingRequestService-GetDiagnostics.test.ts`](../blob/fix/ocpp16-diagnostics-supersession-abort-controller/tests/charging-station/ocpp/1.6/OCPP16IncomingRequestService-GetDiagnostics.test.ts) — **7 targeted supersession tests**.

Test strategy is documented in the file's JSDoc: `basic-ftp`'s `Client` is not directly mockable (module-scoped import, no DI seam, `--experimental-test-module-mocks` not enabled by the test script). The FTP branch is instead exercised through the no-log-file early-exit inside its `try` block (mocking `Configuration.getConfigurationSection` so `logConfiguration.file` is `undefined`). That path still claims state (`abortController` set, `diagnosticsUploadInProgress = true`), enters the `try`, returns the empty response, and runs `finally` — covering the entire state lifecycle without touching the network.

1. **Baseline** — should claim `activeDiagnosticsAbortController` on entry and release both fields in the `finally` block.
2. **Supersession — abort-then-install** — should abort the prior in-flight controller and install a fresh controller when a superseding request arrives.
3. **Clean cleanup after supersession** — should start subsequent dispatches with a fresh, non-aborted controller after a supersession.
4. **`stop()` during upload** — should abort `activeDiagnosticsAbortController` and delete the WeakMap entry on `stop()`. Assert comment uses `cancel-before-delete ordering` post-R11-T-3.
5. **Non-FTP path** — should not install `activeDiagnosticsAbortController` for non-FTP locations.
6. **Trigger cross-check preserved** — should keep `diagnosticsUploadInProgress === true` across the supersession handoff.
7. **Two-station isolation** — should isolate supersession state between stations so an abort on A does not touch B.

**Removed** from `OCPP16IncomingRequestService-Firmware.test.ts`: the "skip when `diagnosticsUploadInProgress` is already set" regression test at L138-181 (which tested the pre-supersession skip-second contract). Its semantic is superseded by test 2 above. The file's `@description` was expanded to scope its remaining GetDiagnostics coverage as guard/early-exit only, with a cross-reference to the new supersession test file.

## Verification gates (all green)

- `pnpm format` — clean
- `pnpm typecheck` — exit 0
- `pnpm lint` — 0 errors, 0 warnings on edited files
- `pnpm test` — **3020 pass / 0 fail / 6 skipped** (baseline @ `0ed90b1dc`: 3014; **+6 net new tests**)
- `pnpm build` — exit 0

## Mechanical invariants (verified @ commit `cfbc3cc5f`)

- `activeDiagnosticsAbortController` — 8 grep hits: interface decl L177 / JSDoc ref (in `diagnosticsUploadInProgress` block) L198 / JSDoc `{@link}` (in `resetStationState` block) L755 / resetStationState abort L761 / entry-guard abort-old L1294 / entry-guard set-new L1306 / finally identity check L1412 / finally clear L1413. The 5 semantic sites bundle abort-old + set-new as one entry-guard replacement.
- `diagnosticsUploadInProgress` — 6 hits, symmetric: JSDoc L158 / interface decl L209 / **trigger cross-check L496** (unchanged from PR #1987) / entry-guard read L1282 / set L1307 / clear L1414.
- Old skip-second log string (`skipped, a diagnostics upload lifecycle is already in flight`) — **0 hits** (removed).
- `abort-before-clear` (R9-D-1 phantom-step wording) — **0 hits codebase-wide** (R11-T-3 cleaned the last surviving instance in the test file).
- `cancel-before-delete` — 3 codebase-wide hits (2 in source JSDoc post-R9-D-1, 1 in test 4's `// Assert` comment post-R11-T-3).
- `#1971` references in the file — **0**.
- Zero `as any` / `@ts-ignore` / `@ts-expect-error` / `!` non-null assertions in new code.
- **State-cleanup idiom (R7-E-1)**: `delete stationState.*` = 0 hits; `stationState.\w+ = undefined` = 5 hits (uniform 1.6 file; matches OCPP 2.0.1's 5-site `= undefined` convention).
- Diff scope: exactly 3 files vs `origin/main`.

## Review rounds — cumulative register

Eleven rounds of review with ≥2 parallel reviewers each.

### Round 1 @ tip `5ba9ef45a`
- **R1-F1 [FIXED] @ `df79be39a`** — JSDoc scoping softened on `diagnosticsUploadInProgress`.
- R1-F2/F3/F5/F6 [REJECTED] with quoted counter-evidence.

### Round 2 @ tip `df79be39a`
- **R2-F1 [FIXED]** — PR body line-number drift after R1-F1 amend.

### Round 3 @ tip `df79be39a` (expanded scope)
- **R3-E1 [FIXED] @ `5398d3140`** — JSDoc "three sites" → "two sites".
- **R3-E2 [FIXED] @ `5398d3140`** — JSDoc "ownership check" → "identity guard".
- **R3-L1 [FIXED] @ `5398d3140`** — Log message aligned to `Canceled previous diagnostics upload`.
- **R3-E4 [FIXED] @ `262122f91`** (reversed from initial [REJECTED]) — Test 7 title single-clause alignment.
- R3-L2/L3 [REJECTED] — user prompt explicitly requires these sections.

### Round 4 @ tip `5398d3140`
- Zero new valid findings. Termination clause met.

### Round 5 @ tip `262122f91` (expanded scope, updated discipline)
- **R5-A [FIXED] @ `3d7690fd8`** — PR body §N01.FR.11 attribution corrected.
- **R5-F1 [FIXED] @ `3d7690fd8`** — Commit message body catch-line number.
- **R5-F2 [FIXED] @ `3d7690fd8`** — `Firmware.test.ts` `@description` scope expanded.
- **R5-F3 [FIXED] @ `3d7690fd8`** — JSDoc L195 `signals` → `indicates`.
- **R5-F4 [FIXED] @ `3d7690fd8`** — Inline L1279 wording.
- **R5-F5 [FIXED] @ `3d7690fd8`** — Inline L1295 rewording with verbatim error string.
- **R5-F6 [FIXED] @ `3d7690fd8`** — Pattern-name `abort-then-install` aligned across all 5 canonical sites.

### Round 6 @ tip `3d7690fd8`
- Zero new valid findings. Termination clause met.

### Round 7 @ tip `3d7690fd8` (expanded scope, updated discipline)
- **R7-E-1 [FIXED] @ `340f64ec9`** (reversed from initial [REJECTED] on maintainer directive) — 5 sites in the 1.6 file harmonized from `delete stationState.X` to `stationState.X = undefined`.
- R7-G-3 [REJECTED] — false positive (grep count verified).
- R7-T9-O1 [REJECTED] — documented cost/benefit trade-off (test scaffolding cost > gain).

### Round 8 @ tip `340f64ec9`
- Zero new valid findings. Semantic equivalence of `delete` vs `= undefined` proven by exhaustive codebase search.

### Round 9 @ tip `340f64ec9` (expanded scope)
- **R9-D-1 [FIXED] @ `138c3a309`** — JSDoc on `resetStationState` reworded from "abort-before-clear" phantom-step to "cancel-before-delete" ordering matching 1.6's actual body.
- **R9-G-1 [FIXED] @ `138c3a309`** — PR body 4 commit titles aligned to actual `git log` verbatim.
- **R9-J1 [FIXED] @ `138c3a309`** — JSDoc L207 `Client.close()` → `ftpClient?.close()`.

### Round 10 @ tip `138c3a309`
- Zero new valid findings. Termination clause met.

### Round 11 @ tip `138c3a309` (expanded scope, updated discipline)
- **R11-T-3 [FIXED] @ `cfbc3cc5f`** — oracle + explore both surfaced — Test file `OCPP16IncomingRequestService-GetDiagnostics.test.ts:226` `// Assert` comment used stale `abort-before-clear ordering` (removed from source by R9-D-1). Aligned to canonical `cancel-before-delete ordering`. Codebase-wide grep post-fix: 0 hits for `abort-before-clear`. Auto-fixes Oracle F2 (mechanical invariants section now literally accurate).
- **R11-T-1 [REJECTED]** — explore NIT claim that `GetDiagnostics.test.ts:3` `@description ... GetDiagnostics (§6.1)` uses the wrong section anchor (allegedly should be `§6.25/§6.26`). Category 1 (false positive with verbatim codebase counter-evidence): the reviewer confused two OCPP 1.6 documents. Codebase convention across **11 test files** uses profile-based section numbering matching the **OCPP 1.6 Compliance Test Cases** doc (published by OCA, external), not the OCPP-1.6-J main spec PDU-definition numbering:<br>• `Configuration.test.ts:3` — `ChangeConfiguration (§5.4) and GetConfiguration (§5.8)`<br>• `RemoteStartTransaction.test.ts:3` — `RemoteStartTransaction ... (§5.11)`<br>• `BootAuth.test.ts:3` — `BootNotification (§4.1) and Authorize (§4.2)`<br>• `Reservation.test.ts:3` — `ReserveNow (§8.2) and CancelReservation (§8.1)`<br>• `Firmware.test.ts:3` — `GetDiagnostics (§6.1) ... UpdateFirmware (§6.4)`<br>• `Reset.test.ts:3` — `Reset ... (§5.13)`<br>• `RemoteStopUnlock.test.ts:3` — `RemoteStopTransaction (§5.12) and UnlockConnector (§5.17)`<br>• `TriggerMessage.test.ts:3` — `TriggerMessage (§10.1)`<br>• `Transactions.test.ts:3` — `StartTransaction (§5.14) and StopTransaction (§5.16)`<br>Per-test `@spec §X.Y — TC_NNN_CS` tags use the same numbering with explicit `TC_NNN_CS` (Compliance Test Case) IDs. Applying the reviewer's suggested fix would break the codebase-wide profile-based convention and insert non-existent-per-that-doc section numbers.
- **R11-T-2 [REJECTED]** — same class as R11-T-1, same rejection reason (Category 1 false positive with the same codebase-wide profile-based convention counter-evidence).

**Zero remaining valid findings.** Ready to squash.