### PR TITLE
test(ocpp): cover OCPP 2.0.1 log/firmware lifecycle supersession and cleanup paths

### DIFF
--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-GetLog.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-GetLog.test.ts
@@ -1,6 +1,6 @@
 /**
  * @file Tests for OCPP20IncomingRequestService GetLog
- * @description Unit tests for OCPP 2.0.1 GetLog command handling (K01) and
+ * @description Unit tests for OCPP 2.0.1 GetLog command handling (N01) and
  *   LogStatusNotification lifecycle simulation per N01
  */
 
@@ -17,10 +17,11 @@ import {
   type OCPP20GetLogRequest,
   type OCPP20GetLogResponse,
   OCPP20IncomingRequestCommand,
+  OCPP20RequestCommand,
   OCPPVersion,
   UploadLogStatusEnumType,
 } from '../../../../src/types/index.js'
-import { Constants } from '../../../../src/utils/index.js'
+import { Constants, logger } from '../../../../src/utils/index.js'
 import {
   flushMicrotasks,
   standardCleanup,
@@ -30,7 +31,24 @@ import { TEST_CHARGING_STATION_BASE_NAME } from '../../ChargingStationTestConsta
 import { createMockChargingStation } from '../../helpers/StationHelpers.js'
 import { createMockStationWithRequestTracking } from './OCPP20TestUtils.js'
 
-await describe('K01 - GetLog', async () => {
+interface LogUploadPlumbing {
+  clearActiveLogUpload: (chargingStation: ChargingStation, requestId: number) => void
+  getOrCreateStationState: (chargingStation: ChargingStation) => LogUploadStateShape
+  simulateLogUploadLifecycle: (chargingStation: ChargingStation, requestId: number) => Promise<void>
+  stationsState: WeakMap<ChargingStation, LogUploadStateShape>
+}
+
+interface LogUploadStateShape {
+  activeLogUploadAbortController?: AbortController
+  activeLogUploadRequestId?: number
+  activeLogUploadStatus?: UploadLogStatusEnumType
+  stopped?: boolean
+}
+
+const asPlumbing = (service: OCPP20IncomingRequestService): LogUploadPlumbing =>
+  service as unknown as LogUploadPlumbing
+
+await describe('N01 - GetLog', async () => {
   let station: ChargingStation
   let testableService: ReturnType<typeof createTestableIncomingRequestService>
 
@@ -145,16 +163,29 @@ await describe('K01 - GetLog', async () => {
       assert.strictEqual(simulateMock.mock.callCount(), 0)
     })
 
-    await it('should handle simulateLogUploadLifecycle rejection gracefully', async () => {
-      mock.method(
-        service as unknown as {
-          simulateLogUploadLifecycle: (
-            chargingStation: ChargingStation,
-            requestId: number
-          ) => Promise<void>
+    await it('should call simulateLogUploadLifecycle when GET_LOG event emitted with AcceptedCanceled response', () => {
+      const request: OCPP20GetLogRequest = {
+        log: {
+          remoteLocation: 'https://csms.example.com/logs',
         },
-        'simulateLogUploadLifecycle',
-        async () => Promise.reject(new Error('log upload error'))
+        logType: LogEnumType.DiagnosticsLog,
+        requestId: 12,
+      }
+      const response: OCPP20GetLogResponse = {
+        filename: 'simulator-log.txt',
+        status: LogStatusEnumType.AcceptedCanceled,
+      }
+
+      service.emit(OCPP20IncomingRequestCommand.GET_LOG, station, request, response)
+
+      assert.strictEqual(simulateMock.mock.callCount(), 1)
+      assert.strictEqual(simulateMock.mock.calls[0].arguments[1], 12)
+    })
+
+    await it('should handle simulateLogUploadLifecycle rejection gracefully', async t => {
+      const errorMock = t.mock.method(logger, 'error')
+      simulateMock.mock.mockImplementation(async () =>
+        Promise.reject(new Error('log upload error'))
       )
 
       const request: OCPP20GetLogRequest = {
@@ -172,6 +203,7 @@ await describe('K01 - GetLog', async () => {
       service.emit(OCPP20IncomingRequestCommand.GET_LOG, station, request, response)
 
       await flushMicrotasks()
+      assert.strictEqual(errorMock.mock.callCount(), 1)
     })
 
     await describe('N01 - LogStatusNotification lifecycle', async () => {
@@ -195,7 +227,11 @@ await describe('K01 - GetLog', async () => {
           await flushMicrotasks()
 
           // Assert
-          assert.ok(sentRequests.length >= 1, 'Expected at least one notification')
+          assert.strictEqual(
+            sentRequests.length,
+            1,
+            'Expected exactly one notification before the timer fires'
+          )
           assert.deepStrictEqual(sentRequests[0].payload, {
             requestId: 42,
             status: UploadLogStatusEnumType.Uploading,
@@ -275,6 +311,147 @@ await describe('K01 - GetLog', async () => {
           assert.strictEqual(sentRequests[1].payload.requestId, 7)
         })
       })
+    })
+  })
+
+  await describe('N01 - GetLog supersession (N01.FR.12/FR.20)', async () => {
+    await it('should return AcceptedCanceled, abort the prior upload, and notify with the previous requestId', () => {
+      // Arrange: seed an in-flight prior log upload (requestId 1)
+      const { sentRequests, station: trackingStation } = createMockStationWithRequestTracking()
+      const service = new OCPP20IncomingRequestService()
+      const testable = createTestableIncomingRequestService(service)
+      const state = asPlumbing(service).getOrCreateStationState(trackingStation)
+      const priorAbortController = new AbortController()
+      state.activeLogUploadAbortController = priorAbortController
+      state.activeLogUploadRequestId = 1
+
+      // Act: a new GetLog supersedes the in-flight upload
+      const request: OCPP20GetLogRequest = {
+        log: { remoteLocation: 'ftp://logs.example.com/' },
+        logType: LogEnumType.DiagnosticsLog,
+        requestId: 2,
+      }
+      const response = testable.handleRequestGetLog(trackingStation, request)
+
+      // Assert: superseded response, prior controller aborted, state reset
+      assert.deepStrictEqual(response, {
+        filename: 'simulator-log.txt',
+        status: LogStatusEnumType.AcceptedCanceled,
+      })
+      assert.strictEqual(priorAbortController.signal.aborted, true)
+      assert.strictEqual(state.activeLogUploadRequestId, undefined)
+      assert.strictEqual(state.activeLogUploadAbortController, undefined)
+      // Terminal LogStatusNotification(AcceptedCanceled) carries the PREVIOUS requestId (1), not the new one (2)
+      assert.strictEqual(sentRequests.length, 1)
+      assert.strictEqual(sentRequests[0].command, OCPP20RequestCommand.LOG_STATUS_NOTIFICATION)
+      assert.deepStrictEqual(sentRequests[0].payload, {
+        requestId: 1,
+        status: UploadLogStatusEnumType.AcceptedCanceled,
+      })
+    })
+
+    await it('should swallow a failed AcceptedCanceled notification and still return AcceptedCanceled', async t => {
+      // Arrange: force the terminal LogStatusNotification send to reject
+      const { station: trackingStation } = createMockStationWithRequestTracking()
+      const service = new OCPP20IncomingRequestService()
+      const testable = createTestableIncomingRequestService(service)
+      const errorMock = t.mock.method(logger, 'error')
+      ;(
+        trackingStation.ocppRequestService as unknown as {
+          requestHandler: (...args: unknown[]) => Promise<unknown>
+        }
+      ).requestHandler = async () => Promise.reject(new Error('notification send failed'))
+      const state = asPlumbing(service).getOrCreateStationState(trackingStation)
+      state.activeLogUploadAbortController = new AbortController()
+      state.activeLogUploadRequestId = 1
+
+      // Act
+      const request: OCPP20GetLogRequest = {
+        log: { remoteLocation: 'ftp://logs.example.com/' },
+        logType: LogEnumType.DiagnosticsLog,
+        requestId: 2,
+      }
+      const response = testable.handleRequestGetLog(trackingStation, request)
+
+      // Assert: handler still returns AcceptedCanceled synchronously; the rejection is not thrown
+      assert.strictEqual(response.status, LogStatusEnumType.AcceptedCanceled)
+      // The rejection is swallowed by the .catch and logged at error
+      await flushMicrotasks()
+      assert.strictEqual(errorMock.mock.callCount(), 1)
+    })
+  })
+
+  await describe('N01 - log upload lifecycle abort boundary', async () => {
+    await it('should exit at the interruptibleSleep boundary and not emit Uploaded when aborted mid-flight', async t => {
+      await withMockTimers(t, ['setTimeout'], async () => {
+        // Arrange
+        const { sentRequests, station: trackingStation } = createMockStationWithRequestTracking()
+        const service = new OCPP20IncomingRequestService()
+        const plumbing = asPlumbing(service)
+
+        // Act: drive the lifecycle; it emits Uploading then parks at interruptibleSleep
+        const lifecycle = plumbing.simulateLogUploadLifecycle(trackingStation, 77)
+        await flushMicrotasks()
+        assert.strictEqual(sentRequests.length, 1)
+        assert.strictEqual(sentRequests[0].payload.status, UploadLogStatusEnumType.Uploading)
+
+        // Abort mid-flight at the sleep boundary. The requestId stays claimed so
+        // the abort signal — not the requestId guard — is what suppresses Uploaded.
+        const state = plumbing.stationsState.get(trackingStation)
+        state?.activeLogUploadAbortController?.abort()
+
+        // Advance past the step delay (LOG_UPLOAD_STEP_DELAY_MS) and settle the lifecycle
+        t.mock.timers.tick(1000)
+        await flushMicrotasks()
+        await lifecycle
+
+        // Uploaded must NOT be emitted — the lifecycle exited at the boundary
+        assert.strictEqual(sentRequests.length, 1)
+        assert.strictEqual(
+          sentRequests.some(request => request.payload.status === UploadLogStatusEnumType.Uploaded),
+          false
+        )
+        // The finally block ran: clearActiveLogUpload reset the claimed requestId
+        assert.strictEqual(state?.activeLogUploadRequestId, undefined)
+      })
+    })
+  })
+
+  await describe('clearActiveLogUpload', async () => {
+    await it('should log at debug and preserve state for a superseded (non-matching) requestId', t => {
+      // Arrange
+      const service = new OCPP20IncomingRequestService()
+      const plumbing = asPlumbing(service)
+      const debugMock = t.mock.method(logger, 'debug')
+      const state = plumbing.getOrCreateStationState(station)
+      state.activeLogUploadRequestId = 200
+
+      // Act: a stale/superseded completion for requestId 199
+      plumbing.clearActiveLogUpload(station, 199)
+
+      // Assert: else-branch fired the debug log and left state untouched
+      assert.strictEqual(debugMock.mock.callCount(), 1)
+      assert.strictEqual(state.activeLogUploadRequestId, 200)
+    })
+
+    await it('should reset state and not log for a matching requestId', t => {
+      // Arrange
+      const service = new OCPP20IncomingRequestService()
+      const plumbing = asPlumbing(service)
+      const debugMock = t.mock.method(logger, 'debug')
+      const state = plumbing.getOrCreateStationState(station)
+      state.activeLogUploadAbortController = new AbortController()
+      state.activeLogUploadRequestId = 200
+      state.activeLogUploadStatus = UploadLogStatusEnumType.Uploading
+
+      // Act: the active upload completes cleanly
+      plumbing.clearActiveLogUpload(station, 200)
+
+      // Assert: state cleared, no "Ignoring" debug log
+      assert.strictEqual(state.activeLogUploadRequestId, undefined)
+      assert.strictEqual(state.activeLogUploadAbortController, undefined)
+      assert.strictEqual(state.activeLogUploadStatus, undefined)
+      assert.strictEqual(debugMock.mock.callCount(), 0)
     })
   })
 })

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-PostStopResurrection.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-PostStopResurrection.test.ts
@@ -377,4 +377,23 @@ await describe('OCPP20IncomingRequestService — post-stop resurrection guard', 
       assert.strictEqual(requestHandlerMock.mock.callCount(), 0)
     })
   })
+
+  await describe('resetStationState abort-on-stop', async () => {
+    await it('should abort in-flight firmware and log upload controllers on stop()', () => {
+      const station = createStation('reset-abort')
+      const state = plumbing.getOrCreateStationState(station)
+      const firmwareController = new AbortController()
+      const logController = new AbortController()
+      state.activeFirmwareUpdateAbortController = firmwareController
+      state.activeLogUploadAbortController = logController
+
+      service.stop(station)
+
+      assert.strictEqual(firmwareController.signal.aborted, true)
+      assert.strictEqual(logController.signal.aborted, true)
+      assert.strictEqual(state.activeFirmwareUpdateAbortController, undefined)
+      assert.strictEqual(state.activeLogUploadAbortController, undefined)
+      assert.strictEqual(state.stopped, true)
+    })
+  })
 })

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-UpdateFirmware.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-UpdateFirmware.test.ts
@@ -21,7 +21,7 @@ import {
   OCPPVersion,
   UpdateFirmwareStatusEnumType,
 } from '../../../../src/types/index.js'
-import { Constants } from '../../../../src/utils/index.js'
+import { Constants, logger } from '../../../../src/utils/index.js'
 import {
   flushMicrotasks,
   standardCleanup,
@@ -34,6 +34,20 @@ import {
   createMockStationWithRequestTracking,
   createStationWithCertificateManager,
 } from './OCPP20TestUtils.js'
+
+interface FirmwareUpdatePlumbing {
+  clearActiveFirmwareUpdate: (chargingStation: ChargingStation, requestId: number) => void
+  getOrCreateStationState: (chargingStation: ChargingStation) => FirmwareUpdateStateShape
+  stationsState: WeakMap<ChargingStation, FirmwareUpdateStateShape>
+}
+
+interface FirmwareUpdateStateShape {
+  activeFirmwareUpdateAbortController?: AbortController
+  activeFirmwareUpdateRequestId?: number
+}
+
+const asPlumbing = (service: OCPP20IncomingRequestService): FirmwareUpdatePlumbing =>
+  service as unknown as FirmwareUpdatePlumbing
 
 await describe('L01/L02 - UpdateFirmware', async () => {
   let station: ChargingStation
@@ -281,17 +295,10 @@ await describe('L01/L02 - UpdateFirmware', async () => {
       assert.strictEqual(simulateMock.mock.callCount(), 0)
     })
 
-    await it('should handle simulateFirmwareUpdateLifecycle rejection gracefully', async () => {
-      mock.method(
-        service as unknown as {
-          simulateFirmwareUpdateLifecycle: (
-            chargingStation: ChargingStation,
-            requestId: number,
-            firmware: FirmwareType
-          ) => Promise<void>
-        },
-        'simulateFirmwareUpdateLifecycle',
-        async () => Promise.reject(new Error('firmware lifecycle error'))
+    await it('should handle simulateFirmwareUpdateLifecycle rejection gracefully', async t => {
+      const errorMock = t.mock.method(logger, 'error')
+      simulateMock.mock.mockImplementation(async () =>
+        Promise.reject(new Error('firmware lifecycle error'))
       )
 
       const request: OCPP20UpdateFirmwareRequest = {
@@ -308,6 +315,7 @@ await describe('L01/L02 - UpdateFirmware', async () => {
       service.emit(OCPP20IncomingRequestCommand.UPDATE_FIRMWARE, station, request, response)
 
       await flushMicrotasks()
+      assert.strictEqual(errorMock.mock.callCount(), 1)
     })
 
     await it('should cancel previous firmware update when new one arrives', async t => {
@@ -1316,6 +1324,42 @@ await describe('L01/L02 - UpdateFirmware', async () => {
           )
         })
       })
+    })
+  })
+
+  await describe('clearActiveFirmwareUpdate', async () => {
+    await it('should log at debug and preserve state for a superseded (non-matching) requestId', t => {
+      // Arrange
+      const service = new OCPP20IncomingRequestService()
+      const plumbing = asPlumbing(service)
+      const debugMock = t.mock.method(logger, 'debug')
+      const state = plumbing.getOrCreateStationState(station)
+      state.activeFirmwareUpdateRequestId = 200
+
+      // Act: a stale/superseded completion for requestId 199
+      plumbing.clearActiveFirmwareUpdate(station, 199)
+
+      // Assert: else-branch fired the debug log and left state untouched
+      assert.strictEqual(debugMock.mock.callCount(), 1)
+      assert.strictEqual(state.activeFirmwareUpdateRequestId, 200)
+    })
+
+    await it('should reset state and not log for a matching requestId', t => {
+      // Arrange
+      const service = new OCPP20IncomingRequestService()
+      const plumbing = asPlumbing(service)
+      const debugMock = t.mock.method(logger, 'debug')
+      const state = plumbing.getOrCreateStationState(station)
+      state.activeFirmwareUpdateAbortController = new AbortController()
+      state.activeFirmwareUpdateRequestId = 200
+
+      // Act: the active firmware update completes cleanly
+      plumbing.clearActiveFirmwareUpdate(station, 200)
+
+      // Assert: state cleared, no "Ignoring" debug log
+      assert.strictEqual(state.activeFirmwareUpdateRequestId, undefined)
+      assert.strictEqual(state.activeFirmwareUpdateAbortController, undefined)
+      assert.strictEqual(debugMock.mock.callCount(), 0)
     })
   })
 })


### PR DESCRIPTION
## Description

Regression-guard capstone for the OCPP 2.0.1 lifecycle supersession / cleanup work introduced by #1962 and hardened across #1976 / #1981 / #1983 / #1984 / #1991 / #1992 / #1994.

**Test-only PR — zero changes under `src/`.** Scope was defined by a per-gap coverage audit, then extended in review to complete the firmware↔log symmetry.

`Closes #1974`

### Per-gap coverage

| Gap | Action |
| --- | --- |
| **#1 log** — `clearActiveLogUpload` else-branch | +2 tests (superseded id → debug + preserve; matching id → reset + no log; also locks `activeLogUploadStatus` clearing) |
| **#1 firmware** — `clearActiveFirmwareUpdate` else-branch | +2 tests (symmetric to the log pair) |
| **#2** — `handleRequestGetLog` supersession | +2 handler tests + 1 listener test (new-lifecycle-on-`AcceptedCanceled`) |
| **#3** — `handleRequestUpdateFirmware` supersession | already covered (`UpdateFirmware.test.ts` L327-368; abort behaviorally locked by the finally-guard test) |
| **#4** — `stop()` integration | +1 test (in-flight `AbortController`s aborted + fields cleared) |
| **#5** — log-upload mid-flight abort boundary | +1 test (exits at `interruptibleSleep`, no `Uploaded`, `finally` cleanup ran) |

Net: **+9 tests** (GetLog 9→15, PostStopResurrection 14→15, UpdateFirmware 27→29); **0 existing tests weakened or removed**; full suite **0 failures** (6 pre-existing skips).

Pre-existing test-quality fixes in the touched files (from the review):
- Both lifecycle-rejection tests (GetLog + UpdateFirmware): replaced a stacked second `mock.method(...)` with `simulateMock.mock.mockImplementation(...)` (reconfigure the `beforeEach` mock, no double-wrap), and added an explicit `errorMock` assertion so the tests lock "rejection swallowed **and** logged at `error`" instead of passing vacuously.
- GetLog Uploading test: `assert.ok(length >= 1)` → `assert.strictEqual(length, 1)`.

### OCPP 2.0.1 spec grounding (verified against the spec text)

- **N01.FR.12** cancel + `AcceptedCanceled` (GetLogResponse) → gap #2.
- **N01.FR.20** cancel → SHALL send `LogStatusNotification(AcceptedCanceled)` → gap #2 terminal-notification assertion.
- **N01.FR.07 / N01.FR.13** every notification carries the originating requestId, mandatory → gap #2 asserts the **previous** requestId.
- **N01.FR.09** `Uploaded` only on success → gap #5 asserts `Uploaded` is NOT emitted after a mid-flight abort.
- GetLog is OCPP 2.0.1 use case **N01** (TC_N_35_CS). Describe blocks use `N01`.

### Mutation-sanity (temporary local reverts, not committed) — 9 guarded lines verified

Each revert failed exactly its target test, then was restored:
`handleRequestGetLog` abort · `simulateLogUploadLifecycle` `!signal.aborted` guard · GET_LOG listener `|| AcceptedCanceled` disjunct · `resetStationState` `resetActive*State` calls · `simulateLogUploadLifecycle` `finally` cleanup · `clearActiveFirmwareUpdate` else-branch debug · `clearActiveFirmwareUpdate` matching reset · `resetActiveLogUploadState` `activeLogUploadStatus` clear · GET_LOG listener `logger.error` level.

Note: `handleRequestGetLog` both aborts **and** resets the requestId (double guard), so the gap #5 test drives `simulateLogUploadLifecycle` directly and keeps the requestId claimed, isolating the `!signal.aborted` guard.

### Review (findings-driven, ≥2 parallel reviewers per round; 4 rounds)

- R1 (correctness + duplication): zero valid findings.
- R2 (spec + TS + design/harmonization/terminology): `K01`→`N01`; supersession describe → `N01 - GetLog supersession (N01.FR.12/FR.20)`; describes promoted to top-level; symmetric abort-controller assertion.
- R3 (exhaustive ×3): AcceptedCanceled listener test, gap #4 field-cleared assertions, gap #5 `finally` assertion; completed the `clearActiveFirmwareUpdate` symmetry; rejected a false positive (firmware supersession sends no notification).
- R4 (exhaustive ×3): fixed the firmware rejection double-mock (symmetry with the GetLog fix), added `errorMock` assertions to both rejection tests, and the `activeLogUploadStatus` assertion. Reviewer findings targeting pre-existing UpdateFirmware tests (FR-label rewrites, unrelated assertion styles) were classified out-of-scope for this test-additions PR.

### Verification gates

- `pnpm format` / `pnpm typecheck` (0) / `pnpm lint` (0) clean on edited files.
- `pnpm test` — full suite **0 failures** (6 pre-existing skips); changed files **50 → 59 tests (+9)**; no existing test removed.
- `pnpm build` — exit 0.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No