### PR TITLE
refactor(utils): swap getRandomFloat(Rounded) params to (min, max) for consistency

### DIFF
--- a/src/charging-station/ocpp/OCPPServiceUtils.ts
+++ b/src/charging-station/ocpp/OCPPServiceUtils.ts
@@ -459,7 +459,7 @@ const buildEnergyMeasurandValue = (
       ),
       energyTemplate.fluctuationPercent ?? Constants.DEFAULT_FLUCTUATION_PERCENT
     )
-    : getRandomFloatRounded(connectorMaximumEnergyRounded, connectorMinimumEnergyRounded)
+    : getRandomFloatRounded(connectorMinimumEnergyRounded, connectorMaximumEnergyRounded)
 
   return {
     template: energyTemplate,
@@ -616,22 +616,22 @@ const buildPowerMeasurandValue = (
           phase1Value ??
           defaultFluctuatedPowerPerPhase ??
           getRandomFloatRounded(
-            connectorMaximumPowerPerPhase / unitDivider,
-            connectorMinimumPowerPerPhase / unitDivider
+            connectorMinimumPowerPerPhase / unitDivider,
+            connectorMaximumPowerPerPhase / unitDivider
           )
         powerValues.L2 =
           phase2Value ??
           defaultFluctuatedPowerPerPhase ??
           getRandomFloatRounded(
-            connectorMaximumPowerPerPhase / unitDivider,
-            connectorMinimumPowerPerPhase / unitDivider
+            connectorMinimumPowerPerPhase / unitDivider,
+            connectorMaximumPowerPerPhase / unitDivider
           )
         powerValues.L3 =
           phase3Value ??
           defaultFluctuatedPowerPerPhase ??
           getRandomFloatRounded(
-            connectorMaximumPowerPerPhase / unitDivider,
-            connectorMinimumPowerPerPhase / unitDivider
+            connectorMinimumPowerPerPhase / unitDivider,
+            connectorMaximumPowerPerPhase / unitDivider
           )
       } else {
         powerValues.L1 = isNotEmptyString(powerTemplate.value)
@@ -648,8 +648,8 @@ const buildPowerMeasurandValue = (
             powerTemplate.fluctuationPercent ?? Constants.DEFAULT_FLUCTUATION_PERCENT
           )
           : getRandomFloatRounded(
-            connectorMaximumPower / unitDivider,
-            connectorMinimumPower / unitDivider
+            connectorMinimumPower / unitDivider,
+            connectorMaximumPower / unitDivider
           )
         powerValues.L2 = 0
         powerValues.L3 = 0
@@ -671,8 +671,8 @@ const buildPowerMeasurandValue = (
           powerTemplate.fluctuationPercent ?? Constants.DEFAULT_FLUCTUATION_PERCENT
         )
         : getRandomFloatRounded(
-          connectorMaximumPower / unitDivider,
-          connectorMinimumPower / unitDivider
+          connectorMinimumPower / unitDivider,
+          connectorMaximumPower / unitDivider
         )
       break
     default: {
@@ -823,15 +823,15 @@ const buildCurrentMeasurandValue = (
         currentValues.L1 =
           phase1Value ??
           defaultFluctuatedAmperagePerPhase ??
-          getRandomFloatRounded(connectorMaximumAmperage, connectorMinimumAmperage)
+          getRandomFloatRounded(connectorMinimumAmperage, connectorMaximumAmperage)
         currentValues.L2 =
           phase2Value ??
           defaultFluctuatedAmperagePerPhase ??
-          getRandomFloatRounded(connectorMaximumAmperage, connectorMinimumAmperage)
+          getRandomFloatRounded(connectorMinimumAmperage, connectorMaximumAmperage)
         currentValues.L3 =
           phase3Value ??
           defaultFluctuatedAmperagePerPhase ??
-          getRandomFloatRounded(connectorMaximumAmperage, connectorMinimumAmperage)
+          getRandomFloatRounded(connectorMinimumAmperage, connectorMaximumAmperage)
       } else {
         currentValues.L1 = isNotEmptyString(currentTemplate.value)
           ? getRandomFloatFluctuatedRounded(
@@ -846,7 +846,7 @@ const buildCurrentMeasurandValue = (
             ),
             currentTemplate.fluctuationPercent ?? Constants.DEFAULT_FLUCTUATION_PERCENT
           )
-          : getRandomFloatRounded(connectorMaximumAmperage, connectorMinimumAmperage)
+          : getRandomFloatRounded(connectorMinimumAmperage, connectorMaximumAmperage)
         currentValues.L2 = 0
         currentValues.L3 = 0
       }
@@ -874,7 +874,7 @@ const buildCurrentMeasurandValue = (
           ),
           currentTemplate.fluctuationPercent ?? Constants.DEFAULT_FLUCTUATION_PERCENT
         )
-        : getRandomFloatRounded(connectorMaximumAmperage, connectorMinimumAmperage)
+        : getRandomFloatRounded(connectorMinimumAmperage, connectorMaximumAmperage)
       break
     default: {
       const errorMsg = `MeterValues measurand ${

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -360,13 +360,13 @@ export const convertToBoolean = (value: unknown): boolean => {
  * @param min - The minimum value (inclusive). Defaults to `0`.
  * @param max - The maximum value (inclusive). Defaults to `Number.MAX_VALUE`.
  * @returns A float in the [min, max] range.
- * @throws {RangeError} If `max < min` or either bound is not finite.
+ * @throws {RangeError} If `max < min` or the interval width (`max - min`) is not finite.
  */
 export const getRandomFloat = (min = 0, max = Number.MAX_VALUE): number => {
   if (max < min) {
     throw new RangeError('Invalid interval')
   }
-  if (!Number.isFinite(max) || !Number.isFinite(min)) {
+  if (!Number.isFinite(max - min)) {
     throw new RangeError('Invalid interval')
   }
   return (randomBytes(4).readUInt32LE() / 0xffffffff) * (max - min) + min
@@ -402,7 +402,7 @@ export const roundTo = (numberValue: number, scale: number): number => {
  * @param max - The maximum value (inclusive). Defaults to `Number.MAX_VALUE`.
  * @param scale - The number of decimal places to round to. Defaults to `2`.
  * @returns A float in the [min, max] range, rounded to `scale` decimal places.
- * @throws {RangeError} If `max < min` or either bound is not finite.
+ * @throws {RangeError} If `max < min` or the interval width (`max - min`) is not finite.
  */
 export const getRandomFloatRounded = (min = 0, max = Number.MAX_VALUE, scale = 2): number => {
   return roundTo(getRandomFloat(min, max), scale)
@@ -415,6 +415,7 @@ export const getRandomFloatRounded = (min = 0, max = Number.MAX_VALUE, scale = 2
  * @param scale - The number of decimal places to round to. Defaults to `2`.
  * @returns A float within `fluctuationPercent` of `staticValue`, rounded to `scale` decimal places.
  * @throws {RangeError} If `fluctuationPercent` is outside the [0, 100] range.
+ * @throws {RangeError} If a non-zero `fluctuationPercent` derives a non-finite interval width (e.g. `staticValue` near `Number.MAX_VALUE`).
  */
 export const getRandomFloatFluctuatedRounded = (
   staticValue: number,

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -356,12 +356,13 @@ export const convertToBoolean = (value: unknown): boolean => {
 }
 
 /**
- * Generates a cryptographically secure random float in the [min, max] range
- * @param max - The maximum value (inclusive). Defaults to `Number.MAX_VALUE`
- * @param min - The minimum value (inclusive). Defaults to `0`
- * @returns A float in the [min, max] range
+ * Generates a cryptographically secure random float in the [min, max] range.
+ * @param min - The minimum value (inclusive). Defaults to `0`.
+ * @param max - The maximum value (inclusive). Defaults to `Number.MAX_VALUE`.
+ * @returns A float in the [min, max] range.
+ * @throws {RangeError} If `max < min` or either bound is not finite.
  */
-export const getRandomFloat = (max = Number.MAX_VALUE, min = 0): number => {
+export const getRandomFloat = (min = 0, max = Number.MAX_VALUE): number => {
   if (max < min) {
     throw new RangeError('Invalid interval')
   }
@@ -395,10 +396,26 @@ export const roundTo = (numberValue: number, scale: number): number => {
   return roundedScaled / factor
 }
 
-export const getRandomFloatRounded = (max = Number.MAX_VALUE, min = 0, scale = 2): number => {
-  return roundTo(getRandomFloat(max, min), scale)
+/**
+ * Generates a cryptographically secure random float in the [min, max] range, rounded to the given scale.
+ * @param min - The minimum value (inclusive). Defaults to `0`.
+ * @param max - The maximum value (inclusive). Defaults to `Number.MAX_VALUE`.
+ * @param scale - The number of decimal places to round to. Defaults to `2`.
+ * @returns A float in the [min, max] range, rounded to `scale` decimal places.
+ * @throws {RangeError} If `max < min` or either bound is not finite.
+ */
+export const getRandomFloatRounded = (min = 0, max = Number.MAX_VALUE, scale = 2): number => {
+  return roundTo(getRandomFloat(min, max), scale)
 }
 
+/**
+ * Generates a cryptographically secure random float fluctuating around `staticValue` by up to `fluctuationPercent`, rounded to the given scale.
+ * @param staticValue - The center value to fluctuate around.
+ * @param fluctuationPercent - The maximum fluctuation as a percentage in the [0, 100] range.
+ * @param scale - The number of decimal places to round to. Defaults to `2`.
+ * @returns A float within `fluctuationPercent` of `staticValue`, rounded to `scale` decimal places.
+ * @throws {RangeError} If `fluctuationPercent` is outside the [0, 100] range.
+ */
 export const getRandomFloatFluctuatedRounded = (
   staticValue: number,
   fluctuationPercent: number,
@@ -417,7 +434,7 @@ export const getRandomFloatFluctuatedRounded = (
   const lowerValue = staticValue * (1 - fluctuationRatio)
   const max = Math.max(upperValue, lowerValue)
   const min = Math.min(upperValue, lowerValue)
-  return getRandomFloatRounded(max, min, scale)
+  return getRandomFloatRounded(min, max, scale)
 }
 
 export const extractTimeSeriesValues = (timeSeries: CircularBuffer<TimestampedData>): number[] => {

--- a/tests/utils/Utils.test.ts
+++ b/tests/utils/Utils.test.ts
@@ -271,9 +271,16 @@ await describe('Utils', async () => {
       },
       { message: /Invalid interval/ }
     )
+    assert.throws(
+      () => {
+        getRandomFloat(-Number.MAX_VALUE, Number.MAX_VALUE)
+      },
+      { message: /Invalid interval/ }
+    )
     randomFloat = getRandomFloat(-Number.MAX_VALUE, 0)
     assert.strictEqual(randomFloat >= -Number.MAX_VALUE, true)
     assert.strictEqual(randomFloat <= 0, true)
+    assert.strictEqual(getRandomFloat(5, 5), 5)
   })
 
   await it('should extract numeric values from timestamped circular buffer', () => {
@@ -838,6 +845,17 @@ await describe('Utils', async () => {
     const negResult = getRandomFloatFluctuatedRounded(-100, 10)
     assert.strictEqual(negResult >= -110, true)
     assert.strictEqual(negResult <= -90, true)
+    // Non-finite derived interval width throws via delegation to getRandomFloat
+    assert.throws(
+      () => {
+        getRandomFloatFluctuatedRounded(Number.MAX_VALUE, 10)
+      },
+      { message: /Invalid interval/ }
+    )
+    // Zero fluctuation returns early without delegating, so it never reaches the width guard
+    assert.doesNotThrow(() => {
+      getRandomFloatFluctuatedRounded(Number.MAX_VALUE, 0)
+    })
   })
 
   await it('should detect Cloud Foundry environment from VCAP_APPLICATION', () => {

--- a/tests/utils/Utils.test.ts
+++ b/tests/utils/Utils.test.ts
@@ -261,17 +261,17 @@ await describe('Utils', async () => {
     assert.notDeepStrictEqual(randomFloat, getRandomFloat())
     assert.throws(
       () => {
-        getRandomFloat(0, 1)
+        getRandomFloat(1, 0)
       },
       { message: /Invalid interval/ }
     )
     assert.throws(
       () => {
-        getRandomFloat(Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY)
+        getRandomFloat(Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY)
       },
       { message: /Invalid interval/ }
     )
-    randomFloat = getRandomFloat(0, -Number.MAX_VALUE)
+    randomFloat = getRandomFloat(-Number.MAX_VALUE, 0)
     assert.strictEqual(randomFloat >= -Number.MAX_VALUE, true)
     assert.strictEqual(randomFloat <= 0, true)
   })
@@ -806,7 +806,7 @@ await describe('Utils', async () => {
   })
 
   await it('should generate random float rounded to specified scale', () => {
-    const result = getRandomFloatRounded(10, 0, 2)
+    const result = getRandomFloatRounded(0, 10, 2)
     assert.strictEqual(result >= 0, true)
     assert.strictEqual(result <= 10, true)
     // Check rounding to 2 decimal places
@@ -815,7 +815,7 @@ await describe('Utils', async () => {
       assert.strictEqual(decimalStr.split('.')[1].length <= 2, true)
     }
     // Default scale
-    const defaultScale = getRandomFloatRounded(10, 0)
+    const defaultScale = getRandomFloatRounded(0, 10)
     assert.strictEqual(defaultScale >= 0, true)
     assert.strictEqual(defaultScale <= 10, true)
   })


### PR DESCRIPTION
## PR Checklist

- [x] Please add a description of your changes.
- [x] Please ensure title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] We need your changes to come with unit tests in order to keep this project in quality and easy to maintain.
- [x] If your changes contain any new feature please be sure to document it. _(N/A — internal refactor + edge-case fix; JSDoc harmonized for the touched helpers.)_
- [x] Please add a link to the open issue or task that this pull request will resolve.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

---

Closes #1967

This PR contains **two commits**:
1. `refactor(utils): swap getRandomFloat(Rounded) params to (min, max)` — the issue's ask.
2. `fix(utils): reject non-finite interval width in getRandomFloat` — a related correctness fix surfaced during review.

## 1. Refactor — parameter-order swap

Swap the parameter order of `getRandomFloat` and `getRandomFloatRounded` from `(max, min[, scale])` to `(min, max[, scale])` so they match the sibling bounds helpers `randomInt` (from `node:crypto`) and `isValidRandomIntBounds`, which take `(min, max)`.

Behavior-preserving: the function bodies reference `max`/`min` by name, so only the parameter declaration order/defaults and each positional call site move. Every call site (production **and** tests) is migrated in the same commit so no site silently swaps min/max — the exact hazard the issue warns about.

> Note on the issue text: it lists `getRandomInteger` as a sibling helper, but no such function exists in the codebase (grep-confirmed). The real `(min, max)`-ordered helpers are `randomInt` and `isValidRandomIntBounds`.

Also bundles the **zero-behavior-change JSDoc polish** the issue mentions:
- `getRandomFloat` `@param`/`@returns` lines now end with a period, matching sibling helpers.
- `getRandomFloatRounded` and `getRandomFloatFluctuatedRounded` gain JSDoc (`@param`, `@returns`, `@throws`) to harmonize the documented random-float family.

## 2. Fix — non-finite interval width

Documenting the `getRandomFloat` contract exposed a pre-existing gap: the guard validated each **endpoint** for finiteness but not the interval **width**. So `getRandomFloat(-Number.MAX_VALUE, Number.MAX_VALUE)` passed the guards and returned `Infinity` (or `NaN` when the random ratio is exactly `0`, via `0 * Infinity`), silently violating the documented `[min, max]` contract.

The fix replaces the per-endpoint finiteness check with a width check on `max - min`, which **subsumes** the endpoint check (a non-finite endpoint yields a non-finite difference) and additionally rejects the overflow. The `max < min` inverted-interval guard is kept (a finite inverted range has finite width and must still throw). Behavior is unchanged for every previously valid input — the default `(0, MAX_VALUE)` and all production call sites have finite width.

`getRandomFloatRounded` and `getRandomFloatFluctuatedRounded` inherit the guard by delegation; both now document it via `@throws` (the latter reaches it when a non-zero `fluctuationPercent` derives a non-finite interval width, e.g. `staticValue` near `Number.MAX_VALUE`).

## Semver reassessment (label correction proposed)

`package.json` `exports` publishes only `./dist/start.js` (the app entrypoint) — **not** the `src/utils` barrel. `getRandomFloat`/`getRandomFloatRounded` are re-exported from `src/utils/index.ts`, but that barrel is **app-internal**; no external consumer can `import` them. So this is an **internal** change — not a semver-major public break; no CHANGELOG entry. Suggest re-labeling `refactor` rather than `semver-major`. The reporter's silent-swap migration concern is honored in full.

## Scope

Family swap of `getRandomFloat` + `getRandomFloatRounded`; `getRandomFloatFluctuatedRounded`'s signature is untouched (no min/max pair), only its internal `getRandomFloatRounded(min, max, scale)` call is reordered — its local `max`/`min` (from `Math.max`/`Math.min`) retain correct semantics. The width fix lives in `getRandomFloat` (single source); the other two inherit it via delegation.

## Blast radius

| File | Change |
|---|---|
| `src/utils/Utils.ts` | `getRandomFloat` signature `(max,min)`→`(min,max)` + JSDoc + width guard; `getRandomFloatRounded` signature `(max,min,scale)`→`(min,max,scale)` + internal call + JSDoc; `getRandomFloatFluctuatedRounded` internal call + JSDoc (2 `@throws`; signature unchanged) |
| `src/charging-station/ocpp/OCPPServiceUtils.ts` | 11 `getRandomFloatRounded` call sites — energy (1), per-phase power (3), power (2), amperage (5), each `(maximum,minimum)`→`(minimum,maximum)` |
| `tests/utils/Utils.test.ts` | 5 sites swapped preserving intent + regression assertions (overflow throw, degenerate `min===max`, FluctuatedRounded overflow throw) |

`getRandomFloatFluctuatedRounded(...)` call sites in `OCPPServiceUtils.ts` are **not** touched (signature unchanged).

### Test intent preservation (not blind reversal)

| Line | Before | After | Preserved intent |
|---|---|---|---|
| 264 | `getRandomFloat(0, 1)` | `getRandomFloat(1, 0)` | `max < min` → still throws |
| 270 | `getRandomFloat(+Inf, -Inf)` | `getRandomFloat(-Inf, +Inf)` | non-finite interval → still throws |
| 274 | `getRandomFloat(0, -MAX)` | `getRandomFloat(-MAX, 0)` | valid `[-MAX, 0]` range |
| 809 | `getRandomFloatRounded(10, 0, 2)` | `getRandomFloatRounded(0, 10, 2)` | `[0, 10]` range |
| 818 | `getRandomFloatRounded(10, 0)` | `getRandomFloatRounded(0, 10)` | `[0, 10]` range |
| new | — | `getRandomFloat(-MAX, MAX)` | overflow width → throws (fix guard) |
| new | — | `getRandomFloat(5, 5)` | degenerate interval → returns `5` |
| new | — | `getRandomFloatFluctuatedRounded(MAX, 10)` | overflow via delegation → throws |
| new | — | `getRandomFloatFluctuatedRounded(MAX, 0)` | zero fluctuation returns early → does NOT throw (locks the non-zero precondition) |

## Verification

- `pnpm format` clean; `pnpm typecheck` 0; `pnpm lint` 0; `pnpm build` exit 0.
- `tests/utils/Utils.test.ts` and `OCPPServiceUtils-MeterValues`/`-Pure` pass. No existing test outcome changed by either commit.
- **Grep completeness**: zero call sites left in the old `(max, min)` order.
- **Mutation sanity (swap)**: reverting one internal call to the old order makes `Utils.test.ts` fail with `RangeError`.
- **Mutation sanity (fix)**: reverting the width guard to the per-endpoint check makes the overflow assertions fail — confirming they guard the width check.
- **Review**: 3 independent reviewers + cross-validation; all confirmed the width guard fully subsumes the endpoint check with zero regression, the `[min,max]` inclusive claim is accurate, and all 11 OCPP sites are correct.

## OCPP / physical-model note

The migrated `getRandomFloatRounded` sites feed simulated `MeterValues` (`Energy.Active.Import.Register`, `Power.Active.Import`, `Current.Import`). Per OCPP 1.6 / 2.0.1 these sampled values are readings with no spec-imposed min/max ordering; the min/max are simulator-side bounds. The swap preserves floor vs ceiling, so the per-measurand distribution is identical and OCPP compliance is unaffected.
