### PR TITLE
style: codebase consistency sweep — JSDoc backticks, != null idiom, .toString()

### DIFF
--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -832,7 +832,7 @@ export class ChargingStation extends EventEmitter {
    * @param reservationId - The reservation ID to check
    * @param idTag - Optional ID tag for user reservation check
    * @param connectorId - Optional connector ID to check availability
-   * @returns True if the connector can accept a reservation
+   * @returns `true` if the connector can accept a reservation
    */
   public isConnectorReservable (
     reservationId: number,

--- a/src/charging-station/ocpp/2.0/OCPP20CertificateManager.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20CertificateManager.ts
@@ -329,7 +329,7 @@ export class OCPP20CertificateManager {
    * @param stationHashId - Charging station unique identifier
    * @param certificateHashData - Certificate hash data to check against stored CS certificates
    * @param hashAlgorithm - Optional hash algorithm override (defaults to certificateHashData.hashAlgorithm)
-   * @returns true if the hash matches a stored ChargingStationCertificate, false otherwise
+   * @returns `true` if the hash matches a stored ChargingStationCertificate, `false` otherwise
    */
   public async isChargingStationCertificateHash (
     stationHashId: string,
@@ -443,7 +443,7 @@ export class OCPP20CertificateManager {
   /**
    * Validates PEM certificate format
    * @param pemData - PEM data to validate
-   * @returns true if valid PEM certificate format, false otherwise
+   * @returns `true` if valid PEM certificate format, `false` otherwise
    */
   public validateCertificateFormat (pemData: unknown): boolean {
     if (pemData == null || typeof pemData !== 'string') {
@@ -678,7 +678,7 @@ export class OCPP20CertificateManager {
 /**
  * Type guard to check if a charging station has a certificate manager
  * @param chargingStation - The charging station to check
- * @returns true if the charging station has a certificate manager
+ * @returns `true` if the charging station has a certificate manager
  */
 export function hasCertificateManager (
   chargingStation: ChargingStation

--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -3288,7 +3288,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
   /**
    * Checks if a specific EVSE has any active transactions.
    * @param evse - The EVSE to check
-   * @returns true if any connector on the EVSE has an active transaction
+   * @returns `true` if any connector on the EVSE has an active transaction
    */
   private hasEvseActiveTransactions (evse: EvseStatus): boolean {
     for (const connector of evse.connectors.values()) {
@@ -3302,7 +3302,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
   /**
    * Checks if a specific EVSE has any non-expired reservations.
    * @param evse - The EVSE to check
-   * @returns true if any connector on the EVSE has a pending reservation
+   * @returns `true` if any connector on the EVSE has a pending reservation
    */
   private hasEvsePendingReservations (evse: EvseStatus): boolean {
     for (const connector of evse.connectors.values()) {
@@ -3395,7 +3395,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
    * Idle means: no active transactions, no firmware update in progress, no pending reservations.
    * Note: Log uploads and cable lock state are not tracked in the simulator.
    * @param chargingStation - The charging station instance
-   * @returns true if charging station is idle
+   * @returns `true` if charging station is idle
    */
   private isChargingStationIdle (chargingStation: ChargingStation): boolean {
     return (
@@ -3410,7 +3410,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
    * Idle means: no active transactions on EVSE, no firmware update in progress, no pending reservations on EVSE.
    * @param chargingStation - The charging station instance
    * @param evse - The EVSE to check
-   * @returns true if EVSE is idle
+   * @returns `true` if EVSE is idle
    */
   private isEvseIdle (chargingStation: ChargingStation, evse: EvseStatus): boolean {
     return (
@@ -4456,7 +4456,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
    * @param chargingStation - The charging station instance
    * @param chargingProfile - The charging profile to validate
    * @param evseId - EVSE identifier
-   * @returns True if purpose validation passes, false otherwise
+   * @returns `true` if purpose validation passes, `false` otherwise
    */
   private validateChargingProfilePurpose (
     chargingStation: ChargingStation,
@@ -4525,7 +4525,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
    * @param scheduleIndex - Index of the schedule in the profile's schedule array
    * @param chargingProfile - The parent charging profile
    * @param evseId - EVSE identifier
-   * @returns True if schedule is valid, false otherwise
+   * @returns `true` if schedule is valid, `false` otherwise
    */
   private validateChargingSchedule (
     chargingStation: ChargingStation,

--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -4652,7 +4652,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
     chargingStation: ChargingStation,
     evse: OCPP20TriggerMessageRequest['evse']
   ): OCPP20TriggerMessageResponse | undefined {
-    if (evse?.id === undefined || evse.id <= 0) {
+    if (evse?.id == null || evse.id <= 0) {
       return undefined
     }
     if (!chargingStation.hasEvses) {

--- a/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.ts
@@ -2407,7 +2407,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
     commandPayload: OCPP20ResetRequest
   ): Promise<OCPP20ResetResponse> {
     logger.debug(
-      `${chargingStation.logPrefix()} ${moduleName}.handleRequestReset: Reset request received with type ${commandPayload.type}${commandPayload.evseId !== undefined ? ` for EVSE ${commandPayload.evseId.toString()}` : ''}`
+      `${chargingStation.logPrefix()} ${moduleName}.handleRequestReset: Reset request received with type ${commandPayload.type}${commandPayload.evseId != null ? ` for EVSE ${commandPayload.evseId.toString()}` : ''}`
     )
 
     const { evseId, type } = commandPayload
@@ -2445,7 +2445,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
       }
     }
 
-    if (evseId !== undefined && evseId > 0) {
+    if (evseId != null && evseId > 0) {
       if (!chargingStation.hasEvses) {
         logger.warn(
           `${chargingStation.logPrefix()} ${moduleName}.handleRequestReset: Charging station does not support EVSE-specific reset`
@@ -2477,7 +2477,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
     const hasActiveTransactions = chargingStation.getNumberOfRunningTransactions() > 0
 
     let evseHasActiveTransactions = false
-    if (evseId !== undefined && evseId > 0) {
+    if (evseId != null && evseId > 0) {
       const evse = chargingStation.getEvseStatus(evseId)
       if (evse != null) {
         evseHasActiveTransactions = this.hasEvseActiveTransactions(evse)
@@ -2486,7 +2486,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
 
     try {
       if (type === ResetEnumType.Immediate) {
-        if (evseId !== undefined && evseId > 0) {
+        if (evseId != null && evseId > 0) {
           if (evseHasActiveTransactions) {
             logger.info(
               `${chargingStation.logPrefix()} ${moduleName}.handleRequestReset: Immediate EVSE reset with active transaction, will terminate transaction and reset EVSE ${evseId.toString()}`
@@ -2555,7 +2555,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
           }
         }
       } else {
-        if (evseId !== undefined && evseId > 0) {
+        if (evseId != null && evseId > 0) {
           const evse = chargingStation.getEvseStatus(evseId)
           if (evse != null && !this.isEvseIdle(chargingStation, evse)) {
             logger.info(
@@ -3067,7 +3067,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
       const { evse, requestedMessage } = commandPayload
 
       logger.debug(
-        `${chargingStation.logPrefix()} ${moduleName}.handleRequestTriggerMessage: TriggerMessage received for '${requestedMessage}'${evse?.id !== undefined ? ` on EVSE ${evse.id.toString()}` : ''}`
+        `${chargingStation.logPrefix()} ${moduleName}.handleRequestTriggerMessage: TriggerMessage received for '${requestedMessage}'${evse?.id != null ? ` on EVSE ${evse.id.toString()}` : ''}`
       )
 
       switch (requestedMessage) {
@@ -4323,7 +4323,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
     evse: OCPP20TriggerMessageRequest['evse'],
     errorHandler: (error: unknown) => void
   ): void {
-    if (evse?.id !== undefined && evse.id > 0 && evse.connectorId !== undefined) {
+    if (evse?.id != null && evse.id > 0 && evse.connectorId != null) {
       const evseStatus = chargingStation.getEvseStatus(evse.id)
       const connectorStatus = evseStatus?.connectors.get(evse.connectorId)
       const resolvedStatus = connectorStatus?.status ?? ConnectorStatusEnum.Available
@@ -4559,14 +4559,14 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
       return false
     }
 
-    if (schedule.duration !== undefined && schedule.duration <= 0) {
+    if (schedule.duration != null && schedule.duration <= 0) {
       logger.warn(
         `${chargingStation.logPrefix()} ${moduleName}.validateChargingSchedule: Schedule duration must be positive if specified`
       )
       return false
     }
 
-    if (schedule.minChargingRate !== undefined && schedule.minChargingRate < 0) {
+    if (schedule.minChargingRate != null && schedule.minChargingRate < 0) {
       logger.warn(
         `${chargingStation.logPrefix()} ${moduleName}.validateChargingSchedule: Minimum charging rate cannot be negative`
       )
@@ -4615,14 +4615,14 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
         return false
       }
 
-      if (schedule.minChargingRate !== undefined && period.limit < schedule.minChargingRate) {
+      if (schedule.minChargingRate != null && period.limit < schedule.minChargingRate) {
         logger.warn(
           `${chargingStation.logPrefix()} ${moduleName}.validateChargingSchedule: Period ${periodIndex.toString()} limit cannot be below minimum charging rate`
         )
         return false
       }
 
-      if (period.numberPhases !== undefined) {
+      if (period.numberPhases != null) {
         if (period.numberPhases < 1 || period.numberPhases > 3) {
           logger.warn(
             `${chargingStation.logPrefix()} ${moduleName}.validateChargingSchedule: Period ${periodIndex.toString()} number of phases must be 1-3`
@@ -4631,7 +4631,7 @@ export class OCPP20IncomingRequestService extends OCPPIncomingRequestService<OCP
         }
 
         if (
-          period.phaseToUse !== undefined &&
+          period.phaseToUse != null &&
           (period.phaseToUse < 1 || period.phaseToUse > period.numberPhases)
         ) {
           logger.warn(

--- a/src/charging-station/ocpp/2.0/OCPP20VariableManager.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20VariableManager.ts
@@ -428,7 +428,7 @@ export class OCPP20VariableManager {
 
     if (resolvedAttributeType === AttributeEnumType.MinSet) {
       if (
-        variableMetadata.min === undefined &&
+        variableMetadata.min == null &&
         this.getMinSetOverrides(stationId).get(variableKey) == null
       ) {
         return this.rejectGet(
@@ -442,7 +442,7 @@ export class OCPP20VariableManager {
       }
       const minValue =
         this.getMinSetOverrides(stationId).get(variableKey) ??
-        (variableMetadata.min !== undefined ? variableMetadata.min.toString() : '')
+        (variableMetadata.min != null ? variableMetadata.min.toString() : '')
       return {
         attributeStatus: GetVariableStatusEnumType.Accepted,
         attributeType: resolvedAttributeType,
@@ -453,7 +453,7 @@ export class OCPP20VariableManager {
     }
     if (resolvedAttributeType === AttributeEnumType.MaxSet) {
       if (
-        variableMetadata.max === undefined &&
+        variableMetadata.max == null &&
         this.getMaxSetOverrides(stationId).get(variableKey) == null
       ) {
         return this.rejectGet(
@@ -467,7 +467,7 @@ export class OCPP20VariableManager {
       }
       const maxValue =
         this.getMaxSetOverrides(stationId).get(variableKey) ??
-        (variableMetadata.max !== undefined ? variableMetadata.max.toString() : '')
+        (variableMetadata.max != null ? variableMetadata.max.toString() : '')
       return {
         attributeStatus: GetVariableStatusEnumType.Accepted,
         attributeType: resolvedAttributeType,
@@ -821,7 +821,7 @@ export class OCPP20VariableManager {
       if (resolvedAttributeType === AttributeEnumType.MinSet) {
         const currentMax =
           this.getMaxSetOverrides(stationId).get(variableKey) ??
-          (variableMetadata.max !== undefined ? variableMetadata.max.toString() : undefined)
+          (variableMetadata.max != null ? variableMetadata.max.toString() : undefined)
         if (currentMax != null && intValue > convertToIntOrNaN(currentMax)) {
           return this.rejectSet(
             variable,
@@ -836,7 +836,7 @@ export class OCPP20VariableManager {
       } else {
         const currentMin =
           this.getMinSetOverrides(stationId).get(variableKey) ??
-          (variableMetadata.min !== undefined ? variableMetadata.min.toString() : undefined)
+          (variableMetadata.min != null ? variableMetadata.min.toString() : undefined)
         if (currentMin != null && intValue < convertToIntOrNaN(currentMin)) {
           return this.rejectSet(
             variable,

--- a/src/charging-station/ocpp/2.0/OCPP20VariableRegistry.ts
+++ b/src/charging-station/ocpp/2.0/OCPP20VariableRegistry.ts
@@ -2594,7 +2594,7 @@ export function getVariableMetadata (
 /**
  * Check if variable metadata is persistent.
  * @param variableMetadata - Variable metadata entry.
- * @returns True when persistence is Persistent.
+ * @returns `true` when persistence is Persistent.
  */
 export function isPersistent (variableMetadata: VariableMetadata): boolean {
   return variableMetadata.persistence === PersistenceEnumType.Persistent
@@ -2603,7 +2603,7 @@ export function isPersistent (variableMetadata: VariableMetadata): boolean {
 /**
  * Check if variable metadata is read-only.
  * @param variableMetadata - Variable metadata entry.
- * @returns True when mutability is ReadOnly.
+ * @returns `true` when mutability is ReadOnly.
  */
 export function isReadOnly (variableMetadata: VariableMetadata): boolean {
   return variableMetadata.mutability === MutabilityEnumType.ReadOnly
@@ -2612,7 +2612,7 @@ export function isReadOnly (variableMetadata: VariableMetadata): boolean {
 /**
  * Check if variable metadata is write-only.
  * @param variableMetadata - Variable metadata entry.
- * @returns True when mutability is WriteOnly.
+ * @returns `true` when mutability is WriteOnly.
  */
 export function isWriteOnly (variableMetadata: VariableMetadata): boolean {
   return variableMetadata.mutability === MutabilityEnumType.WriteOnly

--- a/src/charging-station/ocpp/2.0/__testable__/OCPP20VariableManagerTestable.ts
+++ b/src/charging-station/ocpp/2.0/__testable__/OCPP20VariableManagerTestable.ts
@@ -28,7 +28,7 @@ export interface TestableOCPP20VariableManager {
    * Validates whether a component is supported by the charging station.
    * @param chargingStation - The charging station instance
    * @param component - The component to validate
-   * @returns true if the component is valid/supported
+   * @returns `true` if the component is valid/supported
    */
   isComponentValid: (chargingStation: ChargingStation, component: ComponentType) => boolean
 
@@ -36,7 +36,7 @@ export interface TestableOCPP20VariableManager {
    * Checks whether a variable is supported for the given component.
    * @param component - The component containing the variable
    * @param variable - The variable to check
-   * @returns true if the variable is supported
+   * @returns `true` if the variable is supported
    */
   isVariableSupported: (component: ComponentType, variable: VariableType) => boolean
 }

--- a/src/charging-station/ocpp/auth/adapters/OCPP16AuthAdapter.ts
+++ b/src/charging-station/ocpp/auth/adapters/OCPP16AuthAdapter.ts
@@ -293,7 +293,7 @@ export class OCPP16AuthAdapter implements OCPPAuthAdapter<string> {
 
   /**
    * Check if remote authorization is available
-   * @returns True if remote authorization is enabled and station is online
+   * @returns `true` if remote authorization is enabled and station is online
    */
   isRemoteAvailable (): boolean {
     try {
@@ -316,7 +316,7 @@ export class OCPP16AuthAdapter implements OCPPAuthAdapter<string> {
   /**
    * Check if identifier is valid for OCPP 1.6
    * @param identifier - Identifier to validate
-   * @returns True if identifier has valid ID_TAG type and length within OCPP 1.6 limits
+   * @returns `true` if identifier has valid ID_TAG type and length within OCPP 1.6 limits
    */
   isValidIdentifier (identifier: Identifier): boolean {
     // OCPP 1.6 idTag validation
@@ -340,7 +340,7 @@ export class OCPP16AuthAdapter implements OCPPAuthAdapter<string> {
   /**
    * Validate adapter configuration for OCPP 1.6
    * @param config - Auth configuration to validate
-   * @returns True if configuration has valid auth methods and timeout values
+   * @returns `true` if configuration has valid auth methods and timeout values
    */
   validateConfiguration (config: AuthConfiguration): boolean {
     try {
@@ -375,7 +375,7 @@ export class OCPP16AuthAdapter implements OCPPAuthAdapter<string> {
 
   /**
    * Check if offline transactions are allowed for unknown IDs
-   * @returns True if offline transactions are allowed for unknown IDs
+   * @returns `true` if offline transactions are allowed for unknown IDs
    */
   private getOfflineTransactionConfig (): boolean {
     try {

--- a/src/charging-station/ocpp/auth/adapters/OCPP20AuthAdapter.ts
+++ b/src/charging-station/ocpp/auth/adapters/OCPP20AuthAdapter.ts
@@ -368,7 +368,7 @@ export class OCPP20AuthAdapter implements OCPPAuthAdapter<OCPP20IdTokenType> {
 
   /**
    * Check if remote authorization is available for OCPP 2.0.1
-   * @returns True if remote authorization is available and enabled
+   * @returns `true` if remote authorization is available and enabled
    */
   isRemoteAvailable (): boolean {
     try {
@@ -392,7 +392,7 @@ export class OCPP20AuthAdapter implements OCPPAuthAdapter<OCPP20IdTokenType> {
   /**
    * Check if identifier is valid for OCPP 2.0.1
    * @param identifier - Identifier to validate against OCPP 2.0.1 rules
-   * @returns True if identifier meets OCPP 2.0.1 format requirements (max 36 chars, valid type)
+   * @returns `true` if identifier meets OCPP 2.0.1 format requirements (max 36 chars, valid type)
    */
   isValidIdentifier (identifier: Identifier): boolean {
     // OCPP 2.0.1 idToken validation
@@ -460,7 +460,7 @@ export class OCPP20AuthAdapter implements OCPPAuthAdapter<OCPP20IdTokenType> {
 
   /**
    * Check if offline authorization is allowed
-   * @returns True if offline authorization is enabled
+   * @returns `true` if offline authorization is enabled
    */
   private getOfflineAuthorizationConfig (): boolean {
     try {

--- a/src/charging-station/ocpp/auth/adapters/OCPP20AuthAdapter.ts
+++ b/src/charging-station/ocpp/auth/adapters/OCPP20AuthAdapter.ts
@@ -424,7 +424,7 @@ export class OCPP20AuthAdapter implements OCPPAuthAdapter<OCPP20IdTokenType> {
   /**
    * Validate adapter configuration for OCPP 2.0.1
    * @param config - Authentication configuration to validate
-   * @returns Promise resolving to true if configuration is valid for OCPP 2.0.1 operations
+   * @returns `true` if configuration is valid for OCPP 2.0.1 operations
    */
   validateConfiguration (config: AuthConfiguration): boolean {
     try {

--- a/src/charging-station/ocpp/auth/cache/InMemoryAuthCache.ts
+++ b/src/charging-station/ocpp/auth/cache/InMemoryAuthCache.ts
@@ -371,7 +371,7 @@ export class InMemoryAuthCache implements AuthCache {
   /**
    * Check if identifier has exceeded rate limit
    * @param identifier - Identifier to check
-   * @returns true if within rate limit, false if exceeded
+   * @returns `true` if within rate limit, `false` if exceeded
    */
   private checkRateLimit (identifier: string): boolean {
     if (!this.rateLimit.enabled) {

--- a/src/charging-station/ocpp/auth/interfaces/OCPPAuthService.ts
+++ b/src/charging-station/ocpp/auth/interfaces/OCPPAuthService.ts
@@ -136,7 +136,7 @@ export interface AuthStrategy {
    * Check if this strategy can handle the given request
    * @param request - Authentication request
    * @param config - Current configuration
-   * @returns True if strategy can handle the request
+   * @returns `true` if strategy can handle the request
    */
   canHandle(request: AuthRequest, config: AuthConfiguration): boolean
 

--- a/src/charging-station/ocpp/auth/services/OCPPAuthServiceImpl.ts
+++ b/src/charging-station/ocpp/auth/services/OCPPAuthServiceImpl.ts
@@ -428,7 +428,7 @@ export class OCPPAuthServiceImpl implements OCPPAuthService {
   /**
    * Check if authentication is supported for given identifier type
    * @param identifier - Identifier to check for support
-   * @returns True if at least one strategy can handle the identifier type, false otherwise
+   * @returns `true` if at least one strategy can handle the identifier type, `false` otherwise
    */
   public isSupported (identifier: Identifier): boolean {
     const testRequest: AuthRequest = {
@@ -447,7 +447,7 @@ export class OCPPAuthServiceImpl implements OCPPAuthService {
 
   /**
    * Test connectivity to remote authorization service
-   * @returns True if remote authorization service is reachable
+   * @returns `true` if remote authorization service is reachable
    */
   public testConnectivity (): boolean {
     const remoteStrategy = this.strategies.get('remote')
@@ -645,7 +645,7 @@ export class OCPPAuthServiceImpl implements OCPPAuthService {
   /**
    * Check if an error should stop the authentication chain
    * @param error - Error to evaluate for criticality
-   * @returns True if the error should halt authentication attempts, false to continue trying other strategies
+   * @returns `true` if the error should halt authentication attempts, `false` to continue trying other strategies
    */
   private isCriticalError (error: Error): boolean {
     // Critical errors that should stop trying other strategies

--- a/src/charging-station/ocpp/auth/strategies/CertificateAuthStrategy.ts
+++ b/src/charging-station/ocpp/auth/strategies/CertificateAuthStrategy.ts
@@ -106,7 +106,7 @@ export class CertificateAuthStrategy implements AuthStrategy {
    * Check if this strategy can handle the given request
    * @param request - Authorization request to evaluate for certificate-based handling
    * @param config - Authentication configuration with certificate settings
-   * @returns True if the request contains valid certificate data and certificate auth is enabled
+   * @returns `true` if the request contains valid certificate data and certificate auth is enabled
    */
   canHandle (request: AuthRequest, config: AuthConfiguration): boolean {
     // Only handle certificate-based authentication
@@ -205,7 +205,7 @@ export class CertificateAuthStrategy implements AuthStrategy {
   /**
    * Check if the identifier contains certificate data
    * @param identifier - Identifier to check for certificate hash data
-   * @returns True if all required certificate hash fields are present and non-empty
+   * @returns `true` if all required certificate hash fields are present and non-empty
    */
   private hasCertificateData (identifier: Identifier): boolean {
     const certData = identifier.certificateHashData
@@ -223,7 +223,7 @@ export class CertificateAuthStrategy implements AuthStrategy {
    * Simulate certificate validation (in real implementation, this would involve crypto operations)
    * @param request - Authorization request containing certificate data to validate
    * @param config - Authentication configuration with validation strictness settings
-   * @returns True if the certificate passes simulated validation checks
+   * @returns `true` if the certificate passes simulated validation checks
    */
   private async simulateCertificateValidation (
     request: AuthRequest,

--- a/src/charging-station/ocpp/auth/strategies/LocalAuthStrategy.ts
+++ b/src/charging-station/ocpp/auth/strategies/LocalAuthStrategy.ts
@@ -175,7 +175,7 @@ export class LocalAuthStrategy implements AuthStrategy {
    * Check if this strategy can handle the authentication request
    * @param request - Authorization request to evaluate
    * @param config - Authentication configuration with local auth settings
-   * @returns True if local list, cache, or offline authorization is enabled
+   * @returns `true` if local list, cache, or offline authorization is enabled
    */
   public canHandle (request: AuthRequest, config: AuthConfiguration): boolean {
     // Can handle if local list is enabled OR cache is enabled OR offline is allowed
@@ -299,7 +299,7 @@ export class LocalAuthStrategy implements AuthStrategy {
   /**
    * Check if identifier is in local authorization list
    * @param identifier - Unique identifier string to look up
-   * @returns True if the identifier exists in the local authorization list
+   * @returns `true` if the identifier exists in the local authorization list
    */
   public isInLocalList (identifier: string): boolean {
     if (!this.localAuthListManager) {
@@ -510,7 +510,7 @@ export class LocalAuthStrategy implements AuthStrategy {
    * When DisablePostAuthorize is true or not configured, local results are returned as-is.
    * @param result - Authorization result from cache or local list
    * @param config - Authentication configuration with disablePostAuthorize setting
-   * @returns True if the result should be discarded to trigger remote re-authorization
+   * @returns `true` if the result should be discarded to trigger remote re-authorization
    */
   private shouldTriggerPostAuthorize (
     result: AuthorizationResult,

--- a/src/charging-station/ocpp/auth/strategies/RemoteAuthStrategy.ts
+++ b/src/charging-station/ocpp/auth/strategies/RemoteAuthStrategy.ts
@@ -185,7 +185,7 @@ export class RemoteAuthStrategy implements AuthStrategy {
    * Check if this strategy can handle the authentication request
    * @param request - Authorization request to evaluate
    * @param config - Authentication configuration with remote authorization settings
-   * @returns True if an adapter is available and remote auth is enabled
+   * @returns `true` if an adapter is available and remote auth is enabled
    */
   public canHandle (request: AuthRequest, config: AuthConfiguration): boolean {
     // Can handle if we have an adapter
@@ -341,7 +341,7 @@ export class RemoteAuthStrategy implements AuthStrategy {
 
   /**
    * Test connectivity to remote authorization service
-   * @returns True if the OCPP adapter can reach its remote service
+   * @returns `true` if the OCPP adapter can reach its remote service
    */
   public testConnectivity (): boolean {
     if (!this.isInitialized || this.adapter == null) {
@@ -399,7 +399,7 @@ export class RemoteAuthStrategy implements AuthStrategy {
    * Check if remote authorization service is available
    * @param adapter - OCPP adapter to check for remote service availability
    * @param _config - Authentication configuration (unused)
-   * @returns True if the remote service responds
+   * @returns `true` if the remote service responds
    */
   private checkRemoteAvailability (adapter: OCPPAuthAdapter, _config: AuthConfiguration): boolean {
     try {

--- a/src/charging-station/ocpp/auth/types/AuthTypes.ts
+++ b/src/charging-station/ocpp/auth/types/AuthTypes.ts
@@ -310,7 +310,7 @@ export class AuthenticationError extends Error {
 /**
  * Check if identifier type is certificate-based
  * @param type - Identifier type to check
- * @returns True if certificate-based
+ * @returns `true` if certificate-based
  */
 export const isCertificateBased = (type: IdentifierType): boolean => {
   return type === IdentifierType.CERTIFICATE
@@ -319,7 +319,7 @@ export const isCertificateBased = (type: IdentifierType): boolean => {
 /**
  * Check if identifier type is OCPP 1.6 compatible
  * @param type - Identifier type to check
- * @returns True if OCPP 1.6 type
+ * @returns `true` if OCPP 1.6 type
  */
 export const isOCPP16Type = (type: IdentifierType): boolean => {
   return type === IdentifierType.ID_TAG
@@ -328,7 +328,7 @@ export const isOCPP16Type = (type: IdentifierType): boolean => {
 /**
  * Check if identifier type is OCPP 2.0.1 compatible
  * @param type - Identifier type to check
- * @returns True if OCPP 2.0.1 type
+ * @returns `true` if OCPP 2.0.1 type
  */
 export const isOCPP20Type = (type: IdentifierType): boolean => {
   return (Object.values(OCPP20IdTokenEnumType) as string[]).includes(type)
@@ -337,7 +337,7 @@ export const isOCPP20Type = (type: IdentifierType): boolean => {
 /**
  * Check if identifier type requires additional information
  * @param type - Identifier type to check
- * @returns True if additional info is required
+ * @returns `true` if additional info is required
  */
 export const requiresAdditionalInfo = (type: IdentifierType): boolean => {
   return [

--- a/src/charging-station/ocpp/auth/utils/AuthHelpers.ts
+++ b/src/charging-station/ocpp/auth/utils/AuthHelpers.ts
@@ -118,7 +118,7 @@ function getStatusMessage (status: AuthorizationStatus): string {
 /**
  * Check whether an authorization result represents a permanent failure.
  * @param result - Authorization result to evaluate
- * @returns True if BLOCKED, EXPIRED, or INVALID
+ * @returns `true` if BLOCKED, EXPIRED, or INVALID
  */
 function isPermanentFailure (result: AuthorizationResult): boolean {
   return [
@@ -131,7 +131,7 @@ function isPermanentFailure (result: AuthorizationResult): boolean {
 /**
  * Check whether an authorization result is still valid (ACCEPTED and not expired).
  * @param result - Authorization result to evaluate
- * @returns True if ACCEPTED and expiry date has not passed
+ * @returns `true` if ACCEPTED and expiry date has not passed
  */
 function isResultValid (result: AuthorizationResult): boolean {
   if (result.status !== AuthorizationStatus.ACCEPTED) {
@@ -149,7 +149,7 @@ function isResultValid (result: AuthorizationResult): boolean {
 /**
  * Check whether an authorization result represents a temporary failure.
  * @param result - Authorization result to evaluate
- * @returns True if PENDING or UNKNOWN
+ * @returns `true` if PENDING or UNKNOWN
  */
 function isTemporaryFailure (result: AuthorizationResult): boolean {
   if (result.status === AuthorizationStatus.PENDING) {

--- a/src/charging-station/ocpp/auth/utils/AuthValidators.ts
+++ b/src/charging-station/ocpp/auth/utils/AuthValidators.ts
@@ -23,7 +23,7 @@ const MAX_IDTOKEN_LENGTH = 36
 /**
  * Validate cache TTL value
  * @param ttl - Cache time-to-live duration in seconds, or undefined for optional parameter
- * @returns True if the TTL is undefined or a valid non-negative finite number, false otherwise
+ * @returns `true` if the TTL is undefined or a valid non-negative finite number, `false` otherwise
  */
 function isValidCacheTTL (ttl: number | undefined): boolean {
   if (ttl === undefined) {
@@ -36,7 +36,7 @@ function isValidCacheTTL (ttl: number | undefined): boolean {
 /**
  * Validate connector ID
  * @param connectorId - Charging connector identifier (0 or positive integer), or undefined for optional parameter
- * @returns True if the connector ID is undefined or a valid non-negative integer, false otherwise
+ * @returns `true` if the connector ID is undefined or a valid non-negative integer, `false` otherwise
  */
 function isValidConnectorId (connectorId: number | undefined): boolean {
   if (connectorId === undefined) {
@@ -49,7 +49,7 @@ function isValidConnectorId (connectorId: number | undefined): boolean {
 /**
  * Validate that a string is a valid identifier value
  * @param value - Authentication identifier string to validate (idTag or IdToken value)
- * @returns True if the value is a non-empty string with at least one non-whitespace character, false otherwise
+ * @returns `true` if the value is a non-empty string with at least one non-whitespace character, `false` otherwise
  */
 function isValidIdentifierValue (value: string): boolean {
   return isNotEmptyString(value)
@@ -90,7 +90,7 @@ function sanitizeIdToken (idToken: unknown): string {
 /**
  * Validate authentication configuration
  * @param config - Authentication configuration object to validate (may be any type)
- * @returns True if the configuration has valid required fields and constraints, false otherwise
+ * @returns `true` if the configuration has valid required fields and constraints, `false` otherwise
  */
 function validateAuthConfiguration (config: unknown): boolean {
   if (!config || typeof config !== 'object') {
@@ -144,7 +144,7 @@ function validateAuthConfiguration (config: unknown): boolean {
 /**
  * Validate identifier format and constraints
  * @param identifier - Identifier object to validate (may be any type)
- * @returns True if the identifier has a valid type and value within OCPP length constraints, false otherwise
+ * @returns `true` if the identifier has a valid type and value within OCPP length constraints, `false` otherwise
  */
 function validateIdentifier (identifier: unknown): boolean {
   // Check if identifier itself is valid

--- a/src/utils/ConfigurationMigrations.ts
+++ b/src/utils/ConfigurationMigrations.ts
@@ -126,7 +126,7 @@ const deleteAtPath = (target: Record<string, unknown>, path: string): void => {
  * @param value - value to write at the leaf
  * @param source - originating deprecated key (for error messages)
  * @param fieldErrors - error accumulator
- * @returns true on write or no-op, false when an error is recorded
+ * @returns `true` on write or no-op, `false` when an error is recorded
  */
 const setAtPath = (
   target: Record<string, unknown>,


### PR DESCRIPTION
Closes #1966

Behavior-preserving codebase style-consistency sweep, re-baselined against `origin/main` (`993c39671`) — the issue body's counts/line numbers were stale (they predate #2003, which rewrote `OCPP20IncomingRequestService.ts`).

## Commits

| # | Commit | Scope |
|---|---|---|
| 1 | `style(jsdoc): backtick @returns boolean literals` | 49 sites / 17 files |
| 2 | `refactor(ocpp): align !== undefined to != null for number\|undefined guards` | 13 token swaps, OCPP20IncomingRequestService.ts |
| 3 | `refactor(ocpp): extend != null idiom to VariableManager min/max ternaries and negated EVSE guard` | 7 swaps (OCPP20VariableManager.ts + L4655) |
| 4 | `docs(ocpp): fix validateConfiguration @returns — synchronous boolean, backtick literal` | OCPP20AuthAdapter.ts:427 |

## Re-baselined scope vs. the issue body's stale numbers

| Gap | Issue body (stale) | Re-baselined | Action |
|---|---|---|---|
| **A** — JSDoc `@returns` backticks | 13 sites | **49 sites / 17 files** | Fixed (commit 1) |
| **B** — `!== undefined` → `!= null` | 7 candidates | **15 sites → 12 QUALIFY (13 tokens) / 3 PRESERVE** | Swapped QUALIFY only (commit 2) |
| **C** — `String(x)` → `x.toString()` | 1 site | **1 site — premise false** | **Dropped** (see below) |

## Commit 1 — JSDoc `@returns` backticks (comment-only)

Backticked every `@returns` boolean literal and lowercased capital `True`/`False` across the 49 sites matching `@returns (true|True|false|False)( |,|\.|$)`. Both literals backticked where both appear. Diff exactly 49/49, only `@returns` lines.

## Commit 2 — `!== undefined` → `!= null` (number|undefined guards)

`!= null` excludes both `null` and `undefined`; `!== undefined` excludes only `undefined`. A swap is behavior-preserving **only** when the operand can never be `null`. Every swapped operand was type-verified as `number | undefined`.

### Gap B classification table

| Line | Operand | Type source | Classification |
|---|---|---|---|
| 2410 | `commandPayload.evseId` | `Requests.ts:237` `evseId?: number` | **QUALIFY** → `!= null` |
| 2448/2480/2489/2558 | `evseId` (OCPP20ResetRequest) | `Requests.ts:237` | **QUALIFY** → `!= null` |
| 3070 | `evse?.id` | `OCPP20EVSEType.id: number` + `?.` | **QUALIFY** → `!= null` |
| 4326 | `evse?.id` + `evse.connectorId` | `Transaction.ts:239/241` | **QUALIFY** → `!= null` (2 tokens) |
| 4562 | `schedule.duration` | `Transaction.ts:232` `duration?: number` | **QUALIFY** → `!= null` |
| 4569/4618 | `schedule.minChargingRate` | `Transaction.ts:234` | **QUALIFY** → `!= null` |
| 4625 | `period.numberPhases` | `Transaction.ts:223` | **QUALIFY** → `!= null` |
| 4634 | `period.phaseToUse` | `Transaction.ts:224` | **QUALIFY** → `!= null` |
| 3749 | `chunk` (`...(x !== undefined && {…})`) | conditional-spread inclusion idiom | **PRESERVE** |
| 3811 | `event.techInfo` (spread inclusion) | conditional-spread inclusion idiom | **PRESERVE** |
| 3905 | `techInfo` (spread inclusion) | conditional-spread inclusion idiom | **PRESERVE** |

12 QUALIFY lines = 13 token swaps (L4326 has two).

## Commit 3 — extend `!= null` idiom (review-driven consistency completion)

A multi-agent review surfaced same-class nullish sites outside commit 2's file. Resolved by an **operand + idiom rule**: value-conversion ternaries and control-flow guards on non-nullable `number | undefined` → `!= null`; conditional property-**inclusion** idioms stay `!== undefined`.

- `OCPP20VariableManager.ts` L445/470/824/839 — 4 `min/max` conversion ternaries `x !== undefined ? x.toString() : …` → `x != null ? …` (twins of the log ternaries swapped in commit 2; `min?/max?: number`).
- `OCPP20VariableManager.ts` L431/456 — 2 attribute-presence control-flow guards; swapped `variableMetadata.min/max === undefined` → `== null`, removing an intra-line `=== undefined && … == null` mix and fully migrating the file (0 remaining `== undefined`).
- `OCPP20IncomingRequestService.ts` L4655 — `evse?.id === undefined || evse.id <= 0` → `== null` (exact De Morgan negation of the `!= null` guard at L4326; `number | undefined`).

**Deliberately LEFT as `!== undefined`** (documented, not oversights): the 11 imperative property-inclusion guards in `OCPP20ServiceUtils.ts` L1388–1430 (`if (commandParams.X !== undefined) { req.X = … }`) and the 3 spread inclusion guards (commit 2 PRESERVE set). These are the property-inclusion idiom ("field explicitly provided"), kept uniformly `!== undefined` across both files.

## Commit 4 — `validateConfiguration` @returns doc fix

`OCPP20AuthAdapter.ts:427` read `@returns Promise resolving to true if …`, but `validateConfiguration(config): boolean` is **synchronous**. Corrected to `` @returns `true` if configuration is valid for OCPP 2.0.1 operations `` — factually accurate, backticked, and consistent with the sibling boolean `@returns` at L371/395/463.

## Gap C — DROPPED (premise false)

Expected `String(previousRequestId)` → `previousRequestId.toString()` at L3276, assuming `previousRequestId` is narrowed to `number`. It is not: `activeFirmwareUpdateRequestId?: number` (L287) is `number | undefined`, and the enclosing guard tests the sibling `activeFirmwareUpdateAbortController` field, so no narrowing applies. `previousRequestId.toString()` fails typecheck (`TS18048`). A `?.toString()` rewrite would change behavior (`String(undefined)="undefined"` vs `undefined?.toString()=undefined`). `String(previousRequestId)` is the only behavior-preserving form — left as-is.

## Review-driven decisions explicitly deferred (out of scope)

- **`@returns` `when`/`if`/`iff` phrasing** (48/22/1): NOT normalized. Would touch ~13 unrelated files (scope explosion vs minimal-diff); both `if`/`when` are valid; the single `iff` at `AbstractUIServer.ts:135` is a precise biconditional (if-and-only-if) on a type-guard predicate.
- **Other-directory `!== undefined`**: only `ocpp/2.0` sweep sites addressed; no repo-wide migration.

## Verification gates (run after each commit)

- `pnpm format` / `pnpm typecheck` / `pnpm lint` / `pnpm build` — all clean, 0 warnings, exit 0
- `pnpm test` — 0 failures, 6 skipped (unchanged); total/pass counts vary run-to-run due to parallel-worker subtest counting — stable invariant `fail=0` holds across all runs and baseline
- Safety greps (final state): `OCPP20IncomingRequestService.ts` = 3 `!== undefined` (spread PRESERVE) + 0 `=== undefined`; `OCPP20VariableManager.ts` = 0 `== undefined`; `OCPP20AuthAdapter.ts` = 0 bare-literal `@returns`

## Review

Two rounds of multi-agent review (oracle + explore + deep, 3 reviewers/round, cross-validated against source). Round 1 validated commits 1–2 (zero valid findings). Round 2 designed + validated commits 3–4: all swaps behavior-preserving (operands `number | undefined`, never null), doc fix accurate, LEAVE decisions internally consistent, no new inconsistency introduced.
