### PR TITLE
fix(charging-station): retain creation options so a reset keeps station identity

### DIFF
--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -219,6 +219,7 @@ export class ChargingStation extends EventEmitter {
   private flushMessageBufferSetInterval?: NodeJS.Timeout
   private readonly messageQueue: string[]
   private ocppIncomingRequestService!: OCPPIncomingRequestService
+  private readonly options?: ChargingStationOptions
   private readonly sharedLRUCache: SharedLRUCache
   private stopping: boolean
   private templateFileHash: string
@@ -248,6 +249,10 @@ export class ChargingStation extends EventEmitter {
     this.connectorsConfigurationHash = ''
     this.evsesConfigurationHash = ''
     this.templateFileHash = ''
+    // Retain the creation options so a reset or template-file reload can
+    // re-apply them; otherwise the station reverts to the template defaults
+    // (losing its fixed identity and supervision URL). See issue #2017.
+    this.options = options
 
     this.on(ChargingStationEvents.added, () => {
       parentPort?.postMessage(buildAddedMessage(this))
@@ -1063,7 +1068,7 @@ export class ChargingStation extends EventEmitter {
     }
     await sleep(this.stationInfo?.resetTime ?? 0)
     OCPPAuthServiceFactory.clearInstance(this)
-    this.initialize()
+    this.initialize(this.options)
     this.start()
   }
 
@@ -1113,6 +1118,20 @@ export class ChargingStation extends EventEmitter {
       if (supervisionPassword != null) {
         this.stationInfo.supervisionPassword = supervisionPassword
       }
+      // Keep the retained creation-options snapshot in sync with these runtime
+      // changes so a subsequent reset() re-applies them — a reset reboots the
+      // station into its current configured state rather than reverting to the
+      // creation-time configuration. The snapshot is in-memory only, so a full
+      // simulator restart still reverts to the original options. See issue #2017.
+      if (this.options != null) {
+        this.options.supervisionUrls = url
+        if (supervisionUser != null) {
+          this.options.supervisionUser = supervisionUser
+        }
+        if (supervisionPassword != null) {
+          this.options.supervisionPassword = supervisionPassword
+        }
+      }
       this.saveStationInfo()
       this.emitChargingStationEvent(ChargingStationEvents.updated)
     }
@@ -1148,7 +1167,7 @@ export class ChargingStation extends EventEmitter {
                     this.idTagsCache.deleteIdTags(idTagsFile)
                   }
                   OCPPAuthServiceFactory.clearInstance(this)
-                  this.initialize()
+                  this.initialize(this.options)
                   // Restart the ATG
                   const ATGStarted = this.automaticTransactionGenerator?.started
                   if (ATGStarted === true) {

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -1138,17 +1138,14 @@ export class ChargingStation extends EventEmitter {
     }
     if (this.stationInfo != null) {
       applyCredentials(this.stationInfo)
-      // Mirror the update into the retained creation options so a later reset()
-      // or template reload re-applies this URL, not the creation-time one. Must
-      // run for BOTH branches, OCPP-config mode included: a non-persistent station
-      // does not persist its supervisionUrlOcppKey, so when the template cache is
-      // invalidated (reload, or any cache-cold reinitialization) the key is absent
-      // and re-seeded from configuredSupervisionUrl — derived from
-      // stationInfo.supervisionUrls, which setChargingStationOptions() writes from
-      // these options. Without this mirror the reload would restore the
-      // creation-time URL. (A plain reset() reuses the warm template cache, whose
-      // in-place key mutation already carries the URL.) In-memory only: a full
-      // restart returns to the original options.
+      // Mirror the update into the retained creation options so a later reset() or
+      // template reload re-applies this URL, not the creation-time one — for BOTH
+      // branches above. On a cache-cold reinitialization (reload) a non-persistent
+      // station's supervisionUrlOcppKey is absent and re-seeded from
+      // configuredSupervisionUrl (i.e. stationInfo.supervisionUrls, written from
+      // these options), so without the mirror the reload would restore the old URL.
+      // (A warm reset() reuses the cached template whose in-place key mutation
+      // already carries it.) In-memory only: a full restart reverts to the originals.
       if (this.creationOptions != null) {
         this.creationOptions.supervisionUrls = url
         applyCredentials(this.creationOptions)

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -235,7 +235,7 @@ export class ChargingStation extends EventEmitter {
    * @returns The retained creation options when the station is non-persistent,
    *   `undefined` otherwise.
    */
-  private get reinitializeOptions (): ChargingStationOptions | undefined {
+  private get reinitializationOptions (): ChargingStationOptions | undefined {
     return this.stationInfo?.stationInfoPersistentConfiguration === false
       ? this.creationOptions
       : undefined
@@ -1082,7 +1082,7 @@ export class ChargingStation extends EventEmitter {
     }
     await sleep(this.stationInfo?.resetTime ?? 0)
     OCPPAuthServiceFactory.clearInstance(this)
-    this.initialize(this.reinitializeOptions)
+    this.initialize(this.reinitializationOptions)
     this.start()
   }
 
@@ -1139,14 +1139,16 @@ export class ChargingStation extends EventEmitter {
     if (this.stationInfo != null) {
       applyCredentials(this.stationInfo)
       // Mirror the update into the retained creation options so a later reset()
-      // re-applies this URL, not the creation-time one. This must run for BOTH
-      // branches above, OCPP-config mode included: a non-persistent station does
-      // not save its supervisionUrlOcppKey, so on reset the key is re-seeded from
-      // configuredSupervisionUrl, itself derived from stationInfo.supervisionUrls,
-      // which setChargingStationOptions() force-writes from these options. Mirroring
-      // only in the non-OCPP branch would drop the new URL for non-persistent
-      // OCPP-config stations. In-memory only: a full restart returns to the
-      // original options.
+      // or template reload re-applies this URL, not the creation-time one. Must
+      // run for BOTH branches, OCPP-config mode included: a non-persistent station
+      // does not persist its supervisionUrlOcppKey, so when the template cache is
+      // invalidated (reload, or any cache-cold reinitialization) the key is absent
+      // and re-seeded from configuredSupervisionUrl — derived from
+      // stationInfo.supervisionUrls, which setChargingStationOptions() writes from
+      // these options. Without this mirror the reload would restore the
+      // creation-time URL. (A plain reset() reuses the warm template cache, whose
+      // in-place key mutation already carries the URL.) In-memory only: a full
+      // restart returns to the original options.
       if (this.creationOptions != null) {
         this.creationOptions.supervisionUrls = url
         applyCredentials(this.creationOptions)
@@ -1186,7 +1188,7 @@ export class ChargingStation extends EventEmitter {
                     this.idTagsCache.deleteIdTags(idTagsFile)
                   }
                   OCPPAuthServiceFactory.clearInstance(this)
-                  this.initialize(this.reinitializeOptions)
+                  this.initialize(this.reinitializationOptions)
                   // Restart the ATG
                   const ATGStarted = this.automaticTransactionGenerator?.started
                   if (ATGStarted === true) {

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -1116,6 +1116,17 @@ export class ChargingStation extends EventEmitter {
     supervisionUser?: string,
     supervisionPassword?: string
   ): void {
+    const applyCredentials = (target: {
+      supervisionPassword?: string
+      supervisionUser?: string
+    }): void => {
+      if (supervisionUser != null) {
+        target.supervisionUser = supervisionUser
+      }
+      if (supervisionPassword != null) {
+        target.supervisionPassword = supervisionPassword
+      }
+    }
     if (
       this.stationInfo?.supervisionUrlOcppConfiguration === true &&
       isNotEmptyString(this.stationInfo.supervisionUrlOcppKey)
@@ -1126,12 +1137,7 @@ export class ChargingStation extends EventEmitter {
       this.configuredSupervisionUrl = this.getConfiguredSupervisionUrl()
     }
     if (this.stationInfo != null) {
-      if (supervisionUser != null) {
-        this.stationInfo.supervisionUser = supervisionUser
-      }
-      if (supervisionPassword != null) {
-        this.stationInfo.supervisionPassword = supervisionPassword
-      }
+      applyCredentials(this.stationInfo)
       // Mirror the update into the retained creation options so a later reset()
       // re-applies this URL, not the creation-time one. This must run for BOTH
       // branches above, OCPP-config mode included: a non-persistent station does
@@ -1143,12 +1149,7 @@ export class ChargingStation extends EventEmitter {
       // original options.
       if (this.creationOptions != null) {
         this.creationOptions.supervisionUrls = url
-        if (supervisionUser != null) {
-          this.creationOptions.supervisionUser = supervisionUser
-        }
-        if (supervisionPassword != null) {
-          this.creationOptions.supervisionPassword = supervisionPassword
-        }
+        applyCredentials(this.creationOptions)
       }
       this.saveStationInfo()
       this.emitChargingStationEvent(ChargingStationEvents.updated)

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -249,10 +249,10 @@ export class ChargingStation extends EventEmitter {
     this.connectorsConfigurationHash = ''
     this.evsesConfigurationHash = ''
     this.templateFileHash = ''
-    // Retain the creation options so a reset or template-file reload can
-    // re-apply them; otherwise the station reverts to the template defaults
-    // (losing its fixed identity and supervision URL). See issue #2017.
-    this.options = options
+    // Kept so a reset or template reload can re-apply the configured identity
+    // and supervision URL. Cloned so the in-place update in setSupervisionUrl
+    // stays off the shared worker data.
+    this.options = clone(options)
 
     this.on(ChargingStationEvents.added, () => {
       parentPort?.postMessage(buildAddedMessage(this))
@@ -1118,11 +1118,9 @@ export class ChargingStation extends EventEmitter {
       if (supervisionPassword != null) {
         this.stationInfo.supervisionPassword = supervisionPassword
       }
-      // Keep the retained creation-options snapshot in sync with these runtime
-      // changes so a subsequent reset() re-applies them — a reset reboots the
-      // station into its current configured state rather than reverting to the
-      // creation-time configuration. The snapshot is in-memory only, so a full
-      // simulator restart still reverts to the original options. See issue #2017.
+      // Update the kept options too, so a later reset re-applies this new URL
+      // rather than the creation-time one. This lives only in memory, so a full
+      // simulator restart still returns to the original options.
       if (this.options != null) {
         this.options.supervisionUrls = url
         if (supervisionUser != null) {

--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -213,19 +213,33 @@ export class ChargingStation extends EventEmitter {
   private configuredSupervisionUrl!: URL
   private readonly connectors: Map<number, ConnectorStatus>
   private connectorsConfigurationHash: string
+  private readonly creationOptions?: ChargingStationOptions
   private readonly evses: Map<number, EvseStatus>
   private evsesConfigurationHash: string
   private flushingMessageBuffer: boolean
   private flushMessageBufferSetInterval?: NodeJS.Timeout
   private readonly messageQueue: string[]
   private ocppIncomingRequestService!: OCPPIncomingRequestService
-  private readonly options?: ChargingStationOptions
   private readonly sharedLRUCache: SharedLRUCache
   private stopping: boolean
   private templateFileHash: string
   private templateFileWatcher?: FSWatcher
   private wsConnectionRetryCount: number
   private wsPingSetInterval?: NodeJS.Timeout
+
+  /**
+   * Creation options to re-apply when re-initializing on a reset or template
+   * reload. Only a non-persistent station needs them: a persistent one restores
+   * its identity and configuration from its saved file, which stays the source
+   * of truth, so re-applying the creation options would needlessly override it.
+   * @returns The retained creation options when the station is non-persistent,
+   *   `undefined` otherwise.
+   */
+  private get reinitializeOptions (): ChargingStationOptions | undefined {
+    return this.stationInfo?.stationInfoPersistentConfiguration === false
+      ? this.creationOptions
+      : undefined
+  }
 
   constructor (index: number, templateFile: string, options?: ChargingStationOptions) {
     super()
@@ -252,7 +266,7 @@ export class ChargingStation extends EventEmitter {
     // Kept so a reset or template reload can re-apply the configured identity
     // and supervision URL. Cloned so the in-place update in setSupervisionUrl
     // stays off the shared worker data.
-    this.options = clone(options)
+    this.creationOptions = clone(options)
 
     this.on(ChargingStationEvents.added, () => {
       parentPort?.postMessage(buildAddedMessage(this))
@@ -1068,7 +1082,7 @@ export class ChargingStation extends EventEmitter {
     }
     await sleep(this.stationInfo?.resetTime ?? 0)
     OCPPAuthServiceFactory.clearInstance(this)
-    this.initialize(this.options)
+    this.initialize(this.reinitializeOptions)
     this.start()
   }
 
@@ -1118,16 +1132,22 @@ export class ChargingStation extends EventEmitter {
       if (supervisionPassword != null) {
         this.stationInfo.supervisionPassword = supervisionPassword
       }
-      // Update the kept options too, so a later reset re-applies this new URL
-      // rather than the creation-time one. This lives only in memory, so a full
-      // simulator restart still returns to the original options.
-      if (this.options != null) {
-        this.options.supervisionUrls = url
+      // Mirror the update into the retained creation options so a later reset()
+      // re-applies this URL, not the creation-time one. This must run for BOTH
+      // branches above, OCPP-config mode included: a non-persistent station does
+      // not save its supervisionUrlOcppKey, so on reset the key is re-seeded from
+      // configuredSupervisionUrl, itself derived from stationInfo.supervisionUrls,
+      // which setChargingStationOptions() force-writes from these options. Mirroring
+      // only in the non-OCPP branch would drop the new URL for non-persistent
+      // OCPP-config stations. In-memory only: a full restart returns to the
+      // original options.
+      if (this.creationOptions != null) {
+        this.creationOptions.supervisionUrls = url
         if (supervisionUser != null) {
-          this.options.supervisionUser = supervisionUser
+          this.creationOptions.supervisionUser = supervisionUser
         }
         if (supervisionPassword != null) {
-          this.options.supervisionPassword = supervisionPassword
+          this.creationOptions.supervisionPassword = supervisionPassword
         }
       }
       this.saveStationInfo()
@@ -1165,7 +1185,7 @@ export class ChargingStation extends EventEmitter {
                     this.idTagsCache.deleteIdTags(idTagsFile)
                   }
                   OCPPAuthServiceFactory.clearInstance(this)
-                  this.initialize(this.options)
+                  this.initialize(this.reinitializeOptions)
                   // Restart the ATG
                   const ATGStarted = this.automaticTransactionGenerator?.started
                   if (ATGStarted === true) {

--- a/tests/charging-station/ChargingStation-ResetIdentity.test.ts
+++ b/tests/charging-station/ChargingStation-ResetIdentity.test.ts
@@ -193,11 +193,10 @@ await describe('ChargingStation keeps its identity across a reset', async () => 
     assert.strictEqual(station.stationInfo?.supervisionUrls, 'ws://localhost:8888/')
   })
 
-  await it('should keep an OCPP-config supervision URL across a reset (non-persistent)', async t => {
+  await it('should keep an OCPP-config supervision URL across a warm-cache reset (non-persistent)', async t => {
     // supervisionUrlOcppConfiguration routes the URL through an OCPP config key
     // rather than stationInfo.supervisionUrls, and must be a template field to
-    // survive the reset rebuild. This is the branch the setSupervisionUrl mirror
-    // comment reasons about, and the only retention path otherwise untested.
+    // survive the reset rebuild.
     const station = new ChargingStation(
       1,
       makeTemplate({
@@ -218,7 +217,31 @@ await describe('ChargingStation keeps its identity across a reset', async () => 
 
     await station.reset()
 
-    // The OCPP key is re-seeded from the retained URL, so the station dials it.
+    // A plain reset() reuses the warm template cache, whose in-place OCPP-key
+    // mutation still carries the URL; the retained-options mirror is not exercised
+    // on this path (see the cache-cold reload test below).
+    assert.strictEqual(station.wsConnectionUrl.host, 'localhost:7777')
+  })
+
+  await it('should re-seed an OCPP-config supervision URL from the retained options on template reload (non-persistent)', () => {
+    const station = new ChargingStation(
+      1,
+      makeTemplate({
+        supervisionUrlOcppConfiguration: true,
+        supervisionUrlOcppKey: 'ConnectionUrl',
+      }),
+      { autoStart: false, persistentConfiguration: false, supervisionUrls: 'ws://localhost:9999/' }
+    )
+    station.setSupervisionUrl('ws://localhost:7777/')
+
+    // Invalidate the cached template exactly as the template-reload path does (the
+    // watcher calls deleteChargingStationTemplate before initialize), forcing the
+    // OCPP key absent on reinitialization so it is re-seeded from configuredSupervisionUrl.
+    // This is the only path where the retained-options mirror is load-bearing: a
+    // warm-cache reset passes via the cached mutation and would not guard it.
+    SharedLRUCache.getInstance().clear()
+    internalsOf(station).initialize(internalsOf(station).creationOptions)
+
     assert.strictEqual(station.wsConnectionUrl.host, 'localhost:7777')
   })
 })

--- a/tests/charging-station/ChargingStation-ResetIdentity.test.ts
+++ b/tests/charging-station/ChargingStation-ResetIdentity.test.ts
@@ -13,6 +13,7 @@ import {
   readdirSync,
   readFileSync,
   rmSync,
+  writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -22,6 +23,7 @@ import { setTimeout as sleep } from 'node:timers/promises'
 import type { ChargingStationOptions } from '../../src/types/index.js'
 
 import { ChargingStation } from '../../src/charging-station/ChargingStation.js'
+import { SharedLRUCache } from '../../src/charging-station/SharedLRUCache.js'
 import { standardCleanup } from '../helpers/TestLifecycleHelpers.js'
 
 // The identity logic lives in initialize(); the identity tests call it directly
@@ -40,16 +42,24 @@ const identityOf = (station: ChargingStation): string | undefined =>
 const tmpRoots: string[] = []
 
 // Fresh template under its own temp station-templates dir, so each test's
-// persisted config lands in an isolated sibling configurations dir.
-const makeTemplate = (): string => {
+// persisted config lands in an isolated sibling configurations dir. Optional
+// overrides are merged into the template's top-level fields (e.g. to enable the
+// OCPP-config supervision URL mechanism).
+const makeTemplate = (overrides?: Record<string, boolean | number | string>): string => {
   const root = mkdtempSync(join(tmpdir(), 'cs-reset-identity-'))
   tmpRoots.push(root)
   mkdirSync(join(root, 'station-templates'), { recursive: true })
   const file = join(root, 'station-templates', 'virtual-simple.station-template.json')
-  copyFileSync(
-    join(process.cwd(), 'src/assets/station-templates/virtual-simple.station-template.json'),
-    file
+  const source = join(
+    process.cwd(),
+    'src/assets/station-templates/virtual-simple.station-template.json'
   )
+  if (overrides == null) {
+    copyFileSync(source, file)
+  } else {
+    const template = JSON.parse(readFileSync(source, 'utf8')) as Record<string, unknown>
+    writeFileSync(file, JSON.stringify({ ...template, ...overrides }, null, 2))
+  }
   return file
 }
 
@@ -80,12 +90,16 @@ const waitForPersistedId = async (
 await describe('ChargingStation keeps its identity across a reset', async () => {
   afterEach(() => {
     standardCleanup()
+    // The real ChargingStation uses the real SharedLRUCache singleton (not the
+    // mock standardCleanup resets); clear it so a cached template cannot bleed
+    // between tests.
+    SharedLRUCache.getInstance().clear()
     for (const root of tmpRoots.splice(0)) {
       rmSync(root, { force: true, recursive: true })
     }
   })
 
-  await it('non-persistent: identity is kept only when the creation options are re-applied', () => {
+  await it('should keep identity only when the creation options are re-applied (non-persistent)', () => {
     const options: ChargingStationOptions = {
       autoStart: false,
       baseName: 'TEST-RESET-ID',
@@ -106,7 +120,7 @@ await describe('ChargingStation keeps its identity across a reset', async () => 
     assert.strictEqual(identityOf(station), 'TEST-RESET-ID')
   })
 
-  await it('persistent: identity is kept without re-applying the creation options', async () => {
+  await it('should keep identity without re-applying the creation options (persistent)', async () => {
     const templateFile = makeTemplate()
     const station = new ChargingStation(1, templateFile, {
       autoStart: false,
@@ -132,7 +146,7 @@ await describe('ChargingStation keeps its identity across a reset', async () => 
   // reset() passes nothing. stop/start are stubbed so reset() neither tears down
   // nor dials a socket, and the reset delay is zeroed.
   for (const persistentConfiguration of [false, true]) {
-    await it(`reset re-applies the creation options to initialize() only when non-persistent (persistent=${persistentConfiguration.toString()})`, async t => {
+    await it(`should re-apply the creation options to initialize() only when non-persistent (persistent=${persistentConfiguration.toString()})`, async t => {
       const station = new ChargingStation(1, makeTemplate(), {
         autoStart: false,
         baseName: 'TEST-RESET-WIRING',
@@ -161,7 +175,7 @@ await describe('ChargingStation keeps its identity across a reset', async () => 
     })
   }
 
-  await it('setSupervisionUrl keeps the new URL across a reset via the retained options', () => {
+  await it('should keep the setSupervisionUrl URL across a reset via the retained options', () => {
     const station = new ChargingStation(1, makeTemplate(), {
       autoStart: false,
       persistentConfiguration: false,
@@ -177,5 +191,34 @@ await describe('ChargingStation keeps its identity across a reset', async () => 
     // ...so re-applying them on reset keeps it instead of the creation-time URL.
     internalsOf(station).initialize(internalsOf(station).creationOptions)
     assert.strictEqual(station.stationInfo?.supervisionUrls, 'ws://localhost:8888/')
+  })
+
+  await it('should keep an OCPP-config supervision URL across a reset (non-persistent)', async t => {
+    // supervisionUrlOcppConfiguration routes the URL through an OCPP config key
+    // rather than stationInfo.supervisionUrls, and must be a template field to
+    // survive the reset rebuild. This is the branch the setSupervisionUrl mirror
+    // comment reasons about, and the only retention path otherwise untested.
+    const station = new ChargingStation(
+      1,
+      makeTemplate({
+        supervisionUrlOcppConfiguration: true,
+        supervisionUrlOcppKey: 'ConnectionUrl',
+      }),
+      { autoStart: false, persistentConfiguration: false, supervisionUrls: 'ws://localhost:9999/' }
+    )
+    station.setSupervisionUrl('ws://localhost:7777/')
+    if (station.stationInfo != null) {
+      station.stationInfo.resetTime = 0
+    }
+    // Stub stop/start so the real reset() re-initializes without tearing down or
+    // dialing a socket.
+    const internals = station as unknown as { start: () => void; stop: () => Promise<void> }
+    t.mock.method(internals, 'stop', () => Promise.resolve())
+    t.mock.method(internals, 'start', () => undefined)
+
+    await station.reset()
+
+    // The OCPP key is re-seeded from the retained URL, so the station dials it.
+    assert.strictEqual(station.wsConnectionUrl.host, 'localhost:7777')
   })
 })

--- a/tests/charging-station/ChargingStation-ResetIdentity.test.ts
+++ b/tests/charging-station/ChargingStation-ResetIdentity.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @file Tests that a charging station keeps its configured identity across a reset.
+ * @description A reset re-initializes the station. A station with a persisted
+ * configuration restores its identity from the saved config file; a
+ * non-persistent one only keeps it when the creation options are re-applied.
+ */
+import assert from 'node:assert/strict'
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, it } from 'node:test'
+import { setTimeout as sleep } from 'node:timers/promises'
+
+import type { ChargingStationOptions } from '../../src/types/index.js'
+
+import { ChargingStation } from '../../src/charging-station/ChargingStation.js'
+import { standardCleanup } from '../helpers/TestLifecycleHelpers.js'
+
+// A reset re-runs initialize(); the identity logic lives there, so the tests
+// call initialize() directly instead of going through reset()'s stop/sleep/start.
+interface StationInternals {
+  initialize: (options?: ChargingStationOptions) => void
+  options?: ChargingStationOptions
+}
+const internalsOf = (station: ChargingStation): StationInternals =>
+  station as unknown as StationInternals
+
+const identityOf = (station: ChargingStation): string | undefined =>
+  station.stationInfo?.chargingStationId
+
+const tmpRoots: string[] = []
+
+// Fresh template under its own temp station-templates dir, so each test's
+// persisted config lands in an isolated sibling configurations dir.
+const makeTemplate = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'cs-reset-identity-'))
+  tmpRoots.push(root)
+  mkdirSync(join(root, 'station-templates'), { recursive: true })
+  const file = join(root, 'station-templates', 'virtual-simple.station-template.json')
+  copyFileSync(
+    join(process.cwd(), 'src/assets/station-templates/virtual-simple.station-template.json'),
+    file
+  )
+  return file
+}
+
+// Config writes are asynchronous, so wait until the identity has been persisted.
+// The configurations dir sits beside the station-templates dir (same derivation
+// the station uses to place its config file).
+const waitForPersistedId = async (
+  templateFile: string,
+  chargingStationId: string
+): Promise<boolean> => {
+  const configurationsDir = dirname(templateFile.replace('station-templates', 'configurations'))
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (existsSync(configurationsDir)) {
+      for (const file of readdirSync(configurationsDir)) {
+        const { stationInfo } = JSON.parse(readFileSync(join(configurationsDir, file), 'utf8')) as {
+          stationInfo?: { chargingStationId?: string }
+        }
+        if (stationInfo?.chargingStationId === chargingStationId) {
+          return true
+        }
+      }
+    }
+    await sleep(20)
+  }
+  return false
+}
+
+await describe('ChargingStation keeps its identity across a reset', async () => {
+  afterEach(() => {
+    standardCleanup()
+    for (const root of tmpRoots.splice(0)) {
+      rmSync(root, { force: true, recursive: true })
+    }
+  })
+
+  await it('non-persistent: identity is kept only when the creation options are re-applied', () => {
+    const options: ChargingStationOptions = {
+      autoStart: false,
+      baseName: 'TEST-RESET-ID',
+      fixedName: true,
+      persistentConfiguration: false,
+      supervisionUrls: 'ws://localhost:9999/',
+    }
+    const station = new ChargingStation(1, makeTemplate(), options)
+    assert.strictEqual(identityOf(station), 'TEST-RESET-ID')
+
+    // With no options and no saved config to fall back to, the station reverts
+    // to the template's default identity.
+    internalsOf(station).initialize()
+    assert.notStrictEqual(identityOf(station), 'TEST-RESET-ID')
+
+    // Re-applying the retained creation options restores the configured identity.
+    internalsOf(station).initialize(internalsOf(station).options)
+    assert.strictEqual(identityOf(station), 'TEST-RESET-ID')
+  })
+
+  await it('persistent: identity is kept without re-applying the creation options', async () => {
+    const templateFile = makeTemplate()
+    const station = new ChargingStation(1, templateFile, {
+      autoStart: false,
+      baseName: 'TEST-PERSIST-ID',
+      fixedName: true,
+      persistentConfiguration: true,
+      supervisionUrls: 'ws://localhost:9999/',
+    })
+    assert.strictEqual(identityOf(station), 'TEST-PERSIST-ID')
+    assert.ok(
+      await waitForPersistedId(templateFile, 'TEST-PERSIST-ID'),
+      'identity was not persisted'
+    )
+
+    // The saved configuration restores the identity on its own, so only a
+    // non-persistent station needs the retained options.
+    internalsOf(station).initialize()
+    assert.strictEqual(identityOf(station), 'TEST-PERSIST-ID')
+  })
+})

--- a/tests/charging-station/ChargingStation-ResetIdentity.test.ts
+++ b/tests/charging-station/ChargingStation-ResetIdentity.test.ts
@@ -24,11 +24,12 @@ import type { ChargingStationOptions } from '../../src/types/index.js'
 import { ChargingStation } from '../../src/charging-station/ChargingStation.js'
 import { standardCleanup } from '../helpers/TestLifecycleHelpers.js'
 
-// A reset re-runs initialize(); the identity logic lives there, so the tests
-// call initialize() directly instead of going through reset()'s stop/sleep/start.
+// The identity logic lives in initialize(); the identity tests call it directly
+// to avoid reset()'s stop/sleep/start (which would dial a socket). A separate
+// test drives reset() with those stubbed to guard the reset -> initialize wiring.
 interface StationInternals {
+  creationOptions?: ChargingStationOptions
   initialize: (options?: ChargingStationOptions) => void
-  options?: ChargingStationOptions
 }
 const internalsOf = (station: ChargingStation): StationInternals =>
   station as unknown as StationInternals
@@ -101,7 +102,7 @@ await describe('ChargingStation keeps its identity across a reset', async () => 
     assert.notStrictEqual(identityOf(station), 'TEST-RESET-ID')
 
     // Re-applying the retained creation options restores the configured identity.
-    internalsOf(station).initialize(internalsOf(station).options)
+    internalsOf(station).initialize(internalsOf(station).creationOptions)
     assert.strictEqual(identityOf(station), 'TEST-RESET-ID')
   })
 
@@ -124,5 +125,57 @@ await describe('ChargingStation keeps its identity across a reset', async () => 
     // non-persistent station needs the retained options.
     internalsOf(station).initialize()
     assert.strictEqual(identityOf(station), 'TEST-PERSIST-ID')
+  })
+
+  // reset() forwards the creation options to initialize() only for a
+  // non-persistent station; a persistent one restores from its saved config, so
+  // reset() passes nothing. stop/start are stubbed so reset() neither tears down
+  // nor dials a socket, and the reset delay is zeroed.
+  for (const persistentConfiguration of [false, true]) {
+    await it(`reset re-applies the creation options to initialize() only when non-persistent (persistent=${persistentConfiguration.toString()})`, async t => {
+      const station = new ChargingStation(1, makeTemplate(), {
+        autoStart: false,
+        baseName: 'TEST-RESET-WIRING',
+        fixedName: true,
+        persistentConfiguration,
+        supervisionUrls: 'ws://localhost:9999/',
+      })
+      if (station.stationInfo != null) {
+        station.stationInfo.resetTime = 0
+      }
+      const internals = station as unknown as StationInternals & {
+        start: () => void
+        stop: () => Promise<void>
+      }
+      t.mock.method(internals, 'stop', () => Promise.resolve())
+      t.mock.method(internals, 'start', () => undefined)
+      const initializeSpy = t.mock.method(internals, 'initialize', () => undefined)
+
+      await station.reset()
+
+      assert.strictEqual(initializeSpy.mock.calls.length, 1)
+      assert.strictEqual(
+        initializeSpy.mock.calls[0].arguments[0],
+        persistentConfiguration ? undefined : internals.creationOptions
+      )
+    })
+  }
+
+  await it('setSupervisionUrl keeps the new URL across a reset via the retained options', () => {
+    const station = new ChargingStation(1, makeTemplate(), {
+      autoStart: false,
+      persistentConfiguration: false,
+      supervisionUrls: 'ws://localhost:9999/',
+    })
+    station.setSupervisionUrl('ws://localhost:8888/')
+
+    // The runtime URL is mirrored into the retained options...
+    assert.strictEqual(
+      internalsOf(station).creationOptions?.supervisionUrls,
+      'ws://localhost:8888/'
+    )
+    // ...so re-applying them on reset keeps it instead of the creation-time URL.
+    internalsOf(station).initialize(internalsOf(station).creationOptions)
+    assert.strictEqual(station.stationInfo?.supervisionUrls, 'ws://localhost:8888/')
   })
 })


### PR DESCRIPTION
On an OCPP Reset (and on a template-file reload) the station was re-initialized via initialize() with no arguments, dropping the creation-time options. The restarted station reverted to the template defaults, losing its fixed identity (reappearing as CS-BASIC-000N with a new hashId) and its configured supervision URL; the original station never came back.

Retain the creation options on the instance and, on reset() and template-watcher reload, re-apply them only for a non-persistent station — a persistent one restores its identity and supervision URL from its saved configuration file, which stays the source of truth. setSupervisionUrl() also mirrors a runtime supervision-URL change into the retained creation options so it survives a reset (but not a full simulator restart, which reconstructs the worker from the original options). The retained creation options are in-memory only: never persisted, never written to the template.

Closes #2017.

<!--
  Thanks for contributing to EVSE simulator project.
  Please be sure to read our [contributing guidelines](https://github.com/sap/e-mobility-charging-stations-simulator/blob/master/CONTRIBUTING.md).
-->

## PR Checklist

- [ ] Please add a description of your changes.
- [ ] Please ensure title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] We need your changes to come with unit tests in order to keep this project in quality and easy to maintain.
- [ ] If your changes contain any new feature please be sure to document it.
- [ ] Please add a link to the open issue or task that this pull request will resolve.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

If yes please indicate it in the title and add migration info into the documentation.

---

<!-- Your PR text -->

