### PR TITLE
fix(charging-station): cancel a pending reset when the station is deleted (#2027 part A)

### DIFF
--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -96,6 +96,7 @@ import {
   getMessageTypeString,
   getWebSocketCloseEventStatusString,
   handleFileException,
+  interruptibleSleep,
   isEmpty,
   isNotEmptyArray,
   isNotEmptyString,
@@ -214,6 +215,10 @@ export class ChargingStation extends EventEmitter {
   private readonly connectors: Map<number, ConnectorStatus>
   private connectorsConfigurationHash: string
   private readonly creationOptions?: ChargingStationOptions
+  // Tripped by delete() to cancel a pending reset(). Kept distinct from
+  // started/stopping (which reset() itself toggles through stop()) so a station
+  // deleted during the reset window is not resurrected and reconnected.
+  private readonly deleteAbortController: AbortController
   private readonly evses: Map<number, EvseStatus>
   private evsesConfigurationHash: string
   private flushingMessageBuffer: boolean
@@ -247,6 +252,7 @@ export class ChargingStation extends EventEmitter {
     this.started = false
     this.starting = false
     this.stopping = false
+    this.deleteAbortController = new AbortController()
     this.wsConnection = null
     this.wsConnectionClosedByRequest = false
     this.wsConnectionRetryCount = 0
@@ -422,6 +428,9 @@ export class ChargingStation extends EventEmitter {
    * @param deleteConfiguration - Whether to delete the persisted configuration file
    */
   public async delete (deleteConfiguration = true): Promise<void> {
+    // Cancel any pending reset() so a station deleted during its reset window is
+    // not re-initialized and reconnected to the CSMS.
+    this.deleteAbortController.abort()
     if (this.started) {
       try {
         await this.stop()
@@ -1091,7 +1100,12 @@ export class ChargingStation extends EventEmitter {
       logger.error(`${this.logPrefix()} ${moduleName}.reset: Error during reset stop phase:`, e)
       return
     }
-    await sleep(this.stationInfo?.resetTime ?? 0)
+    await interruptibleSleep(this.stationInfo?.resetTime ?? 0, this.deleteAbortController.signal)
+    // A delete() during the reset window aborts the sleep above; bail out before
+    // re-initializing so a deleted station is not re-initialized or reconnected.
+    if (this.deleteAbortController.signal.aborted) {
+      return
+    }
     OCPPAuthServiceFactory.clearInstance(this)
     this.initialize(this.reinitializationOptions)
     this.start()

--- a/tests/charging-station/ChargingStation-ResetCancellation.test.ts
+++ b/tests/charging-station/ChargingStation-ResetCancellation.test.ts
@@ -1,0 +1,170 @@
+/**
+ * @file Tests that delete() cancels a pending reset() (issue #2027 part A).
+ * @description reset() stops the station, waits resetTime, then re-initializes
+ * and reconnects. A delete() during that window must abort the pending
+ * re-initialize so the deleted station is not resurrected and reconnected to the
+ * CSMS (the "zombie" reconnect that triggers issue #2017).
+ */
+import assert from 'node:assert/strict'
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, it } from 'node:test'
+
+import type { ChargingStationOptions } from '../../src/types/index.js'
+
+import { ChargingStation } from '../../src/charging-station/ChargingStation.js'
+import {
+  flushMicrotasks,
+  standardCleanup,
+  withMockTimers,
+} from '../helpers/TestLifecycleHelpers.js'
+
+const RESET_TIME_MS = 60000
+
+const tmpRoots: string[] = []
+
+// Fresh template under its own temp station-templates dir so each test is
+// isolated, mirroring the ChargingStation-ResetIdentity harness.
+const makeTemplate = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'cs-reset-cancel-'))
+  tmpRoots.push(root)
+  mkdirSync(join(root, 'station-templates'), { recursive: true })
+  const file = join(root, 'station-templates', 'virtual-simple.station-template.json')
+  copyFileSync(
+    join(process.cwd(), 'src/assets/station-templates/virtual-simple.station-template.json'),
+    file
+  )
+  return file
+}
+
+interface ResetInternals {
+  initialize: (options?: ChargingStationOptions) => void
+  start: () => void
+  stop: () => Promise<void>
+}
+
+const newStation = (resetTimeMs = RESET_TIME_MS): ChargingStation => {
+  const station = new ChargingStation(1, makeTemplate(), {
+    autoStart: false,
+    baseName: 'TEST-RESET-CANCEL',
+    fixedName: true,
+    persistentConfiguration: false,
+    supervisionUrls: 'ws://localhost:9999/',
+  })
+  if (station.stationInfo != null) {
+    station.stationInfo.resetTime = resetTimeMs
+  }
+  return station
+}
+
+await describe('ChargingStation cancellable reset', async () => {
+  afterEach(() => {
+    standardCleanup()
+    for (const root of tmpRoots.splice(0)) {
+      rmSync(root, { force: true, recursive: true })
+    }
+  })
+
+  await it('should not re-initialize or reconnect when deleted during the reset sleep window', async t => {
+    await withMockTimers(t, ['setTimeout'], async () => {
+      const station = newStation()
+      // Stub stop/start/initialize so the real reset() neither tears down nor
+      // dials a socket; the spies observe whether a deleted station is resurrected.
+      const internals = station as unknown as ResetInternals
+      t.mock.method(internals, 'stop', () => Promise.resolve())
+      const initializeSpy = t.mock.method(internals, 'initialize', () => undefined)
+      const startSpy = t.mock.method(internals, 'start', () => undefined)
+
+      // Fire-and-forget reset() (matching the OCPP Reset handler) and let it
+      // reach the interruptible sleep.
+      const resetPromise = station.reset()
+      await flushMicrotasks()
+
+      // Delete mid-reset; this must abort the pending re-initialize.
+      await station.delete(false)
+
+      // Elapse the full reset delay to prove even a completed timer cannot
+      // resurrect a deleted station.
+      t.mock.timers.tick(RESET_TIME_MS)
+      await resetPromise
+
+      assert.strictEqual(initializeSpy.mock.calls.length, 0)
+      assert.strictEqual(startSpy.mock.calls.length, 0)
+    })
+  })
+
+  await it('should not re-initialize when deleted after the reset sleep resolves but before re-initialization', async t => {
+    await withMockTimers(t, ['setTimeout'], async () => {
+      const station = newStation()
+      const internals = station as unknown as ResetInternals
+      t.mock.method(internals, 'stop', () => Promise.resolve())
+      const initializeSpy = t.mock.method(internals, 'initialize', () => undefined)
+      const startSpy = t.mock.method(internals, 'start', () => undefined)
+
+      const resetPromise = station.reset()
+      await flushMicrotasks()
+
+      // Fire the timer first: the sleep resolves normally and queues reset's
+      // continuation as a microtask. Deleting before that microtask runs (abort
+      // is synchronous) must still be observed by the post-sleep recheck.
+      t.mock.timers.tick(RESET_TIME_MS)
+      const deletePromise = station.delete(false)
+      await deletePromise
+      await resetPromise
+
+      assert.strictEqual(initializeSpy.mock.calls.length, 0)
+      assert.strictEqual(startSpy.mock.calls.length, 0)
+    })
+  })
+
+  await it('should not re-initialize when deleted during a zero reset time window', async t => {
+    await withMockTimers(t, ['setTimeout'], async () => {
+      const station = newStation(0)
+      const internals = station as unknown as ResetInternals
+      t.mock.method(internals, 'stop', () => Promise.resolve())
+      const initializeSpy = t.mock.method(internals, 'initialize', () => undefined)
+      const startSpy = t.mock.method(internals, 'start', () => undefined)
+
+      const resetPromise = station.reset()
+      await flushMicrotasks()
+
+      await station.delete(false)
+
+      t.mock.timers.tick(0)
+      await resetPromise
+
+      assert.strictEqual(initializeSpy.mock.calls.length, 0)
+      assert.strictEqual(startSpy.mock.calls.length, 0)
+    })
+  })
+
+  await it('should re-initialize and start on each consecutive normal reset when not deleted', async t => {
+    await withMockTimers(t, ['setTimeout'], async () => {
+      const station = newStation()
+      const internals = station as unknown as ResetInternals
+      t.mock.method(internals, 'stop', () => Promise.resolve())
+      const initializeSpy = t.mock.method(internals, 'initialize', () => undefined)
+      const startSpy = t.mock.method(internals, 'start', () => undefined)
+
+      // Positive control: a normal reset (no delete) must re-initialize and
+      // start, so the abort guard cannot fire spuriously. A second reset must
+      // re-initialize too, proving reset() never consumes the shared signal.
+      const firstReset = station.reset()
+      await flushMicrotasks()
+      t.mock.timers.tick(RESET_TIME_MS)
+      await firstReset
+
+      assert.strictEqual(initializeSpy.mock.calls.length, 1)
+      assert.strictEqual(startSpy.mock.calls.length, 1)
+
+      const secondReset = station.reset()
+      await flushMicrotasks()
+      t.mock.timers.tick(RESET_TIME_MS)
+      await secondReset
+
+      assert.strictEqual(initializeSpy.mock.calls.length, 2)
+      assert.strictEqual(startSpy.mock.calls.length, 2)
+    })
+  })
+})


### PR DESCRIPTION
## PR Checklist

- [x] Please add a description of your changes.
- [x] Please ensure title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] We need your changes to come with unit tests in order to keep this project in quality and easy to maintain.
- [x] If your changes contain any new feature please be sure to document it. (N/A — bug fix, no new tunable or user-facing option)
- [x] Please add a link to the open issue or task that this pull request will resolve.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

---

### What

Make `ChargingStation.reset()` cancellable so that deleting a station during the post-`stop()` reset window aborts the pending re-initialize/re-start, instead of resurrecting the station and reconnecting it to the CSMS.

### Why

`reset()` ran `stop()` → `sleep(resetTime)` → `initialize()` → `start()` with no check for deletion during the sleep, and `delete()` never cancelled a pending reset. A station deleted mid-reset came back as a "zombie" reconnect — the dominant trigger of #2017.

### How

- Add `deleteAbortController` on the instance, aborted by `delete()`.
- `reset()` awaits `interruptibleSleep(resetTime, signal)` (the existing primitive already used by the ATG and OCPP 2.0 firmware paths) and rechecks `signal.aborted` before `initialize()`/`start()`, bailing out cleanly on abort with no unhandled rejection in the fire-and-forget path.
- The abort signal is deliberately distinct from `started`/`stopping`: `reset()` calls `stop()` first, so those flags are already `false` during the sleep and cannot detect deletion.

The OCPP Reset response stays `Accepted`; the incoming-request handler still calls `reset()` fire-and-forget. No PDU or protocol change.

### Tests

New `ChargingStation-ResetCancellation.test.ts` with deterministic `t.mock.timers` tests reproducing #2017:

- **Ordering races (negative):** delete during the sleep; delete after the timer fires but before re-init; `resetTime === 0`.
- **Positive control:** a normal reset (no delete) re-initializes and starts, and two consecutive normal resets both re-initialize — proving the abort guard never fires spuriously and `reset()` never consumes the shared signal.

Mutation-verified in both directions: reverting the guard makes the negative tests fail (zombie resurrection observed); forcing `reset()` to always bail makes only the positive control fail. Full suite green.

### Scope

Part A only. **Part B** — element-granular worker-thread termination (a `removeElement` primitive on `WorkerAbstract` across `WorkerSet` and both pools, with pool-eviction semantics) — remains open and is tracked as a deferred follow-up under #2027.

Closes the reset-resurrection (Part A) portion of #2027.