### PR TITLE
fix(ui-server): dedup duplicate station identity on add (#2026)

### DIFF
--- a/src/charging-station/Bootstrap.ts
+++ b/src/charging-station/Bootstrap.ts
@@ -730,7 +730,7 @@ export class Bootstrap extends EventEmitter implements IBootstrap {
         `${this.logPrefix()} ${moduleName}.workerEventAdded: Rejected charging station ${
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           data.stationInfo.chargingStationId
-        } (hashId: ${data.stationInfo.hashId}, templateIndex: ${data.stationInfo.templateIndex.toString()}): a different station identity already maps to this hashId; the added station is orphaned from the UI registry`
+        } (hashId: ${data.stationInfo.hashId}, templateName: ${data.stationInfo.templateName}, templateIndex: ${data.stationInfo.templateIndex.toString()}): a different station identity already maps to this hashId; the added station is orphaned from the UI registry`
       )
       return
     }

--- a/src/charging-station/Bootstrap.ts
+++ b/src/charging-station/Bootstrap.ts
@@ -724,7 +724,17 @@ export class Bootstrap extends EventEmitter implements IBootstrap {
   }
 
   private readonly workerEventAdded = (data: ChargingStationData): void => {
-    if (this.uiServer.setChargingStationData(data.stationInfo.hashId, data)) {
+    const outcome = this.uiServer.setChargingStationData(data.stationInfo.hashId, data)
+    if (outcome === 'collision') {
+      logger.error(
+        `${this.logPrefix()} ${moduleName}.workerEventAdded: Rejected charging station ${
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+          data.stationInfo.chargingStationId
+        } (hashId: ${data.stationInfo.hashId}, templateIndex: ${data.stationInfo.templateIndex.toString()}): a different station identity already maps to this hashId; the added station is orphaned from the UI registry`
+      )
+      return
+    }
+    if (outcome === 'set') {
       this.uiServer.scheduleClientNotification()
     }
     logger.info(
@@ -773,7 +783,7 @@ export class Bootstrap extends EventEmitter implements IBootstrap {
   }
 
   private readonly workerEventStarted = (data: ChargingStationData): void => {
-    if (this.uiServer.setChargingStationData(data.stationInfo.hashId, data)) {
+    if (this.uiServer.setChargingStationData(data.stationInfo.hashId, data) === 'set') {
       this.uiServer.scheduleClientNotification()
     }
     const templateStatistics = this.templateStatistics.get(data.stationInfo.templateName)
@@ -789,7 +799,7 @@ export class Bootstrap extends EventEmitter implements IBootstrap {
   }
 
   private readonly workerEventStopped = (data: ChargingStationData): void => {
-    if (this.uiServer.setChargingStationData(data.stationInfo.hashId, data)) {
+    if (this.uiServer.setChargingStationData(data.stationInfo.hashId, data) === 'set') {
       this.uiServer.scheduleClientNotification()
     }
     const templateStatistics = this.templateStatistics.get(data.stationInfo.templateName)
@@ -805,7 +815,7 @@ export class Bootstrap extends EventEmitter implements IBootstrap {
   }
 
   private readonly workerEventUpdated = (data: ChargingStationData): void => {
-    if (this.uiServer.setChargingStationData(data.stationInfo.hashId, data)) {
+    if (this.uiServer.setChargingStationData(data.stationInfo.hashId, data) === 'set') {
       this.uiServer.scheduleClientNotification()
     }
   }

--- a/src/charging-station/ui-server/AbstractUIServer.ts
+++ b/src/charging-station/ui-server/AbstractUIServer.ts
@@ -52,6 +52,17 @@ import {
 import { getUsernameAndPasswordFromAuthorizationToken, HttpMethod } from './UIServerUtils.js'
 
 /**
+ * Outcome of {@link AbstractUIServer.setChargingStationData}:
+ * - `set`: stored (new `hashId`, or a newer/equal-timestamp update of the same
+ *   physical station, including a legitimate restart re-emit).
+ * - `stale`: an older-timestamp update of the same physical station; dropped.
+ * - `collision`: a distinct physical station (different `templateIndex`) already
+ *   maps to this deterministic `hashId`; rejected without overwriting so neither
+ *   twin is silently shadowed or orphaned.
+ */
+export type SetChargingStationDataOutcome = 'collision' | 'set' | 'stale'
+
+/**
  * Outcome of {@link AbstractUIServer.runRequestPrologue}.
  *
  * Discriminated by `ok`. On `ok: true` the caller proceeds to authentication
@@ -333,13 +344,22 @@ export abstract class AbstractUIServer {
    */
   public abstract sendResponse (response: ProtocolResponse): void
 
-  public setChargingStationData (hashId: string, data: ChargingStationData): boolean {
+  public setChargingStationData (
+    hashId: string,
+    data: ChargingStationData
+  ): SetChargingStationDataOutcome {
     const cachedData = this.chargingStations.get(hashId)
+    if (
+      cachedData != null &&
+      cachedData.stationInfo.templateIndex !== data.stationInfo.templateIndex
+    ) {
+      return 'collision'
+    }
     if (cachedData == null || data.timestamp >= cachedData.timestamp) {
       this.chargingStations.set(hashId, data)
-      return true
+      return 'set'
     }
-    return false
+    return 'stale'
   }
 
   public setChargingStationTemplates (templates: string[] | undefined): void {

--- a/src/charging-station/ui-server/AbstractUIServer.ts
+++ b/src/charging-station/ui-server/AbstractUIServer.ts
@@ -54,11 +54,13 @@ import { getUsernameAndPasswordFromAuthorizationToken, HttpMethod } from './UISe
 /**
  * Outcome of {@link AbstractUIServer.setChargingStationData}:
  * - `set`: stored (new `hashId`, or a newer/equal-timestamp update of the same
- *   physical station, including a legitimate restart re-emit).
- * - `stale`: an older-timestamp update of the same physical station; dropped.
- * - `collision`: a distinct physical station (different `templateIndex`) already
- *   maps to this deterministic `hashId`; rejected without overwriting so neither
- *   twin is silently shadowed or orphaned.
+ *   physical station identity, including a legitimate restart re-emit).
+ * - `stale`: an older-timestamp update of the same physical station identity;
+ *   dropped.
+ * - `collision`: a different physical station identity — a distinct
+ *   `(templateName, templateIndex)` pair — already maps to this deterministic
+ *   `hashId`; rejected without overwriting so the registered station is not
+ *   silently shadowed (the caller surfaces the rejected twin).
  */
 export type SetChargingStationDataOutcome = 'collision' | 'set' | 'stale'
 
@@ -351,7 +353,8 @@ export abstract class AbstractUIServer {
     const cachedData = this.chargingStations.get(hashId)
     if (
       cachedData != null &&
-      cachedData.stationInfo.templateIndex !== data.stationInfo.templateIndex
+      (cachedData.stationInfo.templateName !== data.stationInfo.templateName ||
+        cachedData.stationInfo.templateIndex !== data.stationInfo.templateIndex)
     ) {
       return 'collision'
     }

--- a/tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts
+++ b/tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts
@@ -103,12 +103,14 @@ const emitWorkerResponse = (
  * @param hashId - Deterministic content hash shared by colliding twins.
  * @param templateIndex - Stable per-instance discriminator within a template.
  * @param timestamp - Registry merge timestamp in milliseconds.
+ * @param templateName - Owning template name; differs for identity-clone template files.
  * @returns Charging station data for the described identity.
  */
 const createStationDataWithIndex = (
   hashId: string,
   templateIndex: number,
-  timestamp: number
+  timestamp: number,
+  templateName = 'collision-template'
 ): ChargingStationData =>
   createMockChargingStationData(hashId, {
     stationInfo: {
@@ -118,7 +120,7 @@ const createStationDataWithIndex = (
       chargingStationId: hashId,
       hashId,
       templateIndex,
-      templateName: 'collision-template',
+      templateName,
     },
     timestamp,
   })
@@ -1003,6 +1005,30 @@ await describe('AbstractUIService', async () => {
         'collision'
       )
       assert.strictEqual(server.getChargingStationData(hashId)?.stationInfo.templateIndex, 1)
+      assert.strictEqual(server.getChargingStationsCount(), 1)
+    })
+
+    await it('should reject an identity-clone twin sharing hashId and templateIndex but a different templateName', () => {
+      const server = new TestableUIWebSocketServer(createMockUIServerConfiguration())
+      const hashId = 'clone-file-hash'
+      assert.strictEqual(
+        server.setChargingStationData(
+          hashId,
+          createStationDataWithIndex(hashId, 1, 1000, 'template-a')
+        ),
+        'set'
+      )
+      assert.strictEqual(
+        server.setChargingStationData(
+          hashId,
+          createStationDataWithIndex(hashId, 1, 2000, 'template-b')
+        ),
+        'collision'
+      )
+      assert.strictEqual(
+        server.getChargingStationData(hashId)?.stationInfo.templateName,
+        'template-a'
+      )
       assert.strictEqual(server.getChargingStationsCount(), 1)
     })
 

--- a/tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts
+++ b/tests/charging-station/ui-server/ui-services/AbstractUIService.test.ts
@@ -11,6 +11,7 @@ import type { AbstractUIService } from '../../../../src/charging-station/ui-serv
 import type {
   BroadcastChannelResponse,
   BroadcastChannelResponsePayload,
+  ChargingStationData,
   UUIDv4,
 } from '../../../../src/types/index.js'
 
@@ -95,6 +96,32 @@ const emitWorkerResponse = (
   }
   channel.onmessage({ data: [uuid, responsePayload] })
 }
+
+/**
+ * Build charging station data with an explicit `templateIndex` under `hashId`,
+ * to exercise identity-collision dedup deterministically.
+ * @param hashId - Deterministic content hash shared by colliding twins.
+ * @param templateIndex - Stable per-instance discriminator within a template.
+ * @param timestamp - Registry merge timestamp in milliseconds.
+ * @returns Charging station data for the described identity.
+ */
+const createStationDataWithIndex = (
+  hashId: string,
+  templateIndex: number,
+  timestamp: number
+): ChargingStationData =>
+  createMockChargingStationData(hashId, {
+    stationInfo: {
+      baseName: 'collision-base',
+      chargePointModel: 'TestModel',
+      chargePointVendor: 'TestVendor',
+      chargingStationId: hashId,
+      hashId,
+      templateIndex,
+      templateName: 'collision-template',
+    },
+    timestamp,
+  })
 
 await describe('AbstractUIService', async () => {
   afterEach(() => {
@@ -961,5 +988,69 @@ await describe('AbstractUIService', async () => {
     if (service != null) {
       service.stop()
     }
+  })
+
+  await describe('AbstractUIServer identity-collision dedup (issue #2026)', async () => {
+    await it('should reject a twin whose hashId collides with a different templateIndex', () => {
+      const server = new TestableUIWebSocketServer(createMockUIServerConfiguration())
+      const hashId = 'collision-hash'
+      assert.strictEqual(
+        server.setChargingStationData(hashId, createStationDataWithIndex(hashId, 1, 1000)),
+        'set'
+      )
+      assert.strictEqual(
+        server.setChargingStationData(hashId, createStationDataWithIndex(hashId, 2, 2000)),
+        'collision'
+      )
+      assert.strictEqual(server.getChargingStationData(hashId)?.stationInfo.templateIndex, 1)
+      assert.strictEqual(server.getChargingStationsCount(), 1)
+    })
+
+    await it('should still update the registry for a restart re-emit with a newer timestamp', () => {
+      const server = new TestableUIWebSocketServer(createMockUIServerConfiguration())
+      const hashId = 'restart-hash'
+      assert.strictEqual(
+        server.setChargingStationData(hashId, createStationDataWithIndex(hashId, 1, 1000)),
+        'set'
+      )
+      assert.strictEqual(
+        server.setChargingStationData(hashId, createStationDataWithIndex(hashId, 1, 2000)),
+        'set'
+      )
+      assert.strictEqual(server.getChargingStationData(hashId)?.timestamp, 2000)
+    })
+
+    await it('should drop a stale same-identity re-emit with an older timestamp', () => {
+      const server = new TestableUIWebSocketServer(createMockUIServerConfiguration())
+      const hashId = 'stale-hash'
+      server.setChargingStationData(hashId, createStationDataWithIndex(hashId, 1, 2000))
+      assert.strictEqual(
+        server.setChargingStationData(hashId, createStationDataWithIndex(hashId, 1, 1000)),
+        'stale'
+      )
+      assert.strictEqual(server.getChargingStationData(hashId)?.timestamp, 2000)
+    })
+
+    await it('should not report false success for a targeted broadcast after a twin collision', async () => {
+      const server = new TestableUIWebSocketServer(createMockUIServerConfiguration())
+      server.testRegisterProtocolVersionUIService(ProtocolVersion['0.0.1'])
+      const service = server.getUIService(ProtocolVersion['0.0.1'])
+      if (service == null) {
+        assert.fail('Expected UI service to be registered')
+      }
+      const hashId = 'broadcast-collision-hash'
+      server.setChargingStationData(hashId, createStationDataWithIndex(hashId, 1, 1000))
+      server.setChargingStationData(hashId, createStationDataWithIndex(hashId, 2, 2000))
+      try {
+        await registerTransportStopRequestFor(service, TEST_UUID, [hashId])
+        assert.strictEqual(service.getBroadcastChannelOutstandingResponseCount(TEST_UUID), 1)
+        emitWorkerResponse(service, { hashId, status: ResponseStatus.SUCCESS }, TEST_UUID)
+        assert.strictEqual(service.getBroadcastChannelOutstandingResponseCount(TEST_UUID), 0)
+        assert.strictEqual(server.getChargingStationsCount(), 1)
+        assert.strictEqual(server.getChargingStationData(hashId)?.stationInfo.templateIndex, 1)
+      } finally {
+        service.stop()
+      }
+    })
   })
 })


### PR DESCRIPTION
## Problem

`hashId` is a deterministic content hash of a template's identity fields + composed `chargingStationId`, with no uniqueness check on add. `getHashId` hashes vendor/model + serial-number prefixes + meterType + the composed id — **not** the template file name — and `fixedName: true` collapses the composed id to the bare `baseName`. So two stations built from identical identity fields collide on one `hashId`. `AbstractUIServer.setChargingStationData` was last-writer-wins by timestamp keyed by `hashId`, so the twin silently overwrote the first station in the UI registry; a targeted broadcast UI command (e.g. `startChargingStation`) then completed `success` on the first worker's reply while the collided twin was orphaned — the operator saw success with one station unactioned.

## Fix (scoped per issue)

Post-creation identity dedup at the registry write choke point, keeping deterministic `hashId`s byte-identical:

- `setChargingStationData` returns a discriminated `'set' | 'stale' | 'collision'` outcome. A write whose `hashId` already maps to a **different physical station identity — a distinct `(templateName, templateIndex)` pair —** is rejected as `collision` without overwriting. The guard sits at the single write choke point, so it covers every worker event (added/started/stopped/updated), replacing last-writer-wins with first-writer-wins.
- The `(templateName, templateIndex)` pair is the correct discriminator: `getHashId` excludes the template file name and the index space is per-`templateName`, so two identity-clone template files (copy+rename) can share both `hashId` and `templateIndex`; comparing the pair rejects them, whereas `templateIndex` alone would silently overwrite.
- A legitimate restart/re-emit keeps the same `(templateName, templateIndex)` and still updates by timestamp (no regression).
- `workerEventAdded` logs the rejected collision at `error` level (with `hashId`, `templateName`, `templateIndex`) instead of silently logging the twin as added.

`getHashId` output is byte-identical, so existing `<hashId>.json` config files, the registry map key, broadcast routing and stats resolve unchanged. No OCPP PDU / message-format change; simulator station-registry lifecycle only.

## Tests

- twin (same `hashId`, different `templateIndex`) rejected and not overwritten;
- identity-clone twin (same `hashId` + `templateIndex`, different `templateName`) rejected;
- restart re-emit (same identity, newer timestamp) still updates; stale older-timestamp re-emit dropped;
- no false broadcast `success` after a collision.

Mutation-verified: reverting the collision guard fails the twin/false-success tests; reverting the `templateName` clause fails only the clone-file test; the restart/stale tests stay green throughout. Full project-script gates pass (format/lint/typecheck/test — 3101/3101, 6 pre-existing skips).

## Scope & known limitations (out of scope, deferred)

- Reworking broadcast aggregation to identity-based tracking, and changing the hash algorithm / adding a per-instance salt, are explicitly out of scope.
- Because two twins share one `hashId`, the collided twin's worker `add` genuinely succeeds and its `hashId` still appears in the `addChargingStations` response `hashIdsSucceeded` even though it is absent from the registry; and a later `deleteChargingStations` on that shared `hashId` evicts the surviving primary. Both are inherent to the shared-`hashId` root cause and require the out-of-scope identity-based keying to resolve. This PR keeps the registry and broadcast completion **consistent** for the one accounted station and surfaces the duplicate at add time.
- A collided twin's later `started`/`stopped`/`updated` events return `collision` and are silently dropped (no re-notify); each orphan is announced exactly once at its guaranteed `added` event, so higher-frequency lifecycle events are not re-logged to avoid noise.

Causally linked to #2027 (orphan-worker termination): an orphaned twin is exactly the worker #2027 cannot individually terminate — this add-time dedup surfaces the duplicate instead of letting it silently shadow its twin.

Closes #2026.