### PR TITLE
test: use shared constants and enums instead of hardcoded literals

### DIFF
--- a/tests/charging-station/ocpp/1.6/OCPP16IncomingRequestService-SmartCharging.test.ts
+++ b/tests/charging-station/ocpp/1.6/OCPP16IncomingRequestService-SmartCharging.test.ts
@@ -23,6 +23,7 @@ import {
   OCPP16StandardParametersKey,
 } from '../../../../src/types/index.js'
 import { standardCleanup } from '../../../helpers/TestLifecycleHelpers.js'
+import { TEST_ONE_HOUR_SECONDS } from '../../ChargingStationTestConstants.js'
 import {
   ChargingProfileFixtures,
   createOCPP16IncomingRequestTestContext,
@@ -37,7 +38,7 @@ const attachComposableProfile = (
   profile: OCPP16ChargingProfile
 ): void => {
   profile.chargingSchedule.startSchedule = new Date()
-  profile.chargingSchedule.duration = 3600
+  profile.chargingSchedule.duration = TEST_ONE_HOUR_SECONDS
   const connectorStatus = station.getConnectorStatus(connectorId)
   if (connectorStatus != null) {
     connectorStatus.chargingProfiles = [profile]
@@ -278,14 +279,14 @@ await describe('OCPP16IncomingRequestService — SmartCharging', async () => {
       )
       const profile = ChargingProfileFixtures.createTxDefaultProfile()
       profile.chargingSchedule.startSchedule = new Date()
-      profile.chargingSchedule.duration = 3600
+      profile.chargingSchedule.duration = TEST_ONE_HOUR_SECONDS
       const connectorStatus = station.getConnectorStatus(1)
       if (connectorStatus != null) {
         connectorStatus.chargingProfiles = [profile]
       }
       const request: OCPP16GetCompositeScheduleRequest = {
         connectorId: 1,
-        duration: 3600,
+        duration: TEST_ONE_HOUR_SECONDS,
       }
 
       // Act
@@ -308,7 +309,7 @@ await describe('OCPP16IncomingRequestService — SmartCharging', async () => {
       )
       const request: OCPP16GetCompositeScheduleRequest = {
         connectorId: 99,
-        duration: 3600,
+        duration: TEST_ONE_HOUR_SECONDS,
       }
 
       // Act
@@ -328,7 +329,7 @@ await describe('OCPP16IncomingRequestService — SmartCharging', async () => {
       )
       const request: OCPP16GetCompositeScheduleRequest = {
         connectorId: 0,
-        duration: 3600,
+        duration: TEST_ONE_HOUR_SECONDS,
       }
 
       // Act
@@ -357,7 +358,7 @@ await describe('OCPP16IncomingRequestService — SmartCharging', async () => {
       }
       const request: OCPP16GetCompositeScheduleRequest = {
         connectorId: 1,
-        duration: 3600,
+        duration: TEST_ONE_HOUR_SECONDS,
       }
 
       // Act
@@ -373,7 +374,7 @@ await describe('OCPP16IncomingRequestService — SmartCharging', async () => {
       upsertConfigurationKey(station, OCPP16StandardParametersKey.SupportedFeatureProfiles, 'Core')
       const request: OCPP16GetCompositeScheduleRequest = {
         connectorId: 1,
-        duration: 3600,
+        duration: TEST_ONE_HOUR_SECONDS,
       }
 
       // Act
@@ -396,7 +397,10 @@ await describe('OCPP16IncomingRequestService — SmartCharging', async () => {
         'Core,SmartCharging'
       )
       attachComposableProfile(station, 3, ChargingProfileFixtures.createTxDefaultProfile())
-      const request: OCPP16GetCompositeScheduleRequest = { connectorId: 0, duration: 3600 }
+      const request: OCPP16GetCompositeScheduleRequest = {
+        connectorId: 0,
+        duration: TEST_ONE_HOUR_SECONDS,
+      }
 
       // Act
       const response = testableService.handleRequestGetCompositeSchedule(station, request)
@@ -428,7 +432,10 @@ await describe('OCPP16IncomingRequestService — SmartCharging', async () => {
         }
       }
       attachComposableProfile(station, 0, ChargingProfileFixtures.createChargePointMaxProfile())
-      const request: OCPP16GetCompositeScheduleRequest = { connectorId: 0, duration: 3600 }
+      const request: OCPP16GetCompositeScheduleRequest = {
+        connectorId: 0,
+        duration: TEST_ONE_HOUR_SECONDS,
+      }
 
       // Act
       const response = testableService.handleRequestGetCompositeSchedule(station, request)

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-PostStopResurrection.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-PostStopResurrection.test.ts
@@ -17,7 +17,7 @@ import { afterEach, beforeEach, describe, it, mock } from 'node:test'
 import type { ChargingStation } from '../../../../src/charging-station/index.js'
 
 import { OCPP20IncomingRequestService } from '../../../../src/charging-station/ocpp/2.0/OCPP20IncomingRequestService.js'
-import { OCPPVersion } from '../../../../src/types/index.js'
+import { GenericStatus, OCPPVersion, ReportBaseEnumType } from '../../../../src/types/index.js'
 import { Constants } from '../../../../src/utils/index.js'
 import {
   flushMicrotasks,
@@ -171,8 +171,8 @@ await describe('OCPP20IncomingRequestService — post-stop resurrection guard', 
 
       await plumbing.sendNotifyReportRequest(
         station,
-        { reportBase: 'FullInventory', requestId: 1 },
-        { status: 'Accepted' }
+        { reportBase: ReportBaseEnumType.FullInventory, requestId: 1 },
+        { status: GenericStatus.Accepted }
       )
 
       assert.strictEqual(requestHandlerMock.mock.callCount(), 0)
@@ -190,8 +190,8 @@ await describe('OCPP20IncomingRequestService — post-stop resurrection guard', 
 
       await plumbing.sendNotifyReportRequest(
         station,
-        { reportBase: 'FullInventory', requestId: 42 },
-        { status: 'Accepted' }
+        { reportBase: ReportBaseEnumType.FullInventory, requestId: 42 },
+        { status: GenericStatus.Accepted }
       )
 
       assert.strictEqual(requestHandlerMock.mock.callCount(), 0)

--- a/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-RequestStartTransaction.test.ts
+++ b/tests/charging-station/ocpp/2.0/OCPP20IncomingRequestService-RequestStartTransaction.test.ts
@@ -11,7 +11,6 @@ import type { ChargingStation } from '../../../../src/charging-station/index.js'
 import type {
   EvseStatus,
   OCPP20ChargingProfileType,
-  OCPP20ChargingRateUnitEnumType,
   OCPP20RequestStartTransactionRequest,
   OCPP20RequestStartTransactionResponse,
   OCPP20TransactionEventOptions,
@@ -30,6 +29,7 @@ import {
   AttributeEnumType,
   OCPP20ChargingProfileKindEnumType,
   OCPP20ChargingProfilePurposeEnumType,
+  OCPP20ChargingRateUnitEnumType,
   OCPP20ComponentName,
   OCPP20IdTokenEnumType,
   OCPP20IncomingRequestCommand,
@@ -278,7 +278,7 @@ await describe('F01 & F02 - Remote Start Transaction', async () => {
       chargingProfilePurpose: OCPP20ChargingProfilePurposeEnumType.TxProfile,
       chargingSchedule: [
         {
-          chargingRateUnit: 'A' as OCPP20ChargingRateUnitEnumType,
+          chargingRateUnit: OCPP20ChargingRateUnitEnumType.A,
           chargingSchedulePeriod: [
             {
               limit: 30,
@@ -319,7 +319,7 @@ await describe('F01 & F02 - Remote Start Transaction', async () => {
       chargingProfilePurpose: OCPP20ChargingProfilePurposeEnumType.TxDefaultProfile,
       chargingSchedule: [
         {
-          chargingRateUnit: 'A' as OCPP20ChargingRateUnitEnumType,
+          chargingRateUnit: OCPP20ChargingRateUnitEnumType.A,
           chargingSchedulePeriod: [
             {
               limit: 25,
@@ -361,7 +361,7 @@ await describe('F01 & F02 - Remote Start Transaction', async () => {
       chargingProfilePurpose: OCPP20ChargingProfilePurposeEnumType.TxProfile,
       chargingSchedule: [
         {
-          chargingRateUnit: 'A' as OCPP20ChargingRateUnitEnumType,
+          chargingRateUnit: OCPP20ChargingRateUnitEnumType.A,
           chargingSchedulePeriod: [
             {
               limit: 32,
@@ -433,7 +433,7 @@ await describe('F01 & F02 - Remote Start Transaction', async () => {
       chargingProfilePurpose: OCPP20ChargingProfilePurposeEnumType.TxProfile,
       chargingSchedule: [
         {
-          chargingRateUnit: 'A' as OCPP20ChargingRateUnitEnumType,
+          chargingRateUnit: OCPP20ChargingRateUnitEnumType.A,
           chargingSchedulePeriod: [
             {
               limit: 30,

--- a/tests/charging-station/ui-server/UIHttpServer.test.ts
+++ b/tests/charging-station/ui-server/UIHttpServer.test.ts
@@ -15,7 +15,12 @@ import type { ResponsePayload, UIServerConfiguration, UUIDv4 } from '../../../sr
 
 import { UIHttpServer } from '../../../src/charging-station/ui-server/UIHttpServer.js'
 import { DEFAULT_COMPRESSION_THRESHOLD_BYTES } from '../../../src/charging-station/ui-server/UIServerSecurity.js'
-import { ApplicationProtocol, ProtocolVersion, ResponseStatus } from '../../../src/types/index.js'
+import {
+  ApplicationProtocol,
+  ProcedureName,
+  ProtocolVersion,
+  ResponseStatus,
+} from '../../../src/types/index.js'
 import { Constants, logger } from '../../../src/utils/index.js'
 import {
   createLoggerMocks,
@@ -386,7 +391,7 @@ await describe('UIHttpServer', async () => {
         const res = new MockServerResponse()
 
         broadcastServer.emitRequest(
-          buildProcedureRequest('stopChargingStation', {
+          buildProcedureRequest(ProcedureName.STOP_CHARGING_STATION, {
             hashIds: [TEST_HASH_ID, TEST_HASH_ID_2],
           }),
           res
@@ -428,7 +433,7 @@ await describe('UIHttpServer', async () => {
         const res = new MockServerResponse()
 
         broadcastServer.emitRequest(
-          buildProcedureRequest('stopChargingStation', {
+          buildProcedureRequest(ProcedureName.STOP_CHARGING_STATION, {
             hashIds: [TEST_HASH_ID, TEST_HASH_ID_2],
           }),
           res
@@ -471,7 +476,7 @@ await describe('UIHttpServer', async () => {
 
         broadcastServer.emitRequest(
           buildProcedureRequest(
-            'stopChargingStation',
+            ProcedureName.STOP_CHARGING_STATION,
             { hashIds: [TEST_HASH_ID] },
             { 'accept-encoding': 'gzip' }
           ),
@@ -522,7 +527,7 @@ await describe('UIHttpServer', async () => {
           const res = new MockServerResponse()
 
           broadcastServer.emitRequest(
-            buildProcedureRequest('stopChargingStation', { hashIds: [TEST_HASH_ID] }),
+            buildProcedureRequest(ProcedureName.STOP_CHARGING_STATION, { hashIds: [TEST_HASH_ID] }),
             res
           )
 
@@ -552,7 +557,10 @@ await describe('UIHttpServer', async () => {
       try {
         const res = new MockServerResponse()
 
-        broadcastServer.emitRequest(buildProcedureRequest('listChargingStations', {}), res)
+        broadcastServer.emitRequest(
+          buildProcedureRequest(ProcedureName.LIST_CHARGING_STATIONS, {}),
+          res
+        )
         await awaitFinish(res)
 
         assert.strictEqual(res.statusCode, 200)
@@ -571,7 +579,7 @@ await describe('UIHttpServer', async () => {
         const res = new MockServerResponse()
 
         broadcastServer.emitRequest(
-          buildProcedureRequest('stopChargingStation', { hashIds: [TEST_HASH_ID] }),
+          buildProcedureRequest(ProcedureName.STOP_CHARGING_STATION, { hashIds: [TEST_HASH_ID] }),
           res
         )
 

--- a/tests/charging-station/ui-server/UIServerTestConstants.ts
+++ b/tests/charging-station/ui-server/UIServerTestConstants.ts
@@ -8,13 +8,5 @@ import type { UUIDv4 } from '../../../src/types/index.js'
 export const TEST_UUID = '550e8400-e29b-41d4-a716-446655440000' as UUIDv4
 export const TEST_UUID_2 = '6ba7b810-9dad-41d1-80b4-00c04fd430c8' as UUIDv4
 
-export const TEST_PROCEDURES = {
-  AUTHORIZE: 'Authorize',
-  DELETE_CHARGING_STATIONS: 'deleteChargingStations',
-  LIST_CHARGING_STATIONS: 'listChargingStations',
-  START_CHARGING_STATION: 'startChargingStation',
-  STOP_CHARGING_STATION: 'stopChargingStation',
-} as const
-
 export const TEST_HASH_ID = 'test-station-001' as const
 export const TEST_HASH_ID_2 = 'test-station-002' as const


### PR DESCRIPTION
## PR Checklist

- [x] Please add a description of your changes.
- [x] Please ensure title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] We need your changes to come with unit tests in order to keep this project in quality and easy to maintain.
- [x] If your changes contain any new feature please be sure to document it.
- [ ] Please add a link to the open issue or task that this pull request will resolve.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

---

Test-only hygiene: replace hardcoded literals in recent tests with the shared constants/enums they duplicate, for single-source-of-truth and consistency with sibling tests. No production code and no behavior change — every substituted value is byte-equivalent to the literal it replaces.

### Changes

- **`OCPP20IncomingRequestService-PostStopResurrection.test.ts`** — use `GenericStatus.Accepted` and `ReportBaseEnumType.FullInventory` instead of the raw `'Accepted'` / `'FullInventory'` strings (matches the response-status convention already used across the other OCPP 2.0 tests, e.g. `OCPP20RequestService-SignCertificate.test.ts`).
- **`OCPP20IncomingRequestService-RequestStartTransaction.test.ts`** — use `OCPP20ChargingRateUnitEnumType.A` instead of the `'A' as OCPP20ChargingRateUnitEnumType` casts (import moved from a type-only to a value import accordingly).
- **`OCPP16IncomingRequestService-SmartCharging.test.ts`** — use the existing `TEST_ONE_HOUR_SECONDS` constant instead of the `3600` duration literal.
- **`UIHttpServer.test.ts`** — pass `ProcedureName.*` to `buildProcedureRequest` instead of raw procedure-name strings (aligns with `AbstractUIService.test.ts`).
- **`UIServerTestConstants.ts`** — remove the now-unused `TEST_PROCEDURES` constant; `ProcedureName` is the canonical source.

### Testing

No new tests are needed (this changes test fixtures/expectations to reference existing enums/constants, not behavior). Existing suites are unaffected: root package `format` (no churn), `lint`, `typecheck`, and the full `test` suite (3094 passed, 0 failed, 6 skipped) all pass locally.

<sub>Surfaced by a shared-constant usage review of the recent test changes; no dedicated tracking issue.</sub>
