### PR TITLE
fix(ui-server): reconcile evses wire type so /metrics works on OCPP 2.0.x

### DIFF
--- a/src/charging-station/ui-server/AbstractUIServer.ts
+++ b/src/charging-station/ui-server/AbstractUIServer.ts
@@ -1539,7 +1539,7 @@ const addPerStationStatusInfo = (
 const countConnectors = (data: ChargingStationData): number =>
   isNotEmptyArray(data.connectors)
     ? data.connectors.length
-    : data.evses.reduce((n, evse) => n + evse.evseStatus.connectors.size, 0)
+    : data.evses.reduce((n, evse) => n + evse.evseStatus.connectors.length, 0)
 
 /**
  * Iterate connectors under the same OCPP 1.6 vs OCPP 2.0.x source split as
@@ -1557,8 +1557,8 @@ const iterateConnectors = function * (data: ChargingStationData): Generator<Conn
     return
   }
   for (const evse of data.evses) {
-    for (const [connectorId, connectorStatus] of evse.evseStatus.connectors) {
-      yield { connectorId, connectorStatus, evseId: evse.evseId }
+    for (const entry of evse.evseStatus.connectors) {
+      yield entry
     }
   }
 }

--- a/src/types/ChargingStationWorker.ts
+++ b/src/types/ChargingStationWorker.ts
@@ -8,7 +8,7 @@ import type {
 import type { ChargingStationInfo } from './ChargingStationInfo.js'
 import type { ChargingStationOcppConfiguration } from './ChargingStationOcppConfiguration.js'
 import type { ConnectorEntry } from './ConnectorStatus.js'
-import type { EvseEntry } from './Evse.js'
+import type { EvseEntryData } from './Evse.js'
 import type { JsonObject } from './JsonType.js'
 import type { BootNotificationResponse } from './ocpp/Responses.js'
 import type { Statistics } from './Statistics.js'
@@ -34,7 +34,7 @@ export interface ChargingStationData extends WorkerData {
   automaticTransactionGenerator?: ATGConfiguration
   bootNotificationResponse?: BootNotificationResponse
   connectors: ConnectorEntry[]
-  evses: EvseEntry[]
+  evses: EvseEntryData[]
   ocppConfiguration: ChargingStationOcppConfiguration
   started: boolean
   stationInfo: ChargingStationInfo

--- a/src/types/Evse.ts
+++ b/src/types/Evse.ts
@@ -30,8 +30,8 @@ export interface EvseStatus {
  * `buildEvseEntries` never emits it and no UI-facing consumer reads it off the wire.
  */
 export interface EvseStatusData {
-  availability: AvailabilityType
-  connectors: ConnectorEntry[]
+  readonly availability: AvailabilityType
+  readonly connectors: readonly ConnectorEntry[]
 }
 
 export interface EvseTemplate {

--- a/src/types/Evse.ts
+++ b/src/types/Evse.ts
@@ -7,6 +7,12 @@ export interface EvseEntry {
   readonly evseStatus: EvseStatus
 }
 
+/**
+ * JSON-wire projection of {@link EvseEntry} carried by `ChargingStationData.evses`;
+ * `evseStatus.connectors` is a serialization-safe `ConnectorEntry[]`, whereas the
+ * in-memory {@link EvseEntry} keeps a `Map`. Mirrors the ui-common `EvseEntry` wire
+ * shape (duplicated because packages share no re-exports).
+ */
 export interface EvseEntryData {
   readonly evseId: number
   readonly evseStatus: EvseStatusData
@@ -18,6 +24,11 @@ export interface EvseStatus {
   MeterValues?: SampledValueTemplate[]
 }
 
+/**
+ * JSON-wire projection of {@link EvseStatus}: `connectors` is a `ConnectorEntry[]`
+ * (a `Map` serializes to `{}`). `MeterValues` is intentionally omitted — the producer
+ * `buildEvseEntries` never emits it and no UI-facing consumer reads it off the wire.
+ */
 export interface EvseStatusData {
   availability: AvailabilityType
   connectors: ConnectorEntry[]

--- a/src/types/Evse.ts
+++ b/src/types/Evse.ts
@@ -1,4 +1,4 @@
-import type { ConnectorStatus } from './ConnectorStatus.js'
+import type { ConnectorEntry, ConnectorStatus } from './ConnectorStatus.js'
 import type { SampledValueTemplate } from './MeasurandPerPhaseSampledValueTemplates.js'
 import type { AvailabilityType } from './ocpp/Requests.js'
 
@@ -7,10 +7,20 @@ export interface EvseEntry {
   readonly evseStatus: EvseStatus
 }
 
+export interface EvseEntryData {
+  readonly evseId: number
+  readonly evseStatus: EvseStatusData
+}
+
 export interface EvseStatus {
   availability: AvailabilityType
   connectors: Map<number, ConnectorStatus>
   MeterValues?: SampledValueTemplate[]
+}
+
+export interface EvseStatusData {
+  availability: AvailabilityType
+  connectors: ConnectorEntry[]
 }
 
 export interface EvseTemplate {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,7 +47,7 @@ export {
 export type { ConnectorEntry, ConnectorStatus } from './ConnectorStatus.js'
 export type { EmptyObject } from './EmptyObject.js'
 export type { HandleErrorParams } from './Error.js'
-export type { EvseEntry, EvseStatus, EvseTemplate } from './Evse.js'
+export type { EvseEntry, EvseEntryData, EvseStatus, EvseStatusData, EvseTemplate } from './Evse.js'
 export { FileType } from './FileType.js'
 export type { JsonObject, JsonType } from './JsonType.js'
 export { MapStringifyFormat } from './MapStringifyFormat.js'

--- a/src/utils/ChargingStationConfigurationUtils.ts
+++ b/src/utils/ChargingStationConfigurationUtils.ts
@@ -4,7 +4,7 @@ import type {
   ChargingStationAutomaticTransactionGeneratorConfiguration,
   ConnectorEntry,
   ConnectorStatus,
-  EvseEntry,
+  EvseEntryData,
   EvseStatusConfiguration,
 } from '../types/index.js'
 
@@ -78,7 +78,7 @@ export const buildConnectorsStatus = (
     .toArray()
 }
 
-export const buildEvseEntries = (chargingStation: ChargingStation): EvseEntry[] => {
+export const buildEvseEntries = (chargingStation: ChargingStation): EvseEntryData[] => {
   return chargingStation
     .iterateEvses()
     .map(({ evseId, evseStatus }) => ({
@@ -99,7 +99,7 @@ export const buildEvseEntries = (chargingStation: ChargingStation): EvseEntry[] 
         ),
       },
     }))
-    .toArray() as unknown as EvseEntry[]
+    .toArray()
 }
 
 export const buildEvsesStatus = (

--- a/tests/charging-station/ui-server/UIMetricsEndpoint.test.ts
+++ b/tests/charging-station/ui-server/UIMetricsEndpoint.test.ts
@@ -10,6 +10,7 @@ import type { Registry } from 'prom-client'
 import assert from 'node:assert/strict'
 import { afterEach, beforeEach, describe, it } from 'node:test'
 
+import type { ChargingStation } from '../../../src/charging-station/index.js'
 import type {
   ChargingStationData,
   EvseStatus,
@@ -558,7 +559,7 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
               ],
             },
           },
-        ] as ChargingStationData['evses'],
+        ] satisfies ChargingStationData['evses'],
       })
     )
     server.mockListen(t)
@@ -586,15 +587,14 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
   // never exercised the array shape the worker->main producer actually emits.
   // These feed the REAL buildEvseEntries output into the scrape.
   const buildEvseWireEntries = (evses: Map<number, EvseStatus>): ChargingStationData['evses'] => {
-    const stub = {
-      hasEvses: true,
-      iterateEvses: function * () {
+    const stub: Pick<ChargingStation, 'iterateEvses'> = {
+      * iterateEvses () {
         for (const [evseId, evseStatus] of evses) {
           yield { evseId, evseStatus }
         }
       },
-    } as unknown as Parameters<typeof buildEvseEntries>[0]
-    return buildEvseEntries(stub)
+    }
+    return buildEvseEntries(stub as ChargingStation)
   }
 
   const evseStatusOf = (
@@ -666,8 +666,8 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
     )
   })
 
-  await it('should report connectors_total 0 (not NaN) for an EVSE-mode station with empty evses (issue #2046)', async t => {
-    const evsesWire = buildEvseWireEntries(new Map<number, EvseStatus>())
+  await it('should report connectors_total 0 (not NaN) for an EVSE with an empty connectors array (issue #2046)', async t => {
+    const evsesWire = buildEvseWireEntries(new Map<number, EvseStatus>([[1, evseStatusOf([])]]))
     server.addStation(buildStationData('station-2046-empty', { connectors: [], evses: evsesWire }))
     server.mockListen(t)
 

--- a/tests/charging-station/ui-server/UIMetricsEndpoint.test.ts
+++ b/tests/charging-station/ui-server/UIMetricsEndpoint.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, it } from 'node:test'
 
 import type {
   ChargingStationData,
+  EvseStatus,
   TemplateStatistics,
   UIServerConfiguration,
 } from '../../../src/types/index.js'
@@ -33,6 +34,7 @@ import {
   OCPP16AvailabilityType,
   OCPPVersion,
 } from '../../../src/types/index.js'
+import { buildEvseEntries } from '../../../src/utils/ChargingStationConfigurationUtils.js'
 import { logger } from '../../../src/utils/index.js'
 import { standardCleanup } from '../../helpers/TestLifecycleHelpers.js'
 import {
@@ -543,17 +545,17 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
             evseId: 1,
             evseStatus: {
               availability: OCPP16AvailabilityType.Operative,
-              connectors: new Map([
-                [
-                  1,
-                  {
+              connectors: [
+                {
+                  connectorId: 1,
+                  connectorStatus: {
                     availability: OCPP16AvailabilityType.Operative,
                     MeterValues: [],
                     status: ConnectorStatusEnum.Available,
                   },
-                ],
-              ]),
-              MeterValues: [],
+                  evseId: 1,
+                },
+              ],
             },
           },
         ] as ChargingStationData['evses'],
@@ -578,6 +580,107 @@ await describe('UIHttpServer /metrics endpoint (issue #851)', async () => {
     assert.ok(statusLine != null, 'simulator_connector_status_info value line not found')
     assert.match(statusLine, /connector_id="1"/)
     assert.match(statusLine, /status="Available"/)
+  })
+
+  // issue #2046: the earlier EVSE-mode test hand-builds a synthetic Map, so it
+  // never exercised the array shape the worker->main producer actually emits.
+  // These feed the REAL buildEvseEntries output into the scrape.
+  const buildEvseWireEntries = (evses: Map<number, EvseStatus>): ChargingStationData['evses'] => {
+    const stub = {
+      hasEvses: true,
+      iterateEvses: function * () {
+        for (const [evseId, evseStatus] of evses) {
+          yield { evseId, evseStatus }
+        }
+      },
+    } as unknown as Parameters<typeof buildEvseEntries>[0]
+    return buildEvseEntries(stub)
+  }
+
+  const evseStatusOf = (
+    connectorIds: number[],
+    status = ConnectorStatusEnum.Available
+  ): EvseStatus => ({
+    availability: OCPP16AvailabilityType.Operative,
+    connectors: new Map(
+      connectorIds.map(connectorId => [
+        connectorId,
+        { availability: OCPP16AvailabilityType.Operative, MeterValues: [], status },
+      ])
+    ),
+  })
+
+  await it('should serve 200 with the ACTUAL buildEvseEntries wire shape and sum connectors across EVSEs (issue #2046)', async t => {
+    const evsesWire = buildEvseWireEntries(
+      new Map<number, EvseStatus>([
+        [1, evseStatusOf([1, 2])],
+        [2, evseStatusOf([1])],
+      ])
+    )
+    assert.ok(
+      Array.isArray(evsesWire[0].evseStatus.connectors),
+      'buildEvseEntries must emit evseStatus.connectors as an array (wire contract)'
+    )
+    server.addStation(buildStationData('station-2046', { connectors: [], evses: evsesWire }))
+    server.mockListen(t)
+
+    server.start()
+    const res = new MockServerResponse()
+    server.emitRequest(buildMetricsRequest(), res)
+    await awaitFinish(res)
+    assert.strictEqual(res.statusCode, 200)
+    const body = res.body ?? ''
+    assert.match(body, /^# HELP /m)
+    assert.match(body, /^# TYPE /m)
+    assert.match(body, /simulator_station_connectors_total\{[^}]*hash_id="station-2046"[^}]*\}\s+3/)
+    const statusLine = body
+      .split('\n')
+      .find(
+        l =>
+          l.startsWith('simulator_connector_status_info{') &&
+          l.includes('hash_id="station-2046"') &&
+          l.endsWith(' 1')
+      )
+    assert.ok(statusLine != null, 'simulator_connector_status_info value line not found')
+  })
+
+  await it('should count connector id 0 / evse id 0 in connectors_total (issue #2046)', async t => {
+    const evsesWire = buildEvseWireEntries(
+      new Map<number, EvseStatus>([
+        [0, evseStatusOf([0])],
+        [1, evseStatusOf([1])],
+      ])
+    )
+    server.addStation(buildStationData('station-2046-zero', { connectors: [], evses: evsesWire }))
+    server.mockListen(t)
+
+    server.start()
+    const res = new MockServerResponse()
+    server.emitRequest(buildMetricsRequest(), res)
+    await awaitFinish(res)
+    assert.strictEqual(res.statusCode, 200)
+    const body = res.body ?? ''
+    assert.match(
+      body,
+      /simulator_station_connectors_total\{[^}]*hash_id="station-2046-zero"[^}]*\}\s+2/
+    )
+  })
+
+  await it('should report connectors_total 0 (not NaN) for an EVSE-mode station with empty evses (issue #2046)', async t => {
+    const evsesWire = buildEvseWireEntries(new Map<number, EvseStatus>())
+    server.addStation(buildStationData('station-2046-empty', { connectors: [], evses: evsesWire }))
+    server.mockListen(t)
+
+    server.start()
+    const res = new MockServerResponse()
+    server.emitRequest(buildMetricsRequest(), res)
+    await awaitFinish(res)
+    assert.strictEqual(res.statusCode, 200)
+    const body = res.body ?? ''
+    assert.match(
+      body,
+      /simulator_station_connectors_total\{[^}]*hash_id="station-2046-empty"[^}]*\}\s+0/
+    )
   })
 
   await it('should detect off-by-one at soft cap boundary (strict-greater-than semantics)', async t => {

--- a/tests/utils/ChargingStationConfigurationUtils.test.ts
+++ b/tests/utils/ChargingStationConfigurationUtils.test.ts
@@ -9,7 +9,7 @@ import assert from 'node:assert/strict'
 import { afterEach, describe, it } from 'node:test'
 
 import type { ChargingStation } from '../../src/charging-station/index.js'
-import type { ConnectorEntry, ConnectorStatus, EvseStatus } from '../../src/types/index.js'
+import type { ConnectorStatus, EvseStatus } from '../../src/types/index.js'
 
 import { AvailabilityType } from '../../src/types/index.js'
 import {
@@ -512,7 +512,7 @@ await describe('ChargingStationConfigurationUtils', async () => {
   })
 
   await describe('buildEvseEntries', async () => {
-    await it('should return entries with evseId, evseStatus containing availability and connectors Map', () => {
+    await it('should return entries with evseId, evseStatus containing availability and connectors array', () => {
       const { station } = createMockChargingStation({
         connectorsCount: 1,
         evseConfiguration: { evsesCount: 1 },
@@ -545,9 +545,9 @@ await describe('ChargingStationConfigurationUtils', async () => {
       assert.strictEqual(result.length, 2)
       assert.strictEqual(result[0].evseId, 0)
       assert.strictEqual(result[0].evseStatus.availability, AvailabilityType.Operative)
-      assert.strictEqual((result[0].evseStatus.connectors as unknown as ConnectorEntry[]).length, 0)
+      assert.strictEqual(result[0].evseStatus.connectors.length, 0)
       assert.strictEqual(result[1].evseId, 1)
-      const connectors1 = result[1].evseStatus.connectors as unknown as ConnectorEntry[]
+      const connectors1 = result[1].evseStatus.connectors
       assert.strictEqual(connectors1.length, 1)
       assert.strictEqual(connectors1[0].connectorId, 1)
       assert.ok(!('transactionEndedMeterValues' in connectors1[0].connectorStatus))
@@ -600,7 +600,7 @@ await describe('ChargingStationConfigurationUtils', async () => {
       assert.strictEqual(result.length, 2)
       assert.strictEqual(result[0].evseId, 0)
       assert.strictEqual(result[1].evseId, 3)
-      const connectors3 = result[1].evseStatus.connectors as unknown as ConnectorEntry[]
+      const connectors3 = result[1].evseStatus.connectors
       assert.strictEqual(connectors3.length, 2)
       assert.ok(connectors3.some(c => c.connectorId === 2))
       assert.ok(connectors3.some(c => c.connectorId === 5))


### PR DESCRIPTION
## PR Checklist

- [x] Please add a description of your changes.
- [x] Please ensure title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] We need your changes to come with unit tests in order to keep this project in quality and easy to maintain.
- [x] If your changes contain any new feature please be sure to document it. (N/A — bug fix, no new tunable/behavior)
- [x] Please add a link to the open issue or task that this pull request will resolve.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

---

Closes #2046

### Root cause (proven)

Producer/consumer type-contract mismatch on `evseStatus.connectors`.

- Producer `buildEvseEntries` (`src/utils/ChargingStationConfigurationUtils.ts` L88-102) emits `connectors` as an **array** of `{ connectorId, connectorStatus, evseId }`, laundered by `.toArray() as unknown as EvseEntry[]`, which hides the mismatch from the compiler.
- The declared type `EvseStatus.connectors` (`src/types/Evse.ts`) is a `Map`, and `ChargingStationData.evses` was `EvseEntry[]`.
- On a live scrape the metrics consumer `iterateConnectors` (`src/charging-station/ui-server/AbstractUIServer.ts` L1560) tuple-destructured each element as a `Map` entry (`for (const [connectorId, connectorStatus] of …)`). A plain object is not iterable, so this throws `TypeError: … is not iterable` inside `Gauge.collect` → `Registry.metrics()` rejects → **HTTP 500**.
- Secondary silent defect: `countConnectors` (L1542) used `.size` on the array → `undefined`/`NaN` for `simulator_station_connectors_total`.

The existing unit test passed only because it hand-built `connectors` as a real `Map` (the declared type), never the array shape the producer emits over the worker broadcast channel; the `as unknown as` cast blocked compile-time detection. The failure only surfaced on a live scrape. OCPP 1.6 was unaffected (its `data.connectors` path yields `ConnectorEntry` objects without destructuring).

**Proof** (real `buildEvseEntries` output through the real consumer):

```
PRE-FIX  countConnectors    -> NaN
PRE-FIX  iterateConnectors  -> THREW TypeError: ... is not iterable   (=> HTTP 500)
POST-FIX countConnectors    -> 3
POST-FIX iterateConnectors  -> 3 entries
```

### Fix

Keep the array on the wire (the Web UI and CLI already consume `evseStatus.connectors` as an array over the JSON WebSocket wire, where a `Map` would `JSON.stringify` to `{}`; the worker→main hop uses structured clone, which would preserve a `Map`, but the array is the UI/CLI wire contract), and make the compiler enforce it end to end:

- New dedicated wire types `EvseEntryData` / `EvseStatusData` (`connectors: ConnectorEntry[]`) in `src/types/Evse.ts`; the in-memory `EvseStatus`/`EvseEntry` (Map) are unchanged.
- `ChargingStationData.evses: EvseEntryData[]`; `buildEvseEntries(): EvseEntryData[]` with the `as unknown as` cast dropped so the shape is enforced end to end.
- `countConnectors`: `.size` → `.length`; `iterateConnectors`: `for (const entry of evse.evseStatus.connectors) { yield entry }`.
- `EvseEntryData`/`EvseStatusData` are `readonly` immutable wire snapshots, JSDoc-documented (including why `MeterValues` is intentionally omitted: the producer never emits it and no UI-facing consumer reads it off the wire).

### Tests

- New regression tests feed the **actual** `buildEvseEntries` output through the `/metrics` scrape (not a synthetic `Map`): assert HTTP 200, `simulator_station_connectors_total = 3` (summed across EVSEs, not `NaN`), and a `simulator_connector_status_info … 1` line. They fail pre-fix (500/NaN) and pass post-fix. Plus edge cases: connector/EVSE id 0 counted; an EVSE with an **empty connectors array** → `0` (the case that pre-fix read `.size` on `[]` → `NaN`; a zero-EVSE `reduce` short-circuits and never exercised it).
- Migrated the existing EVSE-mode test off its synthetic `Map` fixture (which masked the defect) to the array shape, using `satisfies` so a Map/array drift is caught at compile time; the producer-driven stub is typed `Pick<ChargingStation, 'iterateEvses'>` instead of `as unknown as`.

### Risk / regression assessment

- Backend-only type reconciliation; the runtime JSON wire shape is unchanged (already an array). No behavior change beyond the fix.
- No breaking change: in-memory `EvseStatus` (Map) and its consumers (`iterateEvses`, OCPP services) are untouched; `ui-common`/CLI/Web already expect the array shape.
- Quality gates green: `tsc --noEmit` (root + `ui/common` + `ui/web` + `ui/cli`), ESLint, build, and the full test suite (0 failures).