### PR TITLE
feat(simulator): share invariant stationInfo fields via flyweight cache

### DIFF
--- a/src/charging-station/ChargingStation.ts
+++ b/src/charging-station/ChargingStation.ts
@@ -144,6 +144,7 @@ import {
   hasFeatureProfile,
   hasReservationExpired,
   initializeConnectorsMapStatus,
+  internStationInfoInvariants,
   prepareConnectorStatus,
   propagateSerialNumber,
   setChargingStationOptions,
@@ -1707,6 +1708,7 @@ export class ChargingStation extends EventEmitter {
       mergeDeepRight(Constants.DEFAULT_STATION_INFO as ChargingStationInfo, stationInfo),
       options
     )
+    internStationInfoInvariants(stationInfo)
     stationInfo.chargingStationId = getChargingStationId(this.index, stationInfo)
     stationInfo.hashId = getHashId(this.index, stationTemplate, stationInfo.chargingStationId)
     return stationInfo

--- a/src/charging-station/Helpers.ts
+++ b/src/charging-station/Helpers.ts
@@ -65,6 +65,7 @@ export {
   hasReservationExpired,
   removeExpiredReservations,
 } from './HelpersReservation.js'
+export { internStationInfoInvariants } from './StationInfoInvariants.js'
 
 export const checkChargingStationState = (
   chargingStation: ChargingStation,

--- a/src/charging-station/StationInfoInvariants.ts
+++ b/src/charging-station/StationInfoInvariants.ts
@@ -101,5 +101,9 @@ export const internStationInfoInvariants = (stationInfo: ChargingStationInfo): v
     sharedInvariants = deepFreeze(clone(projection))
     invariantsCache.set(invariantsHash, sharedInvariants)
   }
+  // A cache hit implies a byte-identical projection, so sharedInvariants holds
+  // exactly this projection's keys. Object.assign preserves per-station key
+  // order; per-key assignment is deliberately avoided — it would write
+  // undefined for any key missing from a (hypothetically) collided graph.
   Object.assign(stationInfo, sharedInvariants)
 }

--- a/src/charging-station/StationInfoInvariants.ts
+++ b/src/charging-station/StationInfoInvariants.ts
@@ -5,9 +5,10 @@
  * @description Shares (flyweight design pattern) the object-valued `stationInfo`
  *   fields that are invariant across all charging stations built from the same
  *   template, instead of duplicating them per instance. On a cache miss a
- *   deep-frozen clone of the invariant projection is stored, keyed by a content
- *   hash of the projection; every subsequent same-content station reuses the
- *   same frozen object graph by reference. `internStationInfoInvariants` is
+ *   deep-frozen clone of the invariant projection is cached through weak
+ *   references, keyed by a content hash of the projection; every subsequent
+ *   same-content station reuses the same frozen object graph by reference while
+ *   at least one station still retains it. `internStationInfoInvariants` is
  *   re-exported from `./Helpers.js`.
  *
  *   Scope decisions (issue #92):
@@ -45,18 +46,87 @@ const INVARIANT_STATION_INFO_OBJECT_KEYS = [
 ] as const satisfies readonly (keyof ChargingStationInfo)[]
 
 /**
- * Per-worker registry: invariants content hash -> deep-frozen invariant graph.
- * The key space is bounded by the number of distinct invariant contents (at
- * most one per template variant), so an unbounded `Map` cannot leak
- * meaningfully; unbounded (rather than an LRU) also guarantees a stable shared
- * identity for the lifetime of the worker.
+ * Weak references to the object values of one deep-frozen invariant projection.
+ * Stations retain these values directly after `Object.assign`; the transient
+ * projection container itself is therefore deliberately not used as the weak
+ * target.
  */
-const invariantsCache = new Map<string, Readonly<Record<string, unknown>>>()
+interface FinalizedInvariantsCacheEntry {
+  readonly cacheEntry: InvariantsCacheEntry
+  readonly invariantsHash: string
+}
+
+interface InvariantsCacheEntry {
+  readonly references: Readonly<Record<string, WeakRef<object>>>
+}
+
+/**
+ * Per-worker weak-value registry: invariants content hash -> invariant object
+ * references. A late finalizer can observe a replacement under the same hash,
+ * so deletion is guarded by cache-entry identity.
+ */
+const invariantsCache = new Map<string, InvariantsCacheEntry>()
+
+const invariantsFinalizationRegistry = new FinalizationRegistry<FinalizedInvariantsCacheEntry>(
+  ({ cacheEntry, invariantsHash }) => {
+    if (invariantsCache.get(invariantsHash) === cacheEntry) {
+      invariantsCache.delete(invariantsHash)
+      invariantsFinalizationRegistry.unregister(cacheEntry)
+    }
+  }
+)
+
+const cacheSharedInvariants = (
+  invariantsHash: string,
+  sharedInvariants: Readonly<Record<string, unknown>>
+): void => {
+  const references: Record<string, WeakRef<object>> = {}
+  for (const [key, value] of Object.entries(sharedInvariants)) {
+    // ChargingStationInfo types and template validation constrain every selected
+    // invariant to an object. Fail open for a malformed direct caller: it still
+    // receives the frozen clone, but the invalid projection is not cached.
+    if (value == null || typeof value !== 'object') {
+      return
+    }
+    references[key] = new WeakRef(value)
+  }
+  const cacheEntry: InvariantsCacheEntry = { references }
+  invariantsCache.set(invariantsHash, cacheEntry)
+  for (const reference of Object.values(references)) {
+    const value = reference.deref()
+    if (value != null) {
+      invariantsFinalizationRegistry.register(value, { cacheEntry, invariantsHash }, cacheEntry)
+    }
+  }
+}
+
+const getSharedInvariants = (
+  invariantsHash: string
+): Readonly<Record<string, unknown>> | undefined => {
+  const cacheEntry = invariantsCache.get(invariantsHash)
+  if (cacheEntry == null) {
+    return undefined
+  }
+  const sharedInvariants: Record<string, unknown> = {}
+  for (const [key, reference] of Object.entries(cacheEntry.references)) {
+    const value = reference.deref()
+    if (value == null) {
+      invariantsFinalizationRegistry.unregister(cacheEntry)
+      invariantsCache.delete(invariantsHash)
+      return undefined
+    }
+    sharedInvariants[key] = value
+  }
+  return sharedInvariants
+}
 
 /**
  * Clears the per-worker invariants cache. Test-only isolation helper.
  */
 export const clearStationInfoInvariantsCache = (): void => {
+  for (const cacheEntry of invariantsCache.values()) {
+    invariantsFinalizationRegistry.unregister(cacheEntry)
+  }
   invariantsCache.clear()
 }
 
@@ -82,7 +152,7 @@ export const internStationInfoInvariants = (stationInfo: ChargingStationInfo): v
       Object.hasOwn(stationInfo, key) &&
       // Skip a field still pointing at the shared DEFAULT reference: it is
       // already deduped, and interning it would only add hashing cost.
-      !Object.is(value, Constants.DEFAULT_STATION_INFO[key])
+      !Object.is(value, (Constants.DEFAULT_STATION_INFO as Partial<ChargingStationInfo>)[key])
     ) {
       projection[key] = value
     }
@@ -94,12 +164,12 @@ export const internStationInfoInvariants = (stationInfo: ChargingStationInfo): v
   // identical key <=> shared identity. Any difference forks its own entry, so
   // reusing an interned graph can never alter a station's serialized bytes.
   const invariantsHash = hash(Constants.DEFAULT_HASH_ALGORITHM, JSON.stringify(projection), 'hex')
-  let sharedInvariants = invariantsCache.get(invariantsHash)
+  let sharedInvariants = getSharedInvariants(invariantsHash)
   if (sharedInvariants == null) {
     // Clone before freezing so the shared graph is independent of the station's
     // (or any file/LRU-cache-aliased) mutable field references.
     sharedInvariants = deepFreeze(clone(projection))
-    invariantsCache.set(invariantsHash, sharedInvariants)
+    cacheSharedInvariants(invariantsHash, sharedInvariants)
   }
   // Object.assign copies only the keys present in sharedInvariants and preserves
   // per-station insertion order. A per-key loop over

--- a/src/charging-station/StationInfoInvariants.ts
+++ b/src/charging-station/StationInfoInvariants.ts
@@ -7,7 +7,8 @@
  *   template, instead of duplicating them per instance. On a cache miss a
  *   deep-frozen clone of the invariant projection is stored, keyed by a content
  *   hash of the projection; every subsequent same-content station reuses the
- *   same frozen object graph by reference. Re-exported from `./Helpers.js`.
+ *   same frozen object graph by reference. `internStationInfoInvariants` is
+ *   re-exported from `./Helpers.js`.
  *
  *   Scope decisions (issue #92):
  *   - Only object-valued invariant fields yield memory savings; primitive fields
@@ -53,8 +54,7 @@ const INVARIANT_STATION_INFO_OBJECT_KEYS = [
 const invariantsCache = new Map<string, Readonly<Record<string, unknown>>>()
 
 /**
- * Clears the per-worker invariants cache. Test-only isolation helper mirroring
- * {@link SharedLRUCache.clear}.
+ * Clears the per-worker invariants cache. Test-only isolation helper.
  */
 export const clearStationInfoInvariantsCache = (): void => {
   invariantsCache.clear()

--- a/src/charging-station/StationInfoInvariants.ts
+++ b/src/charging-station/StationInfoInvariants.ts
@@ -1,0 +1,105 @@
+// Partial Copyright Jerome Benoit. 2021-2025. All Rights Reserved.
+
+/**
+ * @file Station-info invariants flyweight.
+ * @description Shares (flyweight design pattern) the object-valued `stationInfo`
+ *   fields that are invariant across all charging stations built from the same
+ *   template, instead of duplicating them per instance. On a cache miss a
+ *   deep-frozen clone of the invariant projection is stored, keyed by a content
+ *   hash of the projection; every subsequent same-content station reuses the
+ *   same frozen object graph by reference. Re-exported from `./Helpers.js`.
+ *
+ *   Scope decisions (issue #92):
+ *   - Only object-valued invariant fields yield memory savings; primitive fields
+ *     are copied by value regardless, so they are not interned.
+ *   - `wsOptions` is EXCLUDED: it is spread into the ws client options and may
+ *     carry function-valued members, which are neither structured-cloneable nor
+ *     safe to deep-freeze.
+ *   - A field still pointing at the shared `DEFAULT_STATION_INFO` reference is
+ *     skipped (already deduped by `mergeDeepRight`, nothing to gain).
+ *   - Mutable/per-instance fields (`firmwareVersion`, `firmwareStatus`,
+ *     `supervisionUrls`, serial numbers, ids, `maximumPower`/`maximumAmperage`)
+ *     are never interned; they stay own primitive properties of `stationInfo`.
+ *
+ *   The cache is a per-worker module singleton: worker threads do not share the
+ *   JS heap, so sharing is effective only within a worker running several
+ *   stations from the same template.
+ */
+
+import { hash } from 'node:crypto'
+
+import type { ChargingStationInfo } from '../types/index.js'
+
+import { clone, Constants, deepFreeze } from '../utils/index.js'
+
+/**
+ * Object-valued `stationInfo` fields interned by the flyweight. These derive
+ * purely from the template (never mutated at runtime, never per-instance
+ * randomized), so all stations from the same template hold identical content.
+ */
+const INVARIANT_STATION_INFO_OBJECT_KEYS = [
+  'commandsSupport',
+  'firmwareUpgrade',
+  'messageTriggerSupport',
+] as const satisfies readonly (keyof ChargingStationInfo)[]
+
+/**
+ * Per-worker registry: invariants content hash -> deep-frozen invariant graph.
+ * The key space is bounded by the number of distinct invariant contents (at
+ * most one per template variant), so an unbounded `Map` cannot leak
+ * meaningfully; unbounded (rather than an LRU) also guarantees a stable shared
+ * identity for the lifetime of the worker.
+ */
+const invariantsCache = new Map<string, Readonly<Record<string, unknown>>>()
+
+/**
+ * Clears the per-worker invariants cache. Test-only isolation helper mirroring
+ * {@link SharedLRUCache.clear}.
+ */
+export const clearStationInfoInvariantsCache = (): void => {
+  invariantsCache.clear()
+}
+
+/**
+ * Replaces the object-valued invariant fields of `stationInfo` with references
+ * to a shared, deep-frozen invariant graph, in place. No-op when the station
+ * declares none of the interned fields (the common shipped-template case), so
+ * no hash is computed and nothing is allocated.
+ *
+ * Serialization is preserved byte-for-byte: only already-present own keys are
+ * reassigned (property insertion order is unchanged) and the interned value is
+ * a structured clone of the actual built field (nested key order preserved), so
+ * `JSON.stringify(stationInfo)` and therefore the persisted `configurationHash`
+ * are identical to the pre-interning output.
+ * @param stationInfo - Station info to intern in place.
+ */
+export const internStationInfoInvariants = (stationInfo: ChargingStationInfo): void => {
+  const projection: Record<string, unknown> = {}
+  for (const key of INVARIANT_STATION_INFO_OBJECT_KEYS) {
+    const value = stationInfo[key]
+    if (
+      value != null &&
+      Object.hasOwn(stationInfo, key) &&
+      // Skip a field still pointing at the shared DEFAULT reference: it is
+      // already deduped, and interning it would only add hashing cost.
+      !Object.is(value, Constants.DEFAULT_STATION_INFO[key])
+    ) {
+      projection[key] = value
+    }
+  }
+  if (Object.keys(projection).length === 0) {
+    return
+  }
+  // Insertion-order (non-canonicalized) hash: byte-identical serialization <=>
+  // identical key <=> shared identity. Any difference forks its own entry, so
+  // reusing an interned graph can never alter a station's serialized bytes.
+  const invariantsHash = hash(Constants.DEFAULT_HASH_ALGORITHM, JSON.stringify(projection), 'hex')
+  let sharedInvariants = invariantsCache.get(invariantsHash)
+  if (sharedInvariants == null) {
+    // Clone before freezing so the shared graph is independent of the station's
+    // (or any file/LRU-cache-aliased) mutable field references.
+    sharedInvariants = deepFreeze(clone(projection))
+    invariantsCache.set(invariantsHash, sharedInvariants)
+  }
+  Object.assign(stationInfo, sharedInvariants)
+}

--- a/src/charging-station/StationInfoInvariants.ts
+++ b/src/charging-station/StationInfoInvariants.ts
@@ -5,10 +5,9 @@
  * @description Shares (flyweight design pattern) the object-valued `stationInfo`
  *   fields that are invariant across all charging stations built from the same
  *   template, instead of duplicating them per instance. On a cache miss a
- *   deep-frozen clone of the invariant projection is cached through weak
- *   references, keyed by a content hash of the projection; every subsequent
- *   same-content station reuses the same frozen object graph by reference while
- *   at least one station still retains it. `internStationInfoInvariants` is
+ *   deep-frozen clone of the invariant projection is stored, keyed by a content
+ *   hash of the projection; every subsequent same-content station reuses the
+ *   same frozen object graph by reference. `internStationInfoInvariants` is
  *   re-exported from `./Helpers.js`.
  *
  *   Scope decisions (issue #92):
@@ -46,87 +45,18 @@ const INVARIANT_STATION_INFO_OBJECT_KEYS = [
 ] as const satisfies readonly (keyof ChargingStationInfo)[]
 
 /**
- * Weak references to the object values of one deep-frozen invariant projection.
- * Stations retain these values directly after `Object.assign`; the transient
- * projection container itself is therefore deliberately not used as the weak
- * target.
+ * Per-worker registry: invariants content hash -> deep-frozen invariant graph.
+ * The key space is bounded by the number of distinct invariant contents (at
+ * most one per template variant), so an unbounded `Map` cannot leak
+ * meaningfully; unbounded (rather than an LRU) also guarantees a stable shared
+ * identity for the lifetime of the worker.
  */
-interface FinalizedInvariantsCacheEntry {
-  readonly cacheEntry: InvariantsCacheEntry
-  readonly invariantsHash: string
-}
-
-interface InvariantsCacheEntry {
-  readonly references: Readonly<Record<string, WeakRef<object>>>
-}
-
-/**
- * Per-worker weak-value registry: invariants content hash -> invariant object
- * references. A late finalizer can observe a replacement under the same hash,
- * so deletion is guarded by cache-entry identity.
- */
-const invariantsCache = new Map<string, InvariantsCacheEntry>()
-
-const invariantsFinalizationRegistry = new FinalizationRegistry<FinalizedInvariantsCacheEntry>(
-  ({ cacheEntry, invariantsHash }) => {
-    if (invariantsCache.get(invariantsHash) === cacheEntry) {
-      invariantsCache.delete(invariantsHash)
-      invariantsFinalizationRegistry.unregister(cacheEntry)
-    }
-  }
-)
-
-const cacheSharedInvariants = (
-  invariantsHash: string,
-  sharedInvariants: Readonly<Record<string, unknown>>
-): void => {
-  const references: Record<string, WeakRef<object>> = {}
-  for (const [key, value] of Object.entries(sharedInvariants)) {
-    // ChargingStationInfo types and template validation constrain every selected
-    // invariant to an object. Fail open for a malformed direct caller: it still
-    // receives the frozen clone, but the invalid projection is not cached.
-    if (value == null || typeof value !== 'object') {
-      return
-    }
-    references[key] = new WeakRef(value)
-  }
-  const cacheEntry: InvariantsCacheEntry = { references }
-  invariantsCache.set(invariantsHash, cacheEntry)
-  for (const reference of Object.values(references)) {
-    const value = reference.deref()
-    if (value != null) {
-      invariantsFinalizationRegistry.register(value, { cacheEntry, invariantsHash }, cacheEntry)
-    }
-  }
-}
-
-const getSharedInvariants = (
-  invariantsHash: string
-): Readonly<Record<string, unknown>> | undefined => {
-  const cacheEntry = invariantsCache.get(invariantsHash)
-  if (cacheEntry == null) {
-    return undefined
-  }
-  const sharedInvariants: Record<string, unknown> = {}
-  for (const [key, reference] of Object.entries(cacheEntry.references)) {
-    const value = reference.deref()
-    if (value == null) {
-      invariantsFinalizationRegistry.unregister(cacheEntry)
-      invariantsCache.delete(invariantsHash)
-      return undefined
-    }
-    sharedInvariants[key] = value
-  }
-  return sharedInvariants
-}
+const invariantsCache = new Map<string, Readonly<Record<string, unknown>>>()
 
 /**
  * Clears the per-worker invariants cache. Test-only isolation helper.
  */
 export const clearStationInfoInvariantsCache = (): void => {
-  for (const cacheEntry of invariantsCache.values()) {
-    invariantsFinalizationRegistry.unregister(cacheEntry)
-  }
   invariantsCache.clear()
 }
 
@@ -164,12 +94,12 @@ export const internStationInfoInvariants = (stationInfo: ChargingStationInfo): v
   // identical key <=> shared identity. Any difference forks its own entry, so
   // reusing an interned graph can never alter a station's serialized bytes.
   const invariantsHash = hash(Constants.DEFAULT_HASH_ALGORITHM, JSON.stringify(projection), 'hex')
-  let sharedInvariants = getSharedInvariants(invariantsHash)
+  let sharedInvariants = invariantsCache.get(invariantsHash)
   if (sharedInvariants == null) {
     // Clone before freezing so the shared graph is independent of the station's
     // (or any file/LRU-cache-aliased) mutable field references.
     sharedInvariants = deepFreeze(clone(projection))
-    cacheSharedInvariants(invariantsHash, sharedInvariants)
+    invariantsCache.set(invariantsHash, sharedInvariants)
   }
   // Object.assign copies only the keys present in sharedInvariants and preserves
   // per-station insertion order. A per-key loop over

--- a/src/charging-station/StationInfoInvariants.ts
+++ b/src/charging-station/StationInfoInvariants.ts
@@ -101,9 +101,9 @@ export const internStationInfoInvariants = (stationInfo: ChargingStationInfo): v
     sharedInvariants = deepFreeze(clone(projection))
     invariantsCache.set(invariantsHash, sharedInvariants)
   }
-  // A cache hit implies a byte-identical projection, so sharedInvariants holds
-  // exactly this projection's keys. Object.assign preserves per-station key
-  // order; per-key assignment is deliberately avoided — it would write
-  // undefined for any key missing from a (hypothetically) collided graph.
+  // Object.assign copies only the keys present in sharedInvariants and preserves
+  // per-station insertion order. A per-key loop over
+  // INVARIANT_STATION_INFO_OBJECT_KEYS is avoided: for a narrower (subset) entry
+  // it would write undefined for the absent keys, injecting foreign own keys.
   Object.assign(stationInfo, sharedInvariants)
 }

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -2,15 +2,26 @@ import {
   type AutomaticTransactionGeneratorConfiguration,
   type ChargingStationInfo,
   CurrentType,
+  type FirmwareUpgrade,
   OCPPVersion,
   VendorParametersKey,
 } from '../types/index.js'
-import { deepFreeze } from './DeepFreeze.js'
+import { deepFreeze, type DeepReadonly } from './DeepFreeze.js'
 
 // Shared literals for class-static members below (TS2729 forbids static
 // forward-reference).
 const DAY_IN_MS = 86_400_000
 const DAY_IN_SECONDS = 86_400
+
+type DefaultFirmwareUpgrade = DeepReadonly<
+  Required<Pick<FirmwareUpgrade, 'reset' | 'versionUpgrade'>> & {
+    versionUpgrade: Required<Pick<NonNullable<FirmwareUpgrade['versionUpgrade']>, 'step'>>
+  }
+>
+
+type DefaultStationInfo = Readonly<Omit<Partial<ChargingStationInfo>, 'firmwareUpgrade'>> & {
+  readonly firmwareUpgrade: DefaultFirmwareUpgrade
+}
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class Constants {
@@ -79,7 +90,7 @@ export class Constants {
   /** Default cache TTL for remote authorization results, distinct from `DEFAULT_AUTH_CACHE_TTL_SECONDS` (3600, local cache default). */
   static readonly DEFAULT_REMOTE_AUTH_CACHE_TTL_SECONDS = 300
 
-  static readonly DEFAULT_STATION_INFO: Readonly<Partial<ChargingStationInfo>> = deepFreeze({
+  static readonly DEFAULT_STATION_INFO: DefaultStationInfo = deepFreeze({
     automaticTransactionGeneratorPersistentConfiguration: true,
     autoReconnectMaxRetries: -1,
     autoStart: true,
@@ -115,7 +126,7 @@ export class Constants {
     supervisionUrlOcppKey: VendorParametersKey.ConnectionUrl,
     transactionDataMeterValues: false,
     useConnectorId0: true,
-  })
+  } satisfies Partial<ChargingStationInfo>)
 
   static readonly DEFAULT_TX_UPDATED_INTERVAL_SECONDS = 30
 

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -5,6 +5,7 @@ import {
   OCPPVersion,
   VendorParametersKey,
 } from '../types/index.js'
+import { deepFreeze } from './DeepFreeze.js'
 
 // Shared literals for class-static members below (TS2729 forbids static
 // forward-reference).
@@ -78,7 +79,7 @@ export class Constants {
   /** Default cache TTL for remote authorization results, distinct from `DEFAULT_AUTH_CACHE_TTL_SECONDS` (3600, local cache default). */
   static readonly DEFAULT_REMOTE_AUTH_CACHE_TTL_SECONDS = 300
 
-  static readonly DEFAULT_STATION_INFO: Readonly<Partial<ChargingStationInfo>> = Object.freeze({
+  static readonly DEFAULT_STATION_INFO: Readonly<Partial<ChargingStationInfo>> = deepFreeze({
     automaticTransactionGeneratorPersistentConfiguration: true,
     autoReconnectMaxRetries: -1,
     autoStart: true,

--- a/src/utils/DeepFreeze.ts
+++ b/src/utils/DeepFreeze.ts
@@ -20,8 +20,14 @@ const deepFreezeInto = (object: unknown, seen: WeakSet<object>): void => {
   }
   // Mark before recursing so self-referential graphs terminate.
   seen.add(object)
-  for (const value of Object.values(object)) {
-    deepFreezeInto(value, seen)
+  for (const key of Reflect.ownKeys(object)) {
+    const descriptor = Object.getOwnPropertyDescriptor(object, key)
+    // Recurse into own data properties only (incl. symbol-keyed and
+    // non-enumerable); accessor properties are never read — a getter's
+    // transient return cannot be meaningfully frozen.
+    if (descriptor != null && 'value' in descriptor) {
+      deepFreezeInto(descriptor.value, seen)
+    }
   }
   // Freeze after children so the whole reachable graph is frozen even when the
   // input node was already (shallow-)frozen.
@@ -30,9 +36,11 @@ const deepFreezeInto = (object: unknown, seen: WeakSet<object>): void => {
 
 /**
  * Recursively freezes an object graph in place and returns the same reference.
- * Freezes the entire reachable graph of own enumerable object values, including
- * the children of an already (shallow-)frozen input; cycle-safe via a visited
- * set; a no-op for non-objects (primitives and `null` are returned unchanged).
+ * Freezes every own data property (enumerable and non-enumerable, string- and
+ * symbol-keyed) of the reachable graph, including the children of an already
+ * (shallow-)frozen input; cycle-safe via a visited set. Accessor properties are
+ * not traversed. A no-op for non-objects (primitives and `null` are returned
+ * unchanged).
  * @param object - Value to deep-freeze.
  * @returns The same `object` reference, deeply frozen when it is an object.
  * @template T - Type of the value, preserved on return.

--- a/src/utils/DeepFreeze.ts
+++ b/src/utils/DeepFreeze.ts
@@ -19,23 +19,25 @@
  * Runtime-opaque mutable containers keep their original type because
  * `Object.freeze` cannot make their internal slots or backing storage immutable.
  */
-export type DeepReadonly<T> = T extends (...arguments_: never[]) => unknown
+export type DeepReadonly<T> = T extends abstract new (...arguments_: never[]) => unknown
   ? T
-  : T extends ArrayBuffer | ArrayBufferView | Date | RegExp | SharedArrayBuffer
+  : T extends (...arguments_: never[]) => unknown
     ? T
-    : T extends ReadonlyMap<infer _Key, infer _Value>
+    : T extends ArrayBuffer | ArrayBufferView | Date | RegExp | SharedArrayBuffer
       ? T
-      : T extends ReadonlySet<infer _Value>
+      : T extends ReadonlyMap<infer _Key, infer _Value>
         ? T
-        : T extends WeakMap<infer _Key extends object, infer _Value>
+        : T extends ReadonlySet<infer _Value>
           ? T
-          : T extends WeakSet<infer _Value extends object>
+          : T extends WeakMap<infer _Key extends object, infer _Value>
             ? T
-            : T extends readonly unknown[]
-              ? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
-              : T extends object
+            : T extends WeakSet<infer _Value extends object>
+              ? T
+              : T extends readonly unknown[]
                 ? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
-                : T
+                : T extends object
+                  ? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
+                  : T
 
 const deepFreezeInto = (object: unknown, seen: WeakSet<object>): void => {
   if (object == null || typeof object !== 'object' || seen.has(object)) {

--- a/src/utils/DeepFreeze.ts
+++ b/src/utils/DeepFreeze.ts
@@ -14,6 +14,29 @@
  *   field frozen during module evaluation).
  */
 
+/**
+ * Deeply readonly view of an object graph frozen by {@link deepFreeze}.
+ * Runtime-opaque mutable containers keep their original type because
+ * `Object.freeze` cannot make their internal slots or backing storage immutable.
+ */
+export type DeepReadonly<T> = T extends (...arguments_: never[]) => unknown
+  ? T
+  : T extends ArrayBuffer | ArrayBufferView | Date | RegExp | SharedArrayBuffer
+    ? T
+    : T extends ReadonlyMap<infer _Key, infer _Value>
+      ? T
+      : T extends ReadonlySet<infer _Value>
+        ? T
+        : T extends WeakMap<infer _Key extends object, infer _Value>
+          ? T
+          : T extends WeakSet<infer _Value extends object>
+            ? T
+            : T extends readonly unknown[]
+              ? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
+              : T extends object
+                ? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
+                : T
+
 const deepFreezeInto = (object: unknown, seen: WeakSet<object>): void => {
   if (object == null || typeof object !== 'object' || seen.has(object)) {
     return
@@ -48,12 +71,15 @@ const deepFreezeInto = (object: unknown, seen: WeakSet<object>): void => {
  * unchanged). Array-buffer views (typed arrays, `DataView`) are treated as
  * opaque leaves and left unfrozen. `Map`/`Set` objects are frozen, but their
  * entries are not traversed and `Object.freeze` does not prevent `set`/`add`/
- * `delete`/`clear`.
+ * `delete`/`clear`. These opaque mutable containers retain their mutable
+ * TypeScript type; plain objects and arrays are returned as
+ * {@link DeepReadonly} graphs.
  * @param object - Value to deep-freeze.
- * @returns The same `object` reference, deeply frozen when it is an object.
+ * @returns The same `object` reference with a deeply readonly type for the
+ *   object and array shapes that are deeply frozen.
  * @template T - Type of the value, preserved on return.
  */
-export const deepFreeze = <T>(object: T): T => {
+export const deepFreeze = <T>(object: T): DeepReadonly<T> => {
   deepFreezeInto(object, new WeakSet())
-  return object
+  return object as DeepReadonly<T>
 }

--- a/src/utils/DeepFreeze.ts
+++ b/src/utils/DeepFreeze.ts
@@ -1,0 +1,43 @@
+/**
+ * @file Recursive object-freezing utility.
+ * @description Leaf module providing {@link deepFreeze}, a recursive,
+ *   identity-preserving, idempotent deep `Object.freeze`. Consumed both by
+ *   `./Constants.js` (to deep-freeze `DEFAULT_STATION_INFO`) and by the
+ *   station-info invariants flyweight
+ *   (`../charging-station/StationInfoInvariants.js`).
+ *
+ * IMPORTANT: this module MUST remain import-free. `./Constants.js` imports it
+ *   directly (not through the `./index.js` barrel) and is itself imported by
+ *   `./Utils.js`; any import added here that transitively reaches `Constants`
+ *   or `Utils` would reintroduce a module-initialization cycle whose temporal
+ *   dead zone crashes at load time (`DEFAULT_STATION_INFO` is a class-static
+ *   field frozen during module evaluation).
+ */
+
+const deepFreezeInto = (object: unknown, seen: WeakSet<object>): void => {
+  if (object == null || typeof object !== 'object' || seen.has(object)) {
+    return
+  }
+  // Mark before recursing so self-referential graphs terminate.
+  seen.add(object)
+  for (const value of Object.values(object)) {
+    deepFreezeInto(value, seen)
+  }
+  // Freeze after children so the whole reachable graph is frozen even when the
+  // input node was already (shallow-)frozen.
+  Object.freeze(object)
+}
+
+/**
+ * Recursively freezes an object graph in place and returns the same reference.
+ * Freezes the entire reachable graph of own enumerable object values, including
+ * the children of an already (shallow-)frozen input; cycle-safe via a visited
+ * set; a no-op for non-objects (primitives and `null` are returned unchanged).
+ * @param object - Value to deep-freeze.
+ * @returns The same `object` reference, deeply frozen when it is an object.
+ * @template T - Type of the value, preserved on return.
+ */
+export const deepFreeze = <T>(object: T): T => {
+  deepFreezeInto(object, new WeakSet())
+  return object
+}

--- a/src/utils/DeepFreeze.ts
+++ b/src/utils/DeepFreeze.ts
@@ -18,6 +18,11 @@ const deepFreezeInto = (object: unknown, seen: WeakSet<object>): void => {
   if (object == null || typeof object !== 'object' || seen.has(object)) {
     return
   }
+  // Array-buffer views are opaque binary leaves: Object.freeze throws on a
+  // non-empty typed array, and freezing a view cannot lock its backing buffer.
+  if (ArrayBuffer.isView(object)) {
+    return
+  }
   // Mark before recursing so self-referential graphs terminate.
   seen.add(object)
   for (const key of Reflect.ownKeys(object)) {
@@ -40,7 +45,10 @@ const deepFreezeInto = (object: unknown, seen: WeakSet<object>): void => {
  * symbol-keyed) of the reachable graph, including the children of an already
  * (shallow-)frozen input; cycle-safe via a visited set. Accessor properties are
  * not traversed. A no-op for non-objects (primitives and `null` are returned
- * unchanged).
+ * unchanged). Array-buffer views (typed arrays, `DataView`) are treated as
+ * opaque leaves and left unfrozen. `Map`/`Set` objects are frozen, but their
+ * entries are not traversed and `Object.freeze` does not prevent `set`/`add`/
+ * `delete`/`clear`.
  * @param object - Value to deep-freeze.
  * @returns The same `object` reference, deeply frozen when it is an object.
  * @template T - Type of the value, preserved on return.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -31,7 +31,7 @@ export {
 } from './ConfigurationUtils.js'
 export { ConfigurationValidationError, validateConfiguration } from './ConfigurationValidation.js'
 export { Constants } from './Constants.js'
-export { deepFreeze } from './DeepFreeze.js'
+export { deepFreeze, type DeepReadonly } from './DeepFreeze.js'
 export { ACElectricUtils, DCElectricUtils } from './ElectricUtils.js'
 export {
   ensureError,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -31,6 +31,7 @@ export {
 } from './ConfigurationUtils.js'
 export { ConfigurationValidationError, validateConfiguration } from './ConfigurationValidation.js'
 export { Constants } from './Constants.js'
+export { deepFreeze } from './DeepFreeze.js'
 export { ACElectricUtils, DCElectricUtils } from './ElectricUtils.js'
 export {
   ensureError,

--- a/tests/charging-station/StationInfoInvariants.test.ts
+++ b/tests/charging-station/StationInfoInvariants.test.ts
@@ -134,4 +134,62 @@ await describe('StationInfoInvariants', async () => {
     assert.strictEqual(consumer.messageTriggerSupport, producer.messageTriggerSupport)
     assert.strictEqual(JSON.stringify(consumer), consumerBefore)
   })
+
+  await it('should not cross-bleed invariant keys across disjoint key-sets', () => {
+    const stationInfoA = buildStationInfo({
+      commandsSupport: {
+        incomingCommands: { Reset: true },
+      } as NonNullable<ChargingStationInfo['commandsSupport']>,
+    })
+    const stationInfoB = buildStationInfo({
+      messageTriggerSupport: {
+        Heartbeat: true,
+      } as NonNullable<ChargingStationInfo['messageTriggerSupport']>,
+    })
+
+    internStationInfoInvariants(stationInfoA)
+    internStationInfoInvariants(stationInfoB)
+
+    assert.strictEqual(stationInfoA.messageTriggerSupport, undefined)
+    assert.strictEqual(stationInfoB.commandsSupport, undefined)
+    assert.ok(stationInfoA.commandsSupport != null)
+    assert.ok(stationInfoB.messageTriggerSupport != null)
+  })
+
+  await it('should not inject a foreign invariant key on a partial cache-hit', () => {
+    const producer = buildStationInfo({
+      commandsSupport: {
+        incomingCommands: { Reset: true },
+      } as NonNullable<ChargingStationInfo['commandsSupport']>,
+      firmwareUpgrade: { reset: false, versionUpgrade: { step: 2 } },
+    })
+    const consumer = buildStationInfo({
+      firmwareUpgrade: { reset: false, versionUpgrade: { step: 2 } },
+    })
+    const consumerBefore = JSON.stringify(consumer)
+
+    internStationInfoInvariants(producer)
+    internStationInfoInvariants(consumer)
+
+    assert.strictEqual(Object.hasOwn(consumer, 'commandsSupport'), false)
+    assert.strictEqual(JSON.stringify(consumer), consumerBefore)
+  })
+
+  await it('should never set an interned key to undefined', () => {
+    const stationInfo = buildStationInfo({
+      commandsSupport: {
+        incomingCommands: { Reset: true },
+      } as NonNullable<ChargingStationInfo['commandsSupport']>,
+      firmwareUpgrade: { reset: false },
+      messageTriggerSupport: {
+        Heartbeat: true,
+      } as NonNullable<ChargingStationInfo['messageTriggerSupport']>,
+    })
+
+    internStationInfoInvariants(stationInfo)
+
+    assert.notStrictEqual(stationInfo.commandsSupport, undefined)
+    assert.notStrictEqual(stationInfo.firmwareUpgrade, undefined)
+    assert.notStrictEqual(stationInfo.messageTriggerSupport, undefined)
+  })
 })

--- a/tests/charging-station/StationInfoInvariants.test.ts
+++ b/tests/charging-station/StationInfoInvariants.test.ts
@@ -135,7 +135,7 @@ await describe('StationInfoInvariants', async () => {
     assert.strictEqual(JSON.stringify(consumer), consumerBefore)
   })
 
-  await it('should not cross-bleed invariant keys across disjoint key-sets', () => {
+  await it('should not cross-bleed invariant keys across disjoint same-size key-sets', () => {
     const stationInfoA = buildStationInfo({
       commandsSupport: {
         incomingCommands: { Reset: true },
@@ -150,13 +150,13 @@ await describe('StationInfoInvariants', async () => {
     internStationInfoInvariants(stationInfoA)
     internStationInfoInvariants(stationInfoB)
 
-    assert.strictEqual(stationInfoA.messageTriggerSupport, undefined)
-    assert.strictEqual(stationInfoB.commandsSupport, undefined)
+    assert.strictEqual(Object.hasOwn(stationInfoA, 'messageTriggerSupport'), false)
+    assert.strictEqual(Object.hasOwn(stationInfoB, 'commandsSupport'), false)
     assert.ok(stationInfoA.commandsSupport != null)
     assert.ok(stationInfoB.messageTriggerSupport != null)
   })
 
-  await it('should not inject a foreign invariant key on a partial cache-hit', () => {
+  await it('should not inject a foreign invariant key when interning a narrower key-set', () => {
     const producer = buildStationInfo({
       commandsSupport: {
         incomingCommands: { Reset: true },
@@ -173,23 +173,5 @@ await describe('StationInfoInvariants', async () => {
 
     assert.strictEqual(Object.hasOwn(consumer, 'commandsSupport'), false)
     assert.strictEqual(JSON.stringify(consumer), consumerBefore)
-  })
-
-  await it('should never set an interned key to undefined', () => {
-    const stationInfo = buildStationInfo({
-      commandsSupport: {
-        incomingCommands: { Reset: true },
-      } as NonNullable<ChargingStationInfo['commandsSupport']>,
-      firmwareUpgrade: { reset: false },
-      messageTriggerSupport: {
-        Heartbeat: true,
-      } as NonNullable<ChargingStationInfo['messageTriggerSupport']>,
-    })
-
-    internStationInfoInvariants(stationInfo)
-
-    assert.notStrictEqual(stationInfo.commandsSupport, undefined)
-    assert.notStrictEqual(stationInfo.firmwareUpgrade, undefined)
-    assert.notStrictEqual(stationInfo.messageTriggerSupport, undefined)
   })
 })

--- a/tests/charging-station/StationInfoInvariants.test.ts
+++ b/tests/charging-station/StationInfoInvariants.test.ts
@@ -14,6 +14,7 @@ import {
   internStationInfoInvariants,
 } from '../../src/charging-station/StationInfoInvariants.js'
 import { Constants } from '../../src/utils/index.js'
+import { standardCleanup } from '../helpers/TestLifecycleHelpers.js'
 
 const buildStationInfo = (overrides: Partial<ChargingStationInfo> = {}): ChargingStationInfo =>
   ({
@@ -25,6 +26,7 @@ const buildStationInfo = (overrides: Partial<ChargingStationInfo> = {}): Chargin
 
 await describe('StationInfoInvariants', async () => {
   afterEach(() => {
+    standardCleanup()
     clearStationInfoInvariantsCache()
   })
 

--- a/tests/charging-station/StationInfoInvariants.test.ts
+++ b/tests/charging-station/StationInfoInvariants.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @file Tests for StationInfoInvariants
+ * @description Unit tests for the stationInfo invariants flyweight: reference
+ *   sharing, deep-freeze immutability, provenance gate, wsOptions exclusion,
+ *   skip-when-empty, and serialization byte-identity.
+ */
+import assert from 'node:assert/strict'
+import { afterEach, describe, it } from 'node:test'
+
+import type { ChargingStationInfo } from '../../src/types/index.js'
+
+import {
+  clearStationInfoInvariantsCache,
+  internStationInfoInvariants,
+} from '../../src/charging-station/StationInfoInvariants.js'
+import { Constants } from '../../src/utils/index.js'
+
+const buildStationInfo = (overrides: Partial<ChargingStationInfo> = {}): ChargingStationInfo =>
+  ({
+    hashId: 'test-hash',
+    templateIndex: 0,
+    templateName: 'test-template',
+    ...overrides,
+  }) as ChargingStationInfo
+
+await describe('StationInfoInvariants', async () => {
+  afterEach(() => {
+    clearStationInfoInvariantsCache()
+  })
+
+  await it('should share an interned invariant object by reference across equal-content stations', () => {
+    const stationInfoA = buildStationInfo({
+      firmwareUpgrade: { reset: false, versionUpgrade: { step: 2 } },
+    })
+    const stationInfoB = buildStationInfo({
+      firmwareUpgrade: { reset: false, versionUpgrade: { step: 2 } },
+    })
+
+    internStationInfoInvariants(stationInfoA)
+    internStationInfoInvariants(stationInfoB)
+
+    assert.strictEqual(stationInfoA.firmwareUpgrade, stationInfoB.firmwareUpgrade)
+  })
+
+  await it('should not share invariant objects across different-content stations', () => {
+    const stationInfoA = buildStationInfo({ firmwareUpgrade: { reset: false } })
+    const stationInfoB = buildStationInfo({
+      firmwareUpgrade: { reset: true, versionUpgrade: { step: 5 } },
+    })
+
+    internStationInfoInvariants(stationInfoA)
+    internStationInfoInvariants(stationInfoB)
+
+    assert.notStrictEqual(stationInfoA.firmwareUpgrade, stationInfoB.firmwareUpgrade)
+  })
+
+  await it('should deep-freeze the interned invariant object', () => {
+    const stationInfo = buildStationInfo({
+      firmwareUpgrade: { reset: false, versionUpgrade: { step: 2 } },
+    })
+
+    internStationInfoInvariants(stationInfo)
+
+    const firmwareUpgrade = stationInfo.firmwareUpgrade
+    assert.ok(firmwareUpgrade != null)
+    assert.strictEqual(Object.isFrozen(firmwareUpgrade), true)
+    assert.throws(() => {
+      firmwareUpgrade.reset = true
+    }, TypeError)
+  })
+
+  await it('should skip a field still pointing at the shared DEFAULT reference', () => {
+    const stationInfo = buildStationInfo({
+      firmwareUpgrade: Constants.DEFAULT_STATION_INFO.firmwareUpgrade,
+    })
+
+    internStationInfoInvariants(stationInfo)
+
+    assert.strictEqual(stationInfo.firmwareUpgrade, Constants.DEFAULT_STATION_INFO.firmwareUpgrade)
+  })
+
+  await it('should not intern or freeze wsOptions', () => {
+    const wsOptions = { handshakeTimeout: 1000 }
+    const stationInfo = buildStationInfo({ wsOptions })
+
+    internStationInfoInvariants(stationInfo)
+
+    assert.strictEqual(stationInfo.wsOptions, wsOptions)
+    assert.strictEqual(Object.isFrozen(stationInfo.wsOptions), false)
+  })
+
+  await it('should be a no-op when no invariant object field is declared', () => {
+    const stationInfo = buildStationInfo({ chargePointModel: 'Model', chargePointVendor: 'Vendor' })
+    const before = JSON.stringify(stationInfo)
+
+    internStationInfoInvariants(stationInfo)
+
+    assert.strictEqual(JSON.stringify(stationInfo), before)
+    assert.strictEqual(stationInfo.firmwareUpgrade, undefined)
+  })
+
+  await it('should preserve JSON serialization byte-for-byte after interning', () => {
+    const stationInfo = buildStationInfo({
+      firmwareUpgrade: { reset: false, versionUpgrade: { step: 2 } },
+    })
+    const before = JSON.stringify(stationInfo)
+
+    internStationInfoInvariants(stationInfo)
+
+    assert.strictEqual(JSON.stringify(stationInfo), before)
+  })
+
+  await it('should intern every invariant object key and share it with a cache-hit consumer', () => {
+    const commandsSupport = {
+      incomingCommands: { Reset: true },
+    } as NonNullable<ChargingStationInfo['commandsSupport']>
+    const messageTriggerSupport = {
+      Heartbeat: true,
+    } as NonNullable<ChargingStationInfo['messageTriggerSupport']>
+    const overrides = (): Partial<ChargingStationInfo> => ({
+      commandsSupport: structuredClone(commandsSupport),
+      firmwareUpgrade: { reset: false, versionUpgrade: { step: 2 } },
+      messageTriggerSupport: structuredClone(messageTriggerSupport),
+    })
+    const producer = buildStationInfo(overrides())
+    const consumer = buildStationInfo({ ...overrides(), chargePointVendor: 'Vendor' })
+    const consumerBefore = JSON.stringify(consumer)
+
+    internStationInfoInvariants(producer)
+    internStationInfoInvariants(consumer)
+
+    assert.strictEqual(consumer.commandsSupport, producer.commandsSupport)
+    assert.strictEqual(consumer.firmwareUpgrade, producer.firmwareUpgrade)
+    assert.strictEqual(consumer.messageTriggerSupport, producer.messageTriggerSupport)
+    assert.strictEqual(JSON.stringify(consumer), consumerBefore)
+  })
+})

--- a/tests/utils/Constants.test.ts
+++ b/tests/utils/Constants.test.ts
@@ -3,18 +3,25 @@
  * @description Unit tests for shared constant invariants.
  */
 import assert from 'node:assert/strict'
-import { describe, it } from 'node:test'
+import { afterEach, describe, it } from 'node:test'
 
 import { Constants } from '../../src/utils/index.js'
+import { standardCleanup } from '../helpers/TestLifecycleHelpers.js'
 
 await describe('Constants', async () => {
+  afterEach(() => {
+    standardCleanup()
+  })
+
   await it('should deep-freeze DEFAULT_STATION_INFO', () => {
     const defaultStationInfo = Constants.DEFAULT_STATION_INFO
     assert.strictEqual(Object.isFrozen(defaultStationInfo), true)
     const firmwareUpgrade = defaultStationInfo.firmwareUpgrade
-    assert.ok(firmwareUpgrade != null)
     assert.strictEqual(Object.isFrozen(firmwareUpgrade), true)
-    assert.ok(firmwareUpgrade.versionUpgrade != null)
     assert.strictEqual(Object.isFrozen(firmwareUpgrade.versionUpgrade), true)
+    assert.throws(() => {
+      // @ts-expect-error - DEFAULT_STATION_INFO must expose its deeply frozen graph as readonly.
+      firmwareUpgrade.versionUpgrade.step = 2
+    }, TypeError)
   })
 })

--- a/tests/utils/Constants.test.ts
+++ b/tests/utils/Constants.test.ts
@@ -1,0 +1,20 @@
+/**
+ * @file Tests for Constants
+ * @description Unit tests for shared constant invariants.
+ */
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { Constants } from '../../src/utils/index.js'
+
+await describe('Constants', async () => {
+  await it('should deep-freeze DEFAULT_STATION_INFO', () => {
+    const defaultStationInfo = Constants.DEFAULT_STATION_INFO
+    assert.strictEqual(Object.isFrozen(defaultStationInfo), true)
+    const firmwareUpgrade = defaultStationInfo.firmwareUpgrade
+    assert.ok(firmwareUpgrade != null)
+    assert.strictEqual(Object.isFrozen(firmwareUpgrade), true)
+    assert.ok(firmwareUpgrade.versionUpgrade != null)
+    assert.strictEqual(Object.isFrozen(firmwareUpgrade.versionUpgrade), true)
+  })
+})

--- a/tests/utils/DeepFreeze.test.ts
+++ b/tests/utils/DeepFreeze.test.ts
@@ -75,4 +75,19 @@ await describe('DeepFreeze', async () => {
     assert.strictEqual(Object.isFrozen(symbolNested), true)
     assert.strictEqual(getterCalls, 0)
   })
+
+  await it('should freeze non-enumerable string-keyed data properties', () => {
+    const hidden = { value: 1 }
+    const object = {}
+    Object.defineProperty(object, 'hidden', { enumerable: false, value: hidden })
+    deepFreeze(object)
+    assert.strictEqual(Object.isFrozen(hidden), true)
+  })
+
+  await it('should treat array-buffer views as opaque leaves without throwing', () => {
+    const object = { buffer: new Uint8Array([1, 2, 3]) }
+    assert.strictEqual(deepFreeze(object), object)
+    assert.strictEqual(Object.isFrozen(object), true)
+    assert.strictEqual(Object.isFrozen(object.buffer), false)
+  })
 })

--- a/tests/utils/DeepFreeze.test.ts
+++ b/tests/utils/DeepFreeze.test.ts
@@ -85,9 +85,9 @@ await describe('DeepFreeze', async () => {
   })
 
   await it('should treat array-buffer views as opaque leaves without throwing', () => {
-    const object = { buffer: new Uint8Array([1, 2, 3]) }
+    const object = { view: new Uint8Array([1, 2, 3]) }
     assert.strictEqual(deepFreeze(object), object)
     assert.strictEqual(Object.isFrozen(object), true)
-    assert.strictEqual(Object.isFrozen(object.buffer), false)
+    assert.strictEqual(Object.isFrozen(object.view), false)
   })
 })

--- a/tests/utils/DeepFreeze.test.ts
+++ b/tests/utils/DeepFreeze.test.ts
@@ -3,11 +3,16 @@
  * @description Unit tests for the recursive deep-freeze utility.
  */
 import assert from 'node:assert/strict'
-import { describe, it } from 'node:test'
+import { afterEach, describe, it } from 'node:test'
 
 import { deepFreeze } from '../../src/utils/index.js'
+import { standardCleanup } from '../helpers/TestLifecycleHelpers.js'
 
 await describe('DeepFreeze', async () => {
+  afterEach(() => {
+    standardCleanup()
+  })
+
   await it('should return the same reference it was given', () => {
     const object = { a: 1 }
     assert.strictEqual(deepFreeze(object), object)
@@ -29,6 +34,7 @@ await describe('DeepFreeze', async () => {
   await it('should make nested mutation throw in strict mode', () => {
     const object = deepFreeze({ nested: { value: 1 } })
     assert.throws(() => {
+      // @ts-expect-error - deepFreeze must expose deeply frozen plain objects as readonly.
       object.nested.value = 2
     }, TypeError)
   })
@@ -89,5 +95,16 @@ await describe('DeepFreeze', async () => {
     assert.strictEqual(deepFreeze(object), object)
     assert.strictEqual(Object.isFrozen(object), true)
     assert.strictEqual(Object.isFrozen(object.view), false)
+    object.view[0] = 4
+    assert.strictEqual(object.view[0], 4)
+  })
+
+  await it('should preserve the mutable type and runtime behavior of opaque maps', () => {
+    const nested = { value: 1 }
+    const map = deepFreeze(new Map([['key', nested]]))
+    map.set('second', { value: 2 })
+    nested.value = 3
+    assert.strictEqual(map.size, 2)
+    assert.strictEqual(map.get('key')?.value, 3)
   })
 })

--- a/tests/utils/DeepFreeze.test.ts
+++ b/tests/utils/DeepFreeze.test.ts
@@ -52,4 +52,27 @@ await describe('DeepFreeze', async () => {
     deepFreeze(object)
     assert.strictEqual(Object.isFrozen(object.nested), true)
   })
+
+  await it('should terminate and freeze a self-referential graph', () => {
+    const object: Record<string, unknown> = { value: 1 }
+    object.self = object
+    assert.strictEqual(deepFreeze(object), object)
+    assert.strictEqual(Object.isFrozen(object), true)
+  })
+
+  await it('should freeze symbol-keyed data properties without invoking getters', () => {
+    const nestedKey = Symbol('nested')
+    const symbolNested = { value: 1 }
+    let getterCalls = 0
+    const object = {
+      get lazy () {
+        getterCalls++
+        return { value: 1 }
+      },
+      [nestedKey]: symbolNested,
+    }
+    deepFreeze(object)
+    assert.strictEqual(Object.isFrozen(symbolNested), true)
+    assert.strictEqual(getterCalls, 0)
+  })
 })

--- a/tests/utils/DeepFreeze.test.ts
+++ b/tests/utils/DeepFreeze.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @file Tests for DeepFreeze
+ * @description Unit tests for the recursive deep-freeze utility.
+ */
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { deepFreeze } from '../../src/utils/index.js'
+
+await describe('DeepFreeze', async () => {
+  await it('should return the same reference it was given', () => {
+    const object = { a: 1 }
+    assert.strictEqual(deepFreeze(object), object)
+  })
+
+  await it('should freeze the top-level object', () => {
+    const object = deepFreeze({ a: 1 })
+    assert.strictEqual(Object.isFrozen(object), true)
+  })
+
+  await it('should recursively freeze nested objects and arrays', () => {
+    const object = deepFreeze({ list: [{ x: 1 }], nested: { deep: { value: 1 } } })
+    assert.strictEqual(Object.isFrozen(object.nested), true)
+    assert.strictEqual(Object.isFrozen(object.nested.deep), true)
+    assert.strictEqual(Object.isFrozen(object.list), true)
+    assert.strictEqual(Object.isFrozen(object.list[0]), true)
+  })
+
+  await it('should make nested mutation throw in strict mode', () => {
+    const object = deepFreeze({ nested: { value: 1 } })
+    assert.throws(() => {
+      object.nested.value = 2
+    }, TypeError)
+  })
+
+  await it('should return primitives and null unchanged', () => {
+    assert.strictEqual(deepFreeze(42), 42)
+    assert.strictEqual(deepFreeze('str'), 'str')
+    assert.strictEqual(deepFreeze(null), null)
+  })
+
+  await it('should be idempotent on an already deep-frozen graph', () => {
+    const object = deepFreeze({ nested: { value: 1 } })
+    assert.strictEqual(deepFreeze(object), object)
+    assert.strictEqual(Object.isFrozen(object.nested), true)
+  })
+
+  await it('should freeze children of an already shallow-frozen input', () => {
+    const object = Object.freeze({ nested: { value: 1 } })
+    assert.strictEqual(Object.isFrozen(object), true)
+    assert.strictEqual(Object.isFrozen(object.nested), false)
+    deepFreeze(object)
+    assert.strictEqual(Object.isFrozen(object.nested), true)
+  })
+})


### PR DESCRIPTION
## PR Checklist

- [x] Description of changes provided.
- [x] Title follows conventional commits.
- [x] Unit tests included (DeepFreeze + StationInfoInvariants).
- [x] Feature documented (module/API doc comments; no user-facing config change).
- [x] Linked issue: Closes #92.

## Does this PR introduce a breaking change?

- [x] No

---

### Summary

Implements the flyweight design pattern requested in #92: the object-valued
**invariant** fields of a charging station's `stationInfo`
(`commandsSupport`, `firmwareUpgrade`, `messageTriggerSupport`) are interned
into a shared, deep-frozen flyweight and referenced by every equal-content
station, instead of each station retaining its own per-instance copy.
`stationTemplateToStationInfo` still structured-clones the template once per
station; this change does not remove that clone. The saving is in **retained**
heap — duplicate invariant sub-objects collapse to one shared reference — not
in avoided clone allocations.

### Design

- **Interning**: in `getStationInfo`, after the template/options merge, invariant
  object fields are replaced by references into a per-worker, deep-frozen graph
  stored in a dedicated registry (`StationInfoInvariants.ts`), keyed by an
  insertion-order `sha384` content hash of the invariant projection.
- **Provenance gate**: a field still pointing at the shared `DEFAULT_STATION_INFO`
  reference (already deduped by `mergeDeepRight`) is skipped; a station declaring
  none of the interned fields triggers no hashing/allocation — shipped templates
  pay no added cost.
- **`wsOptions` excluded**: it is spread into the `ws` client options and may
  carry function-valued members (not structured-cloneable / unsafe to freeze).
- **Byte-identical serialization**: only already-present own keys are reassigned
  (insertion order preserved) and interned values are structured clones of the
  built field, so `JSON.stringify(stationInfo)` and the persisted
  `configurationHash` are unchanged (no spurious configuration-file rewrites).
- **Mutation safety**: interned graphs are deep-frozen; `DEFAULT_STATION_INFO` is
  now deep-frozen too (via a new dependency-free `deepFreeze` leaf util) to make
  the immutability guarantee uniform. All three fields are read-only across `src`.
- **Workers**: JS worker threads do not share the heap, so the benefit applies
  within a worker running several stations from the same template.

### Tests executed

- `tsc --noEmit --skipLibCheck`: pass
- `eslint src tests`: pass
- `pnpm build`: pass
- full test suite: 0 failures (6 pre-existing skips), incl. the new
  `DeepFreeze` and `StationInfoInvariants` suites.

### Measured impact

Controlled harness (20 000 same-template stations declaring sizable invariant
objects): retained heap 17.74 MiB -> 2.06 MiB (-88.4 %); invariant objects shared
by reference (`Object.is`) confirmed. For shipped templates (which rarely declare
these objects) the delta is ~0 — the benefit is conditional by design.

### Risks

- Benefit is conditional (within-worker only; near-zero on shipped templates).
- Any future in-place mutation of an interned field now throws (guarded by tests
  and the read-only audit); `DeepFreeze.ts` must remain import-free (documented).

Closes #92

