### PR TITLE
chore(opencode): stop Serena MCP from auto-opening the web dashboard

### DIFF
--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -16,6 +16,8 @@
         "start-mcp-server",
         "--context",
         "ide-assistant",
+        "--open-web-dashboard",
+        "false",
       ],
       "enabled": true,
     },


### PR DESCRIPTION
## PR Checklist

- [x] Please add a description of your changes.
- [x] Please ensure title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] We need your changes to come with unit tests in order to keep this project in quality and easy to maintain. — n/a: dev tooling config, no runtime/library code.
- [ ] If your changes contain any new feature please be sure to document it. — n/a: no feature.
- [ ] Please add a link to the open issue or task that this pull request will resolve. — n/a: no associated issue.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

---

The committed `.opencode/opencode.jsonc` starts the Serena MCP server with `serena start-mcp-server` but no dashboard flag, so Serena opens its web dashboard in a browser tab on every OpenCode startup. This adds `--open-web-dashboard false` to that command so it no longer pops a browser tab; the dashboard is still reachable manually at `http://localhost:24282/dashboard/`.

The flag is the documented override for the `web_dashboard_open_on_launch` config option (see the `start-mcp-server` CLI in oraios/serena). Dev-only change: `.opencode/opencode.jsonc` only, no source/build/runtime impact.

Verification: JSONC still parses; the resulting command is `uvx --from git+https://github.com/oraios/serena serena start-mcp-server --context ide-assistant --open-web-dashboard false`.

---

AI usage disclosure per SAP's GenAI contribution guideline: change and verification done with AI assistance; the flag was verified against Serena's CLI source and the config file validated.