### PR TITLE
fix: use Driivz deletion lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 src/assets/config*.json
 !src/assets/config-template.json
 src/scripts/scriptConfig.json
+src/scripts/deleteChargingStations.state.json*
 src/assets/*idtags*.json
 !src/assets/idtags-template.json
 src/assets/ev-profiles*.json

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -25,6 +25,7 @@ words:
   - workerset
   - worktree
   - dedup
+  - Driivz
   - unpushed
   - logform
   - mnemonist

--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -1,0 +1,29 @@
+# Maintenance scripts
+
+## Driivz charger deletion
+
+`deleteChargingStations.cjs` removes configured chargers through the Driivz REST lifecycle. It
+does not delete simulator records directly from MongoDB.
+
+1. Copy `scriptConfig-template.json` to the ignored `scriptConfig.json` file and configure
+   `driivzDeletion`.
+2. Run `node deleteChargingStations.cjs` from this directory.
+3. Run the command again to resume chargers left pending by decommissioning, an API error, or a
+   timeout.
+
+The first successful run performs the profile, transaction, and reservation preflight and requests
+decommissioning. It then exits with the charger pending. A later run polls until the profile reports
+`DECOMMISSIONED` before patching configured connector EVSE data and deleting the charger.
+
+Progress is written atomically to `deleteChargingStations.state.json` by default. Keep this file
+between runs. Completed phases are not repeated, and an uncertain decommission request is reconciled
+before retrying with its original timestamp.
+
+Site and Property cleanup starts only after a profile read-back confirms that the charger is absent.
+A Site is deleted only when its `chargerIds` array is empty. A Property is deleted only when its
+`siteIds` array is empty and the read-back explicitly marks it as non-shared. Missing or ambiguous
+sharing data preserves the Property.
+
+The command exits with code `0` when every configured charger is complete, `2` when work remains
+pending, and `1` for invalid configuration or an unrecoverable startup error. Per-charger API errors
+are persisted as pending work for the next run.

--- a/src/scripts/deleteChargingStations.cjs
+++ b/src/scripts/deleteChargingStations.cjs
@@ -1,30 +1,604 @@
-const { MongoClient } = require('mongodb')
 const fs = require('node:fs')
+const path = require('node:path')
 
-// This script deletes charging stations
-// Filter charging stations by id pattern
+const DEFAULT_CONFIG = Object.freeze({
+  pollIntervalMs: 1000,
+  pollTimeoutMs: 120000,
+  stateFile: 'deleteChargingStations.state.json',
+})
 
-// Use Case: e-mobility-charging-stations-simulator creates thousands of charging stations, which are not longer needed.
-// Delete these charging stations all at once
+const Phase = Object.freeze({
+  CLEAN_PROPERTY: 'CLEAN_PROPERTY',
+  CLEAN_SITE: 'CLEAN_SITE',
+  COMPLETE: 'COMPLETE',
+  DECOMMISSION: 'DECOMMISSION',
+  DELETE_CHARGER: 'DELETE_CHARGER',
+  PATCH_CONNECTORS: 'PATCH_CONNECTORS',
+  POLL_DECOMMISSION: 'POLL_DECOMMISSION',
+  PREFLIGHT: 'PREFLIGHT',
+  VERIFY_CHARGER: 'VERIFY_CHARGER',
+  VERIFY_PROPERTY: 'VERIFY_PROPERTY',
+  VERIFY_SITE: 'VERIFY_SITE',
+})
 
-// Config
-const config = JSON.parse(fs.readFileSync('scriptConfig.json', 'utf8'))
+class DeletionWorkflowError extends Error {
+  constructor (message) {
+    super(message)
+    this.name = 'DeletionWorkflowError'
+  }
+}
 
-// Mongo Connection and Query
-if (config?.mongoConnectionString) {
-  MongoClient.connect(config.mongoConnectionString, async (_err, client) => {
-    const db = client.db()
+class DriivzApiError extends Error {
+  constructor (method, requestPath, status, responseBody) {
+    super(`Driivz ${method} ${requestPath} failed with status ${status.toString()}`)
+    this.name = 'DriivzApiError'
+    this.method = method
+    this.requestPath = requestPath
+    this.responseBody = responseBody
+    this.status = status
+  }
+}
 
-    for await (const tenantID of config.tenantIDs) {
-      const response = await db
-        .collection(`${tenantID}.chargingstations`)
-        .deleteMany({ _id: { $regex: config.idPattern } })
-      console.info(
-        response.deletedCount,
-        `Charging Stations with id = %${config.idPattern}% deleted. TenantID =`,
-        tenantID
+class DriivzClient {
+  constructor ({ baseUrl, fetchImplementation = globalThis.fetch, headers = {} }) {
+    if (typeof fetchImplementation !== 'function') {
+      throw new DeletionWorkflowError('A fetch implementation is required')
+    }
+    this.baseUrl = baseUrl.replace(/\/$/u, '')
+    this.fetchImplementation = fetchImplementation
+    this.headers = headers
+  }
+
+  decommissionCharger (chargerId, date) {
+    return this.request(
+      'PATCH',
+      `/v1/chargers/${encodeURIComponent(chargerId)}/status/actions/decommission`,
+      { allowPastDate: true, date }
+    )
+  }
+
+  deleteCharger (chargerId) {
+    return this.request('DELETE', `/v1/chargers/${encodeURIComponent(chargerId)}`)
+  }
+
+  deleteProperty (propertyId) {
+    return this.request('DELETE', `/v1/properties/${encodeURIComponent(propertyId)}`)
+  }
+
+  deleteSite (siteId) {
+    return this.request('DELETE', `/v1/sites/${encodeURIComponent(siteId)}`)
+  }
+
+  filterEvTransactions (chargerId) {
+    return this.request('POST', '/v1/ev-transactions/filter', { chargerIds: [chargerId] })
+  }
+
+  filterReservations (chargerId) {
+    return this.request('POST', '/v1/reservations/filter', { chargerIds: [chargerId] })
+  }
+
+  getChargerProfile (chargerId) {
+    return this.requestOptional('GET', `/v1/chargers/${encodeURIComponent(chargerId)}/profile`)
+  }
+
+  getProperty (propertyId) {
+    return this.requestOptional('GET', `/v1/properties/${encodeURIComponent(propertyId)}`)
+  }
+
+  getSite (siteId) {
+    return this.requestOptional('GET', `/v1/sites/${encodeURIComponent(siteId)}`)
+  }
+
+  patchConnectorEvse (chargerId, connectorId, payload) {
+    return this.request(
+      'PATCH',
+      `/v1/chargers/${encodeURIComponent(chargerId)}/connectors/${encodeURIComponent(connectorId)}/evse`,
+      payload
+    )
+  }
+
+  async request (method, requestPath, body) {
+    const response = await this.fetchImplementation(`${this.baseUrl}${requestPath}`, {
+      body: body == null ? undefined : JSON.stringify(body),
+      headers: {
+        Accept: 'application/json',
+        ...(body == null ? {} : { 'Content-Type': 'application/json' }),
+        ...this.headers,
+      },
+      method,
+    })
+    const responseText = await response.text()
+    let responseBody
+    if (responseText.length > 0) {
+      try {
+        responseBody = JSON.parse(responseText)
+      } catch {
+        responseBody = responseText
+      }
+    }
+    if (!response.ok) {
+      throw new DriivzApiError(method, requestPath, response.status, responseBody)
+    }
+    return responseBody
+  }
+
+  async requestOptional (method, requestPath) {
+    try {
+      return await this.request(method, requestPath)
+    } catch (error) {
+      if (error instanceof DriivzApiError && error.status === 404) {
+        return null
+      }
+      throw error
+    }
+  }
+}
+
+class DriivzDeletionWorkflow {
+  constructor ({
+    chargers,
+    client,
+    now = Date.now,
+    pollIntervalMs = DEFAULT_CONFIG.pollIntervalMs,
+    pollTimeoutMs = DEFAULT_CONFIG.pollTimeoutMs,
+    sleep = async delay => new Promise(resolve => setTimeout(resolve, delay)),
+    stateStore,
+  }) {
+    this.chargers = chargers
+    this.client = client
+    this.now = now
+    this.pollIntervalMs = pollIntervalMs
+    this.pollTimeoutMs = pollTimeoutMs
+    this.sleep = sleep
+    this.stateStore = stateStore
+  }
+
+  async cleanProperty (state, chargerState) {
+    const { propertyId } = chargerState.charger
+    if (propertyId == null) {
+      this.complete(state, chargerState, 'Charger deletion completed')
+      return false
+    }
+    const property = await this.client.getProperty(propertyId)
+    if (property == null) {
+      this.complete(state, chargerState, 'Charger and parent deletion completed')
+      return false
+    }
+    if (!Array.isArray(property.siteIds)) {
+      throw new DeletionWorkflowError(`Property ${propertyId} read-back does not contain siteIds`)
+    }
+    if (property.siteIds.length > 0) {
+      this.complete(state, chargerState, `Property ${propertyId} is not empty`)
+      return false
+    }
+    if (getSharedFlag(property) !== false) {
+      this.complete(
+        state,
+        chargerState,
+        `Property ${propertyId} is shared or has no explicit sharing flag`
+      )
+      return false
+    }
+    await this.client.deleteProperty(propertyId)
+    this.transition(state, chargerState, Phase.VERIFY_PROPERTY)
+    return true
+  }
+
+  async cleanSite (state, chargerState) {
+    const { siteId } = chargerState.charger
+    if (siteId == null) {
+      this.transition(state, chargerState, Phase.CLEAN_PROPERTY)
+      return true
+    }
+    const site = await this.client.getSite(siteId)
+    if (site == null) {
+      this.transition(state, chargerState, Phase.CLEAN_PROPERTY)
+      return true
+    }
+    if (!Array.isArray(site.chargerIds)) {
+      throw new DeletionWorkflowError(`Site ${siteId} read-back does not contain chargerIds`)
+    }
+    if (site.chargerIds.length > 0) {
+      this.complete(state, chargerState, `Site ${siteId} is not empty`)
+      return false
+    }
+    await this.client.deleteSite(siteId)
+    this.transition(state, chargerState, Phase.VERIFY_SITE)
+    return true
+  }
+
+  complete (state, chargerState, outcome) {
+    chargerState.outcome = outcome
+    this.transition(state, chargerState, Phase.COMPLETE)
+  }
+
+  async deleteCharger (state, chargerState) {
+    try {
+      await this.client.deleteCharger(chargerState.charger.id)
+    } catch (error) {
+      if (!(error instanceof DriivzApiError) || error.status !== 404) {
+        throw error
+      }
+    }
+    this.transition(state, chargerState, Phase.VERIFY_CHARGER)
+  }
+
+  async patchConnectors (state, chargerState) {
+    const connectorEvses = chargerState.charger.connectorEvses ?? []
+    const patchedConnectorIds = new Set(chargerState.patchedConnectorIds ?? [])
+    for (const connectorEvse of connectorEvses) {
+      if (patchedConnectorIds.has(connectorEvse.connectorId)) {
+        continue
+      }
+      await this.client.patchConnectorEvse(
+        chargerState.charger.id,
+        connectorEvse.connectorId,
+        connectorEvse.payload
+      )
+      patchedConnectorIds.add(connectorEvse.connectorId)
+      chargerState.patchedConnectorIds = [...patchedConnectorIds]
+      this.persist(state, chargerState)
+    }
+    this.transition(state, chargerState, Phase.DELETE_CHARGER)
+  }
+
+  persist (state, chargerState) {
+    chargerState.updatedAt = new Date(this.now()).toISOString()
+    this.stateStore.save(state)
+  }
+
+  async pollDecommission (state, chargerState) {
+    const startedAt = this.now()
+    do {
+      const profile = await this.client.getChargerProfile(chargerState.charger.id)
+      if (profile == null) {
+        throw new DeletionWorkflowError(
+          `Charger ${chargerState.charger.id} profile is absent while decommission is pending`
+        )
+      }
+      chargerState.lastProvisionStatus = profile.provisionStatus
+      this.persist(state, chargerState)
+      if (profile.provisionStatus === 'DECOMMISSIONED') {
+        this.transition(state, chargerState, Phase.PATCH_CONNECTORS)
+        return true
+      }
+      if (this.now() - startedAt >= this.pollTimeoutMs) {
+        chargerState.lastError = {
+          at: new Date(this.now()).toISOString(),
+          message: `Timed out waiting for charger ${chargerState.charger.id} to become DECOMMISSIONED`,
+        }
+        this.persist(state, chargerState)
+        return false
+      }
+      await this.sleep(this.pollIntervalMs)
+    } while (true)
+  }
+
+  async preflight (state, chargerState) {
+    const { id } = chargerState.charger
+    const profile = await this.client.getChargerProfile(id)
+    if (profile == null) {
+      throw new DeletionWorkflowError(
+        `Charger ${id} profile is absent before the deletion lifecycle started`
       )
     }
-    client.close()
+
+    const transactions = await this.client.filterEvTransactions(id)
+    const reservations = await this.client.filterReservations(id)
+    chargerState.preflight = {
+      checkedAt: new Date(this.now()).toISOString(),
+      provisionStatus: profile.provisionStatus,
+      reservationsEmpty: isFilterEmpty(reservations),
+      transactionsEmpty: isFilterEmpty(transactions),
+    }
+    if (!chargerState.preflight.transactionsEmpty || !chargerState.preflight.reservationsEmpty) {
+      throw new DeletionWorkflowError(`Charger ${id} still has transactions or reservations`)
+    }
+    if (profile.provisionStatus === 'DECOMMISSIONED') {
+      this.transition(state, chargerState, Phase.PATCH_CONNECTORS)
+      return
+    }
+    this.transition(state, chargerState, Phase.DECOMMISSION)
+  }
+
+  async run () {
+    const state = this.stateStore.load()
+    for (const charger of this.chargers) {
+      state.chargers[charger.id] ??= {
+        attempts: 0,
+        charger,
+        phase: Phase.PREFLIGHT,
+        updatedAt: new Date(this.now()).toISOString(),
+      }
+      const chargerState = state.chargers[charger.id]
+      chargerState.charger = charger
+      chargerState.attempts += 1
+      chargerState.lastError = undefined
+      this.persist(state, chargerState)
+      try {
+        await this.runCharger(state, chargerState)
+      } catch (error) {
+        chargerState.lastError = {
+          at: new Date(this.now()).toISOString(),
+          message: error instanceof Error ? error.message : String(error),
+        }
+        this.persist(state, chargerState)
+      }
+    }
+    return state
+  }
+
+  async runCharger (state, chargerState) {
+    while (chargerState.phase !== Phase.COMPLETE) {
+      switch (chargerState.phase) {
+        case Phase.CLEAN_PROPERTY:
+          if (!(await this.cleanProperty(state, chargerState))) {
+            return
+          }
+          break
+        case Phase.CLEAN_SITE:
+          if (!(await this.cleanSite(state, chargerState))) {
+            return
+          }
+          break
+        case Phase.DECOMMISSION:
+          await this.startDecommission(state, chargerState)
+          return
+        case Phase.DELETE_CHARGER:
+          await this.deleteCharger(state, chargerState)
+          break
+        case Phase.PATCH_CONNECTORS:
+          await this.patchConnectors(state, chargerState)
+          break
+        case Phase.POLL_DECOMMISSION:
+          if (!(await this.pollDecommission(state, chargerState))) {
+            return
+          }
+          break
+        case Phase.PREFLIGHT:
+          await this.preflight(state, chargerState)
+          break
+        case Phase.VERIFY_CHARGER:
+          if (!(await this.verifyChargerDeletion(state, chargerState))) {
+            return
+          }
+          break
+        case Phase.VERIFY_PROPERTY:
+          if (!(await this.verifyPropertyDeletion(state, chargerState))) {
+            return
+          }
+          break
+        case Phase.VERIFY_SITE:
+          if (!(await this.verifySiteDeletion(state, chargerState))) {
+            return
+          }
+          break
+        default:
+          throw new DeletionWorkflowError(`Unknown deletion phase: ${chargerState.phase}`)
+      }
+    }
+  }
+
+  async startDecommission (state, chargerState) {
+    if (chargerState.decommissionAttemptedAt != null) {
+      const startedAt = this.now()
+      do {
+        const profile = await this.client.getChargerProfile(chargerState.charger.id)
+        if (profile == null) {
+          throw new DeletionWorkflowError(
+            `Charger ${chargerState.charger.id} profile is absent while reconciling decommission`
+          )
+        }
+        if (profile.provisionStatus === 'DECOMMISSIONED') {
+          this.transition(state, chargerState, Phase.PATCH_CONNECTORS)
+          return
+        }
+        if (profile.provisionStatus !== chargerState.preflight?.provisionStatus) {
+          this.transition(state, chargerState, Phase.POLL_DECOMMISSION)
+          return
+        }
+        if (this.now() - startedAt >= this.pollTimeoutMs) {
+          break
+        }
+        await this.sleep(this.pollIntervalMs)
+      } while (true)
+    }
+    const decommissionDate =
+      chargerState.decommissionAttemptedAt ?? new Date(this.now()).toISOString()
+    chargerState.decommissionAttemptedAt = decommissionDate
+    this.persist(state, chargerState)
+    await this.client.decommissionCharger(chargerState.charger.id, decommissionDate)
+    chargerState.decommissionRequestedAt = decommissionDate
+    this.transition(state, chargerState, Phase.POLL_DECOMMISSION)
+  }
+
+  transition (state, chargerState, phase) {
+    chargerState.phase = phase
+    chargerState.lastError = undefined
+    this.persist(state, chargerState)
+  }
+
+  async verifyChargerDeletion (state, chargerState) {
+    const profile = await this.client.getChargerProfile(chargerState.charger.id)
+    if (profile != null) {
+      chargerState.lastError = {
+        at: new Date(this.now()).toISOString(),
+        message: `Charger ${chargerState.charger.id} is still present after DELETE`,
+      }
+      this.persist(state, chargerState)
+      return false
+    }
+    this.transition(state, chargerState, Phase.CLEAN_SITE)
+    return true
+  }
+
+  async verifyPropertyDeletion (state, chargerState) {
+    const property = await this.client.getProperty(chargerState.charger.propertyId)
+    if (property != null) {
+      chargerState.lastError = {
+        at: new Date(this.now()).toISOString(),
+        message: `Property ${chargerState.charger.propertyId} is still present after DELETE`,
+      }
+      this.persist(state, chargerState)
+      return false
+    }
+    this.complete(state, chargerState, 'Charger and parent deletion completed')
+    return true
+  }
+
+  async verifySiteDeletion (state, chargerState) {
+    const site = await this.client.getSite(chargerState.charger.siteId)
+    if (site != null) {
+      chargerState.lastError = {
+        at: new Date(this.now()).toISOString(),
+        message: `Site ${chargerState.charger.siteId} is still present after DELETE`,
+      }
+      this.persist(state, chargerState)
+      return false
+    }
+    this.transition(state, chargerState, Phase.CLEAN_PROPERTY)
+    return true
+  }
+}
+
+class FileWorkflowStateStore {
+  constructor (filePath) {
+    this.filePath = path.resolve(filePath)
+  }
+
+  load () {
+    if (!fs.existsSync(this.filePath)) {
+      return { chargers: {}, version: 1 }
+    }
+    const state = JSON.parse(fs.readFileSync(this.filePath, 'utf8'))
+    if (state?.version !== 1 || state.chargers == null || typeof state.chargers !== 'object') {
+      throw new DeletionWorkflowError(`Invalid workflow state in ${this.filePath}`)
+    }
+    return state
+  }
+
+  save (state) {
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true })
+    const temporaryPath = `${this.filePath}.${process.pid.toString()}.tmp`
+    fs.writeFileSync(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 })
+    fs.renameSync(temporaryPath, this.filePath)
+  }
+}
+
+/**
+ * Reads the explicit property sharing flag across supported response variants.
+ * @param property - Property read-back payload.
+ * @returns The sharing flag, or undefined when the API did not provide one.
+ */
+function getSharedFlag (property) {
+  return property.isShared ?? property.shared ?? property.sharedProperty
+}
+
+/**
+ * Determines whether a Driivz filter response contains no resources.
+ * @param response - Filter endpoint response.
+ * @returns Whether the response reports zero resources.
+ */
+function isFilterEmpty (response) {
+  if (Array.isArray(response)) {
+    return response.length === 0
+  }
+  if (response == null || typeof response !== 'object') {
+    throw new DeletionWorkflowError('Driivz filter response has an unsupported shape')
+  }
+  for (const key of ['items', 'results', 'content', 'data']) {
+    if (Array.isArray(response[key])) {
+      return response[key].length === 0
+    }
+  }
+  for (const key of ['count', 'total', 'totalCount', 'totalElements']) {
+    if (Number.isInteger(response[key])) {
+      return response[key] === 0
+    }
+  }
+  throw new DeletionWorkflowError('Driivz filter response does not expose an item list or count')
+}
+
+/**
+ * Creates and runs the deletion workflow from the script configuration.
+ * @param root0 - Runtime dependencies and configuration location.
+ * @param root0.configPath - Script configuration file path.
+ * @param root0.fetchImplementation - HTTP implementation, injectable for tests.
+ * @param root0.now - Clock implementation, injectable for tests.
+ * @param root0.sleep - Delay implementation, injectable for tests.
+ * @returns The persisted workflow state after this run.
+ */
+async function runFromConfig ({
+  configPath = path.resolve('scriptConfig.json'),
+  fetchImplementation = globalThis.fetch,
+  now,
+  sleep,
+} = {}) {
+  const rootConfig = JSON.parse(fs.readFileSync(configPath, 'utf8'))
+  const config = { ...DEFAULT_CONFIG, ...rootConfig.driivzDeletion }
+  validateConfig(config)
+  const configDirectory = path.dirname(configPath)
+  const stateFile = path.resolve(configDirectory, config.stateFile)
+  const workflow = new DriivzDeletionWorkflow({
+    chargers: config.chargers,
+    client: new DriivzClient({
+      baseUrl: config.baseUrl,
+      fetchImplementation,
+      headers: config.headers,
+    }),
+    now,
+    pollIntervalMs: config.pollIntervalMs,
+    pollTimeoutMs: config.pollTimeoutMs,
+    sleep,
+    stateStore: new FileWorkflowStateStore(stateFile),
   })
+  return workflow.run()
+}
+
+/**
+ * Validates required deletion configuration.
+ * @param config - Merged Driivz deletion configuration.
+ */
+function validateConfig (config) {
+  if (typeof config.baseUrl !== 'string' || config.baseUrl.length === 0) {
+    throw new DeletionWorkflowError('driivzDeletion.baseUrl is required')
+  }
+  if (!Array.isArray(config.chargers) || config.chargers.length === 0) {
+    throw new DeletionWorkflowError('driivzDeletion.chargers must contain at least one charger')
+  }
+  for (const charger of config.chargers) {
+    if (typeof charger.id !== 'string' || charger.id.length === 0) {
+      throw new DeletionWorkflowError('Every configured charger must have an id')
+    }
+  }
+}
+
+if (require.main === module) {
+  runFromConfig()
+    .then(state => {
+      const pending = Object.values(state.chargers).filter(({ phase }) => phase !== Phase.COMPLETE)
+      console.info(
+        pending.length === 0
+          ? 'Driivz deletion workflow completed'
+          : `Driivz deletion workflow has ${pending.length.toString()} pending charger(s)`
+      )
+      process.exitCode = pending.length === 0 ? 0 : 2
+      return state
+    })
+    .catch(error => {
+      console.error(error)
+      process.exitCode = 1
+    })
+}
+
+module.exports = {
+  DEFAULT_CONFIG,
+  DeletionWorkflowError,
+  DriivzApiError,
+  DriivzClient,
+  DriivzDeletionWorkflow,
+  FileWorkflowStateStore,
+  isFilterEmpty,
+  Phase,
+  runFromConfig,
 }

--- a/src/scripts/scriptConfig-template.json
+++ b/src/scripts/scriptConfig-template.json
@@ -1,4 +1,26 @@
 {
+  "driivzDeletion": {
+    "baseUrl": "https://example.driivz.com",
+    "headers": {
+      "Authorization": "Bearer ..."
+    },
+    "pollIntervalMs": 1000,
+    "pollTimeoutMs": 120000,
+    "stateFile": "deleteChargingStations.state.json",
+    "chargers": [
+      {
+        "id": "",
+        "siteId": "",
+        "propertyId": "",
+        "connectorEvses": [
+          {
+            "connectorId": "",
+            "payload": {}
+          }
+        ]
+      }
+    ]
+  },
   "publicFlag": true,
   "tenantIDs": [""],
   "idPattern": "",

--- a/tests/scripts/DeleteChargingStations.test.ts
+++ b/tests/scripts/DeleteChargingStations.test.ts
@@ -1,0 +1,448 @@
+/**
+ * @file Tests for the persistent Driivz charger deletion workflow
+ * @description Verifies lifecycle sequencing, recovery, and parent resource protection.
+ */
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, it } from 'node:test'
+
+import { standardCleanup } from '../helpers/TestLifecycleHelpers.js'
+
+interface ChargerState {
+  attempts: number
+  charger?: typeof CHARGER
+  decommissionAttemptedAt?: string
+  lastError?: { message: string }
+  phase: string
+  preflight?: { provisionStatus: string }
+  updatedAt?: string
+}
+
+interface DriivzClientApi {
+  decommissionCharger: (chargerId: string, date: string) => Promise<unknown>
+  deleteCharger: (chargerId: string) => Promise<unknown>
+  deleteProperty: (propertyId: string) => Promise<unknown>
+  deleteSite: (siteId: string) => Promise<unknown>
+  filterEvTransactions: (chargerId: string) => Promise<unknown>
+  filterReservations: (chargerId: string) => Promise<unknown>
+  getChargerProfile: (chargerId: string) => Promise<unknown>
+  getProperty: (propertyId: string) => Promise<unknown>
+  getSite: (siteId: string) => Promise<unknown>
+  patchConnectorEvse: (chargerId: string, connectorId: string, payload: object) => Promise<unknown>
+}
+
+interface MockResponseSpec {
+  body?: unknown
+  method: string
+  path: string
+  status?: number
+}
+
+interface ScriptModule {
+  DriivzClient: new (options: {
+    baseUrl: string
+    fetchImplementation: typeof fetch
+  }) => DriivzClientApi
+  DriivzDeletionWorkflow: new (options: WorkflowOptions) => {
+    run: () => Promise<WorkflowState>
+  }
+  FileWorkflowStateStore: new (filePath: string) => StateStore
+  Phase: Record<string, string>
+}
+
+interface StateStore {
+  load: () => WorkflowState
+  save: (state: WorkflowState) => void
+}
+
+interface WorkflowOptions {
+  chargers: {
+    connectorEvses?: { connectorId: string; payload: object }[]
+    id: string
+    propertyId?: string
+    siteId?: string
+  }[]
+  client: DriivzClientApi
+  now?: () => number
+  pollIntervalMs?: number
+  pollTimeoutMs?: number
+  sleep?: (delay: number) => Promise<void>
+  stateStore: StateStore
+}
+
+interface WorkflowState {
+  chargers: Record<string, ChargerState>
+  version?: number
+}
+
+const require = createRequire(import.meta.url)
+const { DriivzClient, DriivzDeletionWorkflow, FileWorkflowStateStore, Phase } =
+  require('../../src/scripts/deleteChargingStations.cjs') as ScriptModule
+
+const BASE_URL = 'https://driivz.example'
+const CHARGER = {
+  connectorEvses: [{ connectorId: 'connector-1', payload: { evseId: null } }],
+  id: 'charger-1',
+  propertyId: 'property-1',
+  siteId: 'site-1',
+}
+
+/**
+ * Creates a deterministic fetch mock with an expected response sequence.
+ * @param responses - Ordered HTTP responses and request expectations.
+ * @returns The mock implementation and recorded calls.
+ */
+function createFetchMock (responses: MockResponseSpec[]): {
+  calls: { body?: unknown; method: string; path: string }[]
+  fetchImplementation: typeof fetch
+} {
+  const calls: { body?: unknown; method: string; path: string }[] = []
+  const fetchImplementation = ((input: Request | string | URL, init?: RequestInit) => {
+    const response = responses.shift()
+    const inputUrl =
+      typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+    assert.notStrictEqual(response, undefined, `Unexpected request: ${inputUrl}`)
+    const url = new URL(inputUrl)
+    const method = init?.method ?? 'GET'
+    const body: unknown =
+      typeof init?.body === 'string' ? (JSON.parse(init.body) as unknown) : undefined
+    calls.push({ body, method, path: url.pathname })
+    assert.strictEqual(method, response?.method)
+    assert.strictEqual(url.pathname, response?.path)
+    const status = response?.status ?? 200
+    return Promise.resolve(
+      new Response(response?.body == null ? undefined : JSON.stringify(response.body), {
+        headers: { 'Content-Type': 'application/json' },
+        status,
+      })
+    )
+  }) as typeof fetch
+  return { calls, fetchImplementation }
+}
+
+await describe('DriivzDeletionWorkflow', async () => {
+  let temporaryDirectory: string
+  let stateFile: string
+
+  beforeEach(() => {
+    temporaryDirectory = mkdtempSync(join(tmpdir(), 'driivz-deletion-test-'))
+    stateFile = join(temporaryDirectory, 'state.json')
+  })
+
+  afterEach(() => {
+    standardCleanup()
+    rmSync(temporaryDirectory, { force: true, recursive: true })
+  })
+
+  await it('should persist a barrier between decommission and deletion', async () => {
+    const { calls, fetchImplementation } = createFetchMock([
+      {
+        body: { provisionStatus: 'ACTIVE' },
+        method: 'GET',
+        path: '/v1/chargers/charger-1/profile',
+      },
+      { body: { items: [] }, method: 'POST', path: '/v1/ev-transactions/filter' },
+      { body: { items: [] }, method: 'POST', path: '/v1/reservations/filter' },
+      {
+        body: {},
+        method: 'PATCH',
+        path: '/v1/chargers/charger-1/status/actions/decommission',
+      },
+    ])
+    const workflow = createWorkflow(fetchImplementation)
+
+    const state = await workflow.run()
+
+    assert.deepStrictEqual(
+      calls.map(({ method, path }) => `${method} ${path}`),
+      [
+        'GET /v1/chargers/charger-1/profile',
+        'POST /v1/ev-transactions/filter',
+        'POST /v1/reservations/filter',
+        'PATCH /v1/chargers/charger-1/status/actions/decommission',
+      ]
+    )
+    assert.deepStrictEqual(calls[1].body, { chargerIds: ['charger-1'] })
+    assert.deepStrictEqual(calls[2].body, { chargerIds: ['charger-1'] })
+    assert.deepStrictEqual(calls[3].body, {
+      allowPastDate: true,
+      date: '2026-08-07T15:11:14.278Z',
+    })
+    assert.strictEqual(state.chargers['charger-1'].phase, Phase.POLL_DECOMMISSION)
+  })
+
+  await it('should leave deletion pending when decommission polling times out', async () => {
+    writePollingState()
+    let clock = 0
+    const { calls, fetchImplementation } = createFetchMock([
+      {
+        body: { provisionStatus: 'DECOMMISSIONING' },
+        method: 'GET',
+        path: '/v1/chargers/charger-1/profile',
+      },
+      {
+        body: { provisionStatus: 'DECOMMISSIONING' },
+        method: 'GET',
+        path: '/v1/chargers/charger-1/profile',
+      },
+    ])
+    const workflow = createWorkflow(fetchImplementation, {
+      now: () => clock,
+      pollIntervalMs: 10,
+      pollTimeoutMs: 10,
+      sleep: delay => {
+        clock += delay
+        return Promise.resolve()
+      },
+    })
+
+    const state = await workflow.run()
+
+    assert.strictEqual(state.chargers['charger-1'].phase, Phase.POLL_DECOMMISSION)
+    assert.match(state.chargers['charger-1'].lastError?.message ?? '', /Timed out/)
+    assert.strictEqual(
+      calls.some(({ method }) => method === 'DELETE'),
+      false
+    )
+  })
+
+  await it('should retry polling after an API error without repeating decommission', async () => {
+    writePollingState()
+    const failedRun = createFetchMock([
+      {
+        body: { message: 'temporary failure' },
+        method: 'GET',
+        path: '/v1/chargers/charger-1/profile',
+        status: 503,
+      },
+    ])
+
+    const failedState = await createWorkflow(failedRun.fetchImplementation).run()
+
+    assert.strictEqual(failedState.chargers['charger-1'].phase, Phase.POLL_DECOMMISSION)
+    assert.match(failedState.chargers['charger-1'].lastError?.message ?? '', /status 503/)
+
+    const retryRun = createFetchMock(completionResponses())
+    const completedState = await createWorkflow(retryRun.fetchImplementation).run()
+
+    assert.strictEqual(completedState.chargers['charger-1'].phase, Phase.COMPLETE)
+    assert.strictEqual(
+      retryRun.calls.some(({ path }) => path.endsWith('/actions/decommission')),
+      false
+    )
+  })
+
+  await it('should resume from persisted state after process restart', async () => {
+    const firstRun = createFetchMock([
+      {
+        body: { provisionStatus: 'ACTIVE' },
+        method: 'GET',
+        path: '/v1/chargers/charger-1/profile',
+      },
+      { body: { total: 0 }, method: 'POST', path: '/v1/ev-transactions/filter' },
+      { body: { total: 0 }, method: 'POST', path: '/v1/reservations/filter' },
+      { body: {}, method: 'PATCH', path: '/v1/chargers/charger-1/status/actions/decommission' },
+    ])
+    await createWorkflow(firstRun.fetchImplementation).run()
+
+    const secondRun = createFetchMock(completionResponses())
+    const state = await createWorkflow(secondRun.fetchImplementation).run()
+
+    assert.strictEqual(state.chargers['charger-1'].phase, Phase.COMPLETE)
+    assert.strictEqual(secondRun.calls[0].path, '/v1/chargers/charger-1/profile')
+    assert.strictEqual(
+      secondRun.calls.some(({ path }) => path === '/v1/ev-transactions/filter'),
+      false
+    )
+    const persistedState = JSON.parse(readFileSync(stateFile, 'utf8')) as WorkflowState
+    assert.strictEqual(persistedState.chargers['charger-1'].phase, Phase.COMPLETE)
+  })
+
+  await it('should reconcile an accepted decommission after a crash before phase persistence', async () => {
+    writeState(Phase.DECOMMISSION, {
+      decommissionAttemptedAt: '2026-08-07T15:11:14.278Z',
+      preflight: { provisionStatus: 'ACTIVE' },
+    })
+    const { calls, fetchImplementation } = createFetchMock([
+      {
+        body: { provisionStatus: 'DECOMMISSIONING' },
+        method: 'GET',
+        path: '/v1/chargers/charger-1/profile',
+      },
+    ])
+
+    const state = await createWorkflow(fetchImplementation).run()
+
+    assert.strictEqual(state.chargers['charger-1'].phase, Phase.POLL_DECOMMISSION)
+    assert.deepStrictEqual(
+      calls.map(({ method }) => method),
+      ['GET']
+    )
+  })
+
+  await it('should reconcile before retrying decommission and reuse the persisted timestamp', async () => {
+    writeState(Phase.DECOMMISSION, {
+      decommissionAttemptedAt: '2026-08-07T15:11:14.278Z',
+      preflight: { provisionStatus: 'ACTIVE' },
+    })
+    let clock = 0
+    const { calls, fetchImplementation } = createFetchMock([
+      {
+        body: { provisionStatus: 'ACTIVE' },
+        method: 'GET',
+        path: '/v1/chargers/charger-1/profile',
+      },
+      {
+        body: { provisionStatus: 'ACTIVE' },
+        method: 'GET',
+        path: '/v1/chargers/charger-1/profile',
+      },
+      { body: {}, method: 'PATCH', path: '/v1/chargers/charger-1/status/actions/decommission' },
+    ])
+
+    const state = await createWorkflow(fetchImplementation, {
+      now: () => clock,
+      pollIntervalMs: 10,
+      pollTimeoutMs: 10,
+      sleep: delay => {
+        clock += delay
+        return Promise.resolve()
+      },
+    }).run()
+
+    assert.strictEqual(state.chargers['charger-1'].phase, Phase.POLL_DECOMMISSION)
+    assert.deepStrictEqual(
+      calls.map(({ method }) => method),
+      ['GET', 'GET', 'PATCH']
+    )
+    assert.deepStrictEqual(calls[2].body, {
+      allowPastDate: true,
+      date: '2026-08-07T15:11:14.278Z',
+    })
+  })
+
+  await it('should keep the workflow pending when a profile is absent before charger deletion', async () => {
+    for (const phase of [Phase.PREFLIGHT, Phase.POLL_DECOMMISSION]) {
+      writeState(phase)
+      const { calls, fetchImplementation } = createFetchMock([
+        { body: {}, method: 'GET', path: '/v1/chargers/charger-1/profile', status: 404 },
+      ])
+
+      const state = await createWorkflow(fetchImplementation).run()
+
+      assert.strictEqual(state.chargers['charger-1'].phase, phase)
+      assert.match(state.chargers['charger-1'].lastError?.message ?? '', /profile is absent/)
+      assert.strictEqual(
+        calls.some(({ method }) => method === 'DELETE'),
+        false
+      )
+    }
+  })
+
+  await it('should retain a non-empty site and not read or delete its property', async () => {
+    writeState(Phase.CLEAN_SITE)
+    const { calls, fetchImplementation } = createFetchMock([
+      { body: { chargerIds: ['shared-charger'] }, method: 'GET', path: '/v1/sites/site-1' },
+    ])
+
+    const state = await createWorkflow(fetchImplementation).run()
+
+    assert.strictEqual(state.chargers['charger-1'].phase, Phase.COMPLETE)
+    assert.deepStrictEqual(
+      calls.map(({ method, path }) => `${method} ${path}`),
+      ['GET /v1/sites/site-1']
+    )
+  })
+
+  await it('should retain shared and ambiguously shared properties', async () => {
+    for (const property of [{ isShared: true, siteIds: [] }, { siteIds: [] }]) {
+      writeState(Phase.CLEAN_PROPERTY)
+      const { calls, fetchImplementation } = createFetchMock([
+        { body: property, method: 'GET', path: '/v1/properties/property-1' },
+      ])
+
+      const state = await createWorkflow(fetchImplementation).run()
+
+      assert.strictEqual(state.chargers['charger-1'].phase, Phase.COMPLETE)
+      assert.strictEqual(
+        calls.some(({ method }) => method === 'DELETE'),
+        false
+      )
+    }
+  })
+
+  /**
+   * Builds the successful response sequence after decommissioning.
+   * @returns Ordered API responses through parent deletion.
+   */
+  function completionResponses (): MockResponseSpec[] {
+    return [
+      {
+        body: { provisionStatus: 'DECOMMISSIONED' },
+        method: 'GET',
+        path: '/v1/chargers/charger-1/profile',
+      },
+      { body: {}, method: 'PATCH', path: '/v1/chargers/charger-1/connectors/connector-1/evse' },
+      { body: {}, method: 'DELETE', path: '/v1/chargers/charger-1' },
+      { body: {}, method: 'GET', path: '/v1/chargers/charger-1/profile', status: 404 },
+      { body: { chargerIds: [] }, method: 'GET', path: '/v1/sites/site-1' },
+      { body: {}, method: 'DELETE', path: '/v1/sites/site-1' },
+      { body: {}, method: 'GET', path: '/v1/sites/site-1', status: 404 },
+      { body: { isShared: false, siteIds: [] }, method: 'GET', path: '/v1/properties/property-1' },
+      { body: {}, method: 'DELETE', path: '/v1/properties/property-1' },
+      { body: {}, method: 'GET', path: '/v1/properties/property-1', status: 404 },
+    ]
+  }
+
+  /**
+   * Creates a workflow backed by the current test state file.
+   * @param fetchImplementation - Fetch mock for this run.
+   * @param overrides - Optional workflow timing overrides.
+   * @returns A configured deletion workflow.
+   */
+  function createWorkflow (
+    fetchImplementation: typeof fetch,
+    overrides: Partial<WorkflowOptions> = {}
+  ): { run: () => Promise<WorkflowState> } {
+    return new DriivzDeletionWorkflow({
+      chargers: [CHARGER],
+      client: new DriivzClient({ baseUrl: BASE_URL, fetchImplementation }),
+      now: () => Date.parse('2026-08-07T15:11:14.278Z'),
+      pollIntervalMs: 1,
+      pollTimeoutMs: 10,
+      sleep: () => Promise.resolve(),
+      stateStore: new FileWorkflowStateStore(stateFile),
+      ...overrides,
+    })
+  }
+
+  /**
+   * Persists a workflow waiting for decommission completion.
+   */
+  function writePollingState (): void {
+    writeState(Phase.POLL_DECOMMISSION)
+  }
+
+  /**
+   * Persists a workflow at a selected phase.
+   * @param phase - Phase to resume from.
+   * @param stateOverrides - Additional persisted charger state.
+   */
+  function writeState (phase: string, stateOverrides: Partial<ChargerState> = {}): void {
+    new FileWorkflowStateStore(stateFile).save({
+      chargers: {
+        'charger-1': {
+          attempts: 1,
+          charger: CHARGER,
+          phase,
+          updatedAt: '2026-08-07T15:11:14.278Z',
+          ...stateOverrides,
+        },
+      },
+      version: 1,
+    })
+  }
+})


### PR DESCRIPTION
## Summary
- replace direct MongoDB deletion with the dedicated persistent Driivz lifecycle
- separate decommission and deletion across runs, with polling, retry, and crash recovery
- protect shared Site and Property resources through read-back checks
- add mocked sequencing, timeout, retry, restart, and parent-protection tests

No live Driivz writes were performed.