### PR TITLE
fix(simulator): seed autoRegister and ocppProtocol defaults into stationInfo

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -373,6 +373,7 @@ export {
   MeterValueUnit,
   type SampledValue,
 } from './ocpp/MeterValues.js'
+export { OCPPProtocol } from './ocpp/OCPPProtocol.js'
 export { OCPPVersion } from './ocpp/OCPPVersion.js'
 export {
   AvailabilityType,

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -2,6 +2,7 @@ import {
   type AutomaticTransactionGeneratorConfiguration,
   type ChargingStationInfo,
   CurrentType,
+  OCPPProtocol,
   OCPPVersion,
   VendorParametersKey,
 } from '../types/index.js'
@@ -81,6 +82,7 @@ export class Constants {
   static readonly DEFAULT_STATION_INFO: Readonly<Partial<ChargingStationInfo>> = Object.freeze({
     automaticTransactionGeneratorPersistentConfiguration: true,
     autoReconnectMaxRetries: -1,
+    autoRegister: false,
     autoStart: true,
     beginEndMeterValues: false,
     currentOutType: CurrentType.AC,
@@ -99,6 +101,7 @@ export class Constants {
     mainVoltageMeterValues: true,
     meteringPerTransaction: true,
     ocppPersistentConfiguration: true,
+    ocppProtocol: OCPPProtocol.JSON,
     ocppStrictCompliance: true,
     ocppVersion: OCPPVersion.VERSION_16,
     outOfOrderEndMeterValues: false,

--- a/tests/TEST_STYLE_GUIDE.md
+++ b/tests/TEST_STYLE_GUIDE.md
@@ -327,14 +327,14 @@ Tests exercising the real construction pipeline (persistence, reset, reconnect, 
 parsing) MUST build a real station from a template file via
 `helpers/StationHelpers.realStation.ts` — never re-implement the temp-dir scaffolding:
 
-| Helper                                 | Purpose                                                     |
-| -------------------------------------- | ----------------------------------------------------------- |
-| `writeStationTemplate(obj)`            | Write an inline template object into an isolated temp dir   |
-| `copyStationTemplate(ovr?)`            | Copy a bundled asset template, optionally merging overrides |
-| `cleanupStationTemplates()`            | Remove temp template dirs (call in `afterEach`)             |
-| `createStationFromTemplate()`          | Construct a real `ChargingStation` from a template file     |
-| `persistedConfigurationDir(f)`         | Resolve the sibling `configurations` dir of a template file |
-| `resolvePersistedConfigurationFile(f)` | Resolve the persisted config file (throws if none yet)      |
+| Helper                                    | Purpose                                                     |
+| ----------------------------------------- | ----------------------------------------------------------- |
+| `writeStationTemplate(obj)`               | Write an inline template object into an isolated temp dir   |
+| `copyStationTemplate(ovr?)`               | Copy a bundled asset template, optionally merging overrides |
+| `cleanupStationTemplates()`               | Remove temp template dirs (call in `afterEach`)             |
+| `createStationFromTemplate()`             | Construct a real `ChargingStation` from a template file     |
+| `persistedConfigurationDir(file)`         | Resolve the sibling `configurations` dir of a template file |
+| `resolvePersistedConfigurationFile(file)` | Resolve the persisted config file (throws if none yet)      |
 
 ```typescript
 afterEach(() => {

--- a/tests/TEST_STYLE_GUIDE.md
+++ b/tests/TEST_STYLE_GUIDE.md
@@ -327,12 +327,14 @@ Tests exercising the real construction pipeline (persistence, reset, reconnect, 
 parsing) MUST build a real station from a template file via
 `helpers/StationHelpers.realStation.ts` — never re-implement the temp-dir scaffolding:
 
-| Helper                        | Purpose                                                     |
-| ----------------------------- | ----------------------------------------------------------- |
-| `writeStationTemplate(obj)`   | Write an inline template object into an isolated temp dir   |
-| `copyStationTemplate(ovr?)`   | Copy a bundled asset template, optionally merging overrides |
-| `createStationFromTemplate()` | Construct a real `ChargingStation` from a template file     |
-| `cleanupStationTemplates()`   | Remove temp template dirs (call in `afterEach`)             |
+| Helper                                 | Purpose                                                     |
+| -------------------------------------- | ----------------------------------------------------------- |
+| `writeStationTemplate(obj)`            | Write an inline template object into an isolated temp dir   |
+| `copyStationTemplate(ovr?)`            | Copy a bundled asset template, optionally merging overrides |
+| `cleanupStationTemplates()`            | Remove temp template dirs (call in `afterEach`)             |
+| `createStationFromTemplate()`          | Construct a real `ChargingStation` from a template file     |
+| `persistedConfigurationDir(f)`         | Resolve the sibling `configurations` dir of a template file |
+| `resolvePersistedConfigurationFile(f)` | Resolve the persisted config file (throws if none yet)      |
 
 ```typescript
 afterEach(() => {

--- a/tests/charging-station/ChargingStation-AutoRegisterOcppProtocol.test.ts
+++ b/tests/charging-station/ChargingStation-AutoRegisterOcppProtocol.test.ts
@@ -11,8 +11,7 @@
  * from the default (non-discriminant).
  */
 import assert from 'node:assert/strict'
-import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { afterEach, describe, it } from 'node:test'
 
 import type { ChargingStation } from '../../src/charging-station/ChargingStation.js'
@@ -23,6 +22,7 @@ import { flushMicrotasks, standardCleanup } from '../helpers/TestLifecycleHelper
 import {
   cleanupStationTemplates,
   createStationFromTemplate,
+  resolvePersistedConfigurationFile,
   writeStationTemplate,
 } from './helpers/StationHelpers.realStation.js'
 
@@ -93,11 +93,7 @@ await describe('ChargingStation autoRegister/ocppProtocol seeding', async () => 
     makeStation(templateFile, true)
     await flushMicrotasks()
     // Simulate a legacy configuration written before the fields were seeded.
-    const configurationDir = join(dirname(dirname(templateFile)), 'configurations')
-    const configurationFile = join(
-      configurationDir,
-      readdirSync(configurationDir).find(entry => entry.endsWith('.json')) ?? ''
-    )
+    const configurationFile = resolvePersistedConfigurationFile(templateFile)
     const configuration = JSON.parse(readFileSync(configurationFile, 'utf8')) as {
       stationInfo: { autoRegister?: boolean; ocppProtocol?: string }
     }

--- a/tests/charging-station/ChargingStation-AutoRegisterOcppProtocol.test.ts
+++ b/tests/charging-station/ChargingStation-AutoRegisterOcppProtocol.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @file Tests for `autoRegister` and `ocppProtocol` default seeding into `stationInfo`.
+ * @description Both fields are static defaults with no derivation, so they live in
+ * `DEFAULT_STATION_INFO` (`autoRegister: false`, `ocppProtocol: OCPPProtocol.JSON`)
+ * and are applied by `getStationInfo` via `mergeDeepRight(DEFAULT_STATION_INFO, stationInfo)`.
+ * A template omitting them must yield the seeded values in `stationInfo` and in the UI
+ * data payload (`buildAddedMessage`) instead of `undefined` (the empty Web UI placeholder).
+ * An explicit template value is preserved (idempotent, no clobber), and a persisted
+ * configuration predating the fields is backfilled on reload. `ocppProtocol` preservation
+ * is not tested: the enum has a single value, so an explicit value is indistinguishable
+ * from the default (non-discriminant).
+ */
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, it } from 'node:test'
+
+import type { ChargingStation } from '../../src/charging-station/ChargingStation.js'
+
+import { OCPPProtocol } from '../../src/types/index.js'
+import { buildAddedMessage } from '../../src/utils/MessageChannelUtils.js'
+import { flushMicrotasks, standardCleanup } from '../helpers/TestLifecycleHelpers.js'
+import {
+  cleanupStationTemplates,
+  createStationFromTemplate,
+  writeStationTemplate,
+} from './helpers/StationHelpers.realStation.js'
+
+const POWER_W = 22000
+
+interface TemplateOverrides {
+  autoRegister?: boolean
+}
+
+const buildTemplate = (overrides: TemplateOverrides = {}): Record<string, unknown> => ({
+  $schemaVersion: 1,
+  baseName: 'TEST-AUTO-REGISTER-OCPP-PROTOCOL',
+  chargePointModel: 'Simulator simple',
+  chargePointVendor: 'Simulator',
+  Connectors: {
+    0: {},
+    1: { bootStatus: 'Available' },
+  },
+  currentOutType: 'AC',
+  numberOfConnectors: 1,
+  power: POWER_W,
+  powerUnit: 'W',
+  randomConnectors: false,
+  ...(overrides.autoRegister != null ? { autoRegister: overrides.autoRegister } : {}),
+})
+
+const makeStation = (templateFile: string, persistentConfiguration = false): ChargingStation =>
+  createStationFromTemplate(templateFile, {
+    baseName: 'TEST-AUTO-REGISTER-OCPP-PROTOCOL',
+    fixedName: true,
+    persistentConfiguration,
+  })
+
+const newStation = (overrides: TemplateOverrides = {}): ChargingStation =>
+  makeStation(writeStationTemplate(buildTemplate(overrides)))
+
+await describe('ChargingStation autoRegister/ocppProtocol seeding', async () => {
+  afterEach(() => {
+    standardCleanup()
+    cleanupStationTemplates()
+  })
+
+  await it('should seed autoRegister to false for a template omitting the field', () => {
+    const station = newStation()
+    assert.strictEqual(station.stationInfo?.autoRegister, false)
+  })
+
+  await it('should seed ocppProtocol to json for a template omitting the field', () => {
+    const station = newStation()
+    assert.strictEqual(station.stationInfo?.ocppProtocol, OCPPProtocol.JSON)
+  })
+
+  await it('should transmit the seeded defaults in the UI data payload', () => {
+    const station = newStation()
+    const { stationInfo } = buildAddedMessage(station).data
+    assert.strictEqual(stationInfo.autoRegister, false)
+    assert.strictEqual(stationInfo.ocppProtocol, OCPPProtocol.JSON)
+  })
+
+  await it('should preserve an explicit autoRegister template value', () => {
+    const station = newStation({ autoRegister: true })
+    assert.strictEqual(station.stationInfo?.autoRegister, true)
+  })
+
+  await it('should backfill the defaults into a persisted config that predates the fields', async () => {
+    const templateFile = writeStationTemplate(buildTemplate())
+    // The persisted config write runs under an async lock; flush before reading it back.
+    makeStation(templateFile, true)
+    await flushMicrotasks()
+    // Simulate a legacy configuration written before the fields were seeded.
+    const configurationDir = join(dirname(dirname(templateFile)), 'configurations')
+    const configurationFile = join(
+      configurationDir,
+      readdirSync(configurationDir).find(entry => entry.endsWith('.json')) ?? ''
+    )
+    const configuration = JSON.parse(readFileSync(configurationFile, 'utf8')) as {
+      stationInfo: { autoRegister?: boolean; ocppProtocol?: string }
+    }
+    assert.strictEqual(configuration.stationInfo.autoRegister, false)
+    assert.strictEqual(configuration.stationInfo.ocppProtocol, OCPPProtocol.JSON)
+    delete configuration.stationInfo.autoRegister
+    delete configuration.stationInfo.ocppProtocol
+    writeFileSync(configurationFile, JSON.stringify(configuration), 'utf8')
+    // A fresh station starts with an empty configurationFileHash, so getConfigurationFromFile
+    // bypasses the shared cache and reads the file from disk; the file-sourced stationInfo
+    // is backfilled by mergeDeepRight(DEFAULT_STATION_INFO, stationInfo) in getStationInfo.
+    const reloaded = makeStation(templateFile, true)
+    assert.ok(reloaded.stationInfo)
+    assert.strictEqual(reloaded.stationInfo.autoRegister, false)
+    assert.strictEqual(reloaded.stationInfo.ocppProtocol, OCPPProtocol.JSON)
+  })
+})

--- a/tests/charging-station/ChargingStation-NumberOfPhases.test.ts
+++ b/tests/charging-station/ChargingStation-NumberOfPhases.test.ts
@@ -10,8 +10,7 @@
  * backfilled on reload.
  */
 import assert from 'node:assert/strict'
-import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { afterEach, describe, it } from 'node:test'
 
 import type { ChargingStation } from '../../src/charging-station/ChargingStation.js'
@@ -21,6 +20,7 @@ import { flushMicrotasks, standardCleanup } from '../helpers/TestLifecycleHelper
 import {
   cleanupStationTemplates,
   createStationFromTemplate,
+  resolvePersistedConfigurationFile,
   writeStationTemplate,
 } from './helpers/StationHelpers.realStation.js'
 
@@ -103,11 +103,7 @@ await describe('ChargingStation numberOfPhases seeding', async () => {
     makeStation(templateFile, true)
     await flushMicrotasks()
     // Simulate a legacy configuration written before numberOfPhases was seeded.
-    const configurationDir = join(dirname(dirname(templateFile)), 'configurations')
-    const configurationFile = join(
-      configurationDir,
-      readdirSync(configurationDir).find(entry => entry.endsWith('.json')) ?? ''
-    )
+    const configurationFile = resolvePersistedConfigurationFile(templateFile)
     const configuration = JSON.parse(readFileSync(configurationFile, 'utf8')) as {
       stationInfo: { numberOfPhases?: number }
     }

--- a/tests/charging-station/ChargingStation-ResetIdentity.test.ts
+++ b/tests/charging-station/ChargingStation-ResetIdentity.test.ts
@@ -6,7 +6,7 @@
  */
 import assert from 'node:assert/strict'
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 import { afterEach, describe, it } from 'node:test'
 import { setTimeout as sleep } from 'node:timers/promises'
 
@@ -19,6 +19,7 @@ import {
   cleanupStationTemplates,
   copyStationTemplate,
   createStationFromTemplate,
+  persistedConfigurationDir,
 } from './helpers/StationHelpers.realStation.js'
 
 // The identity logic lives in initialize(); the identity tests call it directly
@@ -41,7 +42,7 @@ const waitForPersistedId = async (
   templateFile: string,
   chargingStationId: string
 ): Promise<boolean> => {
-  const configurationsDir = dirname(templateFile.replace('station-templates', 'configurations'))
+  const configurationsDir = persistedConfigurationDir(templateFile)
   for (let attempt = 0; attempt < 100; attempt++) {
     if (existsSync(configurationsDir)) {
       for (const file of readdirSync(configurationsDir)) {

--- a/tests/charging-station/helpers/StationHelpers.realStation.ts
+++ b/tests/charging-station/helpers/StationHelpers.realStation.ts
@@ -2,15 +2,25 @@
  * @file Helpers to build a real ChargingStation from a template file.
  * @description Tests that exercise the real construction pipeline
  * (`initialize()`/`getStationInfo()`, persistence, reset, reconnect) cannot use
- * the `createMockChargingStation` stub, which bypasses it. These helpers write a
- * template into an isolated temp `station-templates` dir and construct a real
- * `ChargingStation` from it, tracking temp roots for a single `afterEach`
- * cleanup. Two template sources are supported: an inline object
- * (`writeStationTemplate`) and a bundled asset (`copyStationTemplate`).
+ * the `createMockChargingStation` stub, which bypasses it. Grouped by concern:
+ * (1) temp `station-templates` dir lifecycle — write an inline template
+ * (`writeStationTemplate`) or copy a bundled asset (`copyStationTemplate`),
+ * removed by a single `afterEach` `cleanupStationTemplates`; (2) real
+ * `ChargingStation` construction (`createStationFromTemplate`); (3) resolution of
+ * the persisted configuration the station writes (`persistedConfigurationDir`,
+ * `resolvePersistedConfigurationFile`).
  */
-import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
 import type { ChargingStationOptions } from '../../../src/types/index.js'
 
@@ -28,6 +38,10 @@ const freshTemplateDir = (): string => {
   mkdirSync(join(root, 'station-templates'), { recursive: true })
   return root
 }
+
+// ---------------------------------------------------------------
+// Temp template dir lifecycle
+// ---------------------------------------------------------------
 
 /**
  * Writes an inline template object into a fresh isolated `station-templates` dir.
@@ -67,6 +81,20 @@ export const copyStationTemplate = (
 }
 
 /**
+ * Removes every temp template dir created by `writeStationTemplate`/`copyStationTemplate`.
+ * Call in `afterEach`, alongside `standardCleanup()`.
+ */
+export const cleanupStationTemplates = (): void => {
+  for (const root of templateRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true })
+  }
+}
+
+// ---------------------------------------------------------------
+// Real station construction
+// ---------------------------------------------------------------
+
+/**
  * Constructs a real ChargingStation from a template file with test defaults
  * (`autoStart` off, local supervision URL); caller options take precedence.
  * @param templateFile - Path returned by `writeStationTemplate`/`copyStationTemplate`.
@@ -85,12 +113,31 @@ export const createStationFromTemplate = (
     ...options,
   })
 
+// ---------------------------------------------------------------
+// Persisted configuration resolution
+// ---------------------------------------------------------------
+
 /**
- * Removes every temp template dir created by `writeStationTemplate`/`copyStationTemplate`.
- * Call in `afterEach`, alongside `standardCleanup()`.
+ * Resolves the isolated `configurations` dir sitting beside the
+ * `station-templates` dir of a template file — where a persisted
+ * ChargingStation writes its configuration.
+ * @param templateFile - Path returned by `writeStationTemplate`/`copyStationTemplate`.
+ * @returns Absolute path to the sibling `configurations` dir.
  */
-export const cleanupStationTemplates = (): void => {
-  for (const root of templateRoots.splice(0)) {
-    rmSync(root, { force: true, recursive: true })
+export const persistedConfigurationDir = (templateFile: string): string =>
+  join(dirname(dirname(templateFile)), 'configurations')
+
+/**
+ * Resolves the single persisted configuration file written by a station built
+ * from `templateFile`. Throws when none exists yet (flush the async write first).
+ * @param templateFile - Path returned by `writeStationTemplate`/`copyStationTemplate`.
+ * @returns Absolute path to the persisted configuration `.json` file.
+ */
+export const resolvePersistedConfigurationFile = (templateFile: string): string => {
+  const configurationDir = persistedConfigurationDir(templateFile)
+  const configurationFile = readdirSync(configurationDir).find(entry => entry.endsWith('.json'))
+  if (configurationFile == null) {
+    throw new Error(`No persisted configuration file found in ${configurationDir}`)
   }
+  return join(configurationDir, configurationFile)
 }


### PR DESCRIPTION
## Problem

In the Web UI station details, **Auto Register** and **OCPP Protocol** render as an empty placeholder (Ø) when the template does not define them. Neither `autoRegister` nor `ocppProtocol` has a default value, so `stationInfo` carries `undefined` for both. Raw consumers of `stationInfo` — the UI data payload (`buildChargingStationDataPayload`, `src/utils/MessageChannelUtils.ts:105`) and the persisted configuration — therefore receive `undefined`.

## Change

Both fields are **static** defaults (no derivation), so they belong in `DEFAULT_STATION_INFO` (`src/utils/Constants.ts`) alongside `currentOutType`, `ocppVersion`, `autoStart`:

- `autoRegister: false` — read only in `=== true` guards (`ChargingStation.ts:2044`, `:2948`); default intent is "not auto-registered".
- `ocppProtocol: OCPPProtocol.JSON` — the only enum value (`src/types/ocpp/OCPPProtocol.ts`).

`getStationInfo` applies them via `mergeDeepRight(Constants.DEFAULT_STATION_INFO, stationInfo)` (`ChargingStation.ts:1739`, a custom right-wins merge in `src/utils/Utils.ts`): an explicit template/file value or option still wins (idempotent, no clobber — `false` is never treated as absent), and a persisted config predating the fields is backfilled on reload. Same single-source-of-truth pattern as the recent `numberOfPhases` seeding (#2078), except these fields are static rather than derived (so no getter).

`OCPPProtocol` is now exported from the types barrel (`src/types/index.ts`, next to `OCPPVersion`) so `Constants.ts` keeps importing types from a single source; the barrel did not export it before. `OCPPProtocol` is a leaf enum module, so no import cycle is introduced (passes the `circular-deps` gate).

No UI change is needed: the symptom resolves downstream once `stationInfo` is populated (`ui/web/src/shared/utils/stationDetails.ts` renders the seeded `'json'` and `false`→`No`).

## Design summary

- **Seeding location:** `DEFAULT_STATION_INFO`, single source of truth, DRY, idempotent via the existing merge.
- **Precedence:** `default < selected template-or-file stationInfo < explicit options`. `getStationInfo` selects one source (file XOR template), then merges defaults under it.
- **Heartbeat-warn side effect (investigated, narrow, benign):** the `getHeartbeatInterval` warn guarded by `stationInfo?.autoRegister === false` (`ChargingStation.ts:767`) is the only `autoRegister` read where `false` differs from `undefined`. It is reached only when neither `HeartbeatInterval` nor `HeartBeatInterval` config key exists. `initializeOcppConfiguration` (`:2286-2293`) seeds `HeartbeatInterval='0'` before every `getHeartbeatInterval` caller — **but** `addConfigurationKey` no-ops when `ocppConfiguration.configurationKey` is not an array (`ConfigurationKeyUtils.ts:215-217`), and that is `undefined` when a template omits the `Configuration` block and has no persisted config. So:
  - For templates **with** a `Configuration` block (all 15 shipped templates — `grep -l '"configurationKey"' src/assets/station-templates/*.json` = 15/15), the warn stays **unreachable**; seeding is behavior-neutral.
  - For a custom template that **omits** `Configuration` entirely, a *started* default station emits the warn **once** where it was previously silent. Impact is a single informational log line; the return value (`DEFAULT_HEARTBEAT_INTERVAL_MS`) and all control flow are unchanged; the message ("key not set, using default") is accurate.
  The warn logic is out of scope and unchanged (its message is correct — not proven incorrect).
- **Non-regression:** `ocppProtocol` has zero runtime read; the `autoRegister === true` branches are unaffected by `false` vs `undefined`.

## Tests

New `tests/charging-station/ChargingStation-AutoRegisterOcppProtocol.test.ts` (mirrors `ChargingStation-NumberOfPhases.test.ts`, builds a real station from a template):

- seeds `autoRegister` to `false` when the template omits it;
- seeds `ocppProtocol` to `'json'` when the template omits it;
- transmits both seeded defaults in the UI data payload (`buildAddedMessage`);
- preserves an explicit `autoRegister: true` template value (no clobber);
- backfills both defaults into a persisted config that predates the fields on reload.

Discriminance was verified by mutation: removing either default from `DEFAULT_STATION_INFO` turns 3 of the 5 cases red. `ocppProtocol` preservation is intentionally not tested: the enum has a single value, so an explicit value is indistinguishable from the default (non-discriminant). The warn is not asserted (the test template omits `Configuration` but never starts the station).

## Validation (local, all green)

- `pnpm typecheck` ✔
- `pnpm lint` ✔
- `pnpm build` ✔
- `pnpm test` ✔ — 3225 tests, 3219 pass, 0 fail, 6 skipped
- `prettier --check` on touched files ✔
- New suite: 5/5 pass

## Risks

- One-time, benign persisted-config rewrite on the first reload of a station whose config predates these fields (the recomputed configuration hash differs once, then stabilizes) — same behavior as the `numberOfPhases` precedent.
- One extra informational `warn` log line at start for custom templates that omit the `Configuration` block (see Design summary); shipped templates unaffected.

## Acceptance criteria

1. Template without `autoRegister` → `stationInfo.autoRegister === false`, present in payload. ✔
2. Template without `ocppProtocol` → `stationInfo.ocppProtocol === 'json'`, present in payload. ✔
3. Explicit template/option values preserved (e.g. `autoRegister: true`). ✔
4. `getHeartbeatInterval` side effect investigated and documented (narrow, cosmetic, return-value-neutral). ✔
5. Non-regression: no runtime `ocppProtocol` read; `autoRegister === true` branches unchanged. ✔
6. Root-package quality gates green. ✔