### PR TITLE
fix(webui): keep modern station-card Delete action aligned on the footer row

### DIFF
--- a/ui/web/src/skins/modern/modern.css
+++ b/ui/web/src/skins/modern/modern.css
@@ -592,9 +592,12 @@ html[data-skin='modern'] #app {
   text-align: center;
 }
 
+/* Single flex line: keep the action group and the Delete button on one
+ * row so the group can never push Delete onto its own wrapped line. When
+ * space is tight the group (below) wraps its buttons internally instead. */
 .modern-card__foot {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: center;
   gap: var(--skin-space-2);
   padding: var(--skin-space-3) var(--skin-space-4);
@@ -602,17 +605,25 @@ html[data-skin='modern'] #app {
   border-top: 1px solid var(--skin-border);
 }
 
+/* Wrap the primary/secondary actions internally on narrow cards; the
+ * group shrinks and reflows its buttons across rows rather than forcing
+ * the footer to break Delete off. */
 .modern-card__foot-group {
-  display: inline-flex;
+  display: flex;
+  flex-wrap: wrap;
   gap: var(--skin-space-2);
   align-items: center;
 }
 
 /* Push the danger action to the right. The red outline carries the
  * "destructive, different category" signal by itself — no extra divider
- * needed, which would disrupt the button's rounded shape. */
+ * needed, which would disrupt the button's rounded shape. align-self keeps
+ * Delete top-aligned with the first action row when the group wraps (it is
+ * a no-op on single-row cards), so it reads as a top-right peer instead of
+ * floating at the group's vertical centre. */
 .modern-card__foot > .modern-btn--danger {
   margin-left: auto;
+  align-self: flex-start;
 }
 
 /* ── Connector row ─────────────────────────────────────────────────── */


### PR DESCRIPTION
## PR Checklist

- [x] Please add a description of your changes.
- [x] Please ensure title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] We need your changes to come with unit tests in order to keep this project in quality and easy to maintain.
- [x] If your changes contain any new feature please be sure to document it.
- [ ] Please add a link to the open issue or task that this pull request will resolve.

> Tests: none added. The change is a pure CSS layout fix in the modern skin; a CSS-layout unit test would not defend an observable component contract (the existing StationCard suite of 601 tests still passes, and jsdom has no layout engine). Verification was done visually in a real browser (below).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

---

### Problem

In the **modern** skin, a station card's **Delete** button rendered on a second row, bottom-right, **below** the other action buttons (Start/Stop, Connect/Disconnect, Authorize, Details, Configuration) instead of aligned with them.

**Root cause** (`ui/web/src/skins/modern/modern.css`):
- `.modern-card__foot` was `display: flex; flex-wrap: wrap`.
- `.modern-card__foot-group` (the 5 action buttons) was `display: inline-flex` with **no wrap** — one rigid flex item as wide as its buttons summed.
- `.modern-card__foot > .modern-btn--danger` (Delete) is a sibling with `margin-left: auto`.

Once the group's *max-content* width exceeded the card, the footer's line-collection (CSS Flexbox §9.3, which sizes items by their hypothetical/max-content size) broke the line **between the group and Delete**, dropping Delete onto its own line where `margin-left: auto` pinned it bottom-right. A 4th/5th ghost button (Details #2072, Configuration #2077) pushed the group past the card width and exposed the regression.

### Fix

Make the footer a **single flex line** and let the action group **wrap internally**:
- `.modern-card__foot`: `flex-wrap: wrap` → `flex-wrap: nowrap` (keeps the group and Delete on one row so the group can never eject Delete).
- `.modern-card__foot-group`: `display: inline-flex` → `display: flex` + `flex-wrap: wrap` (the group shrinks and reflows its buttons across rows on narrow cards).
- `.modern-card__foot > .modern-btn--danger`: keep `margin-left: auto`, add `align-self: flex-start` (top-aligns Delete with the first action row when the group wraps; a no-op on single-row cards).

Only existing `--skin-*` tokens; no magic numbers; no markup or handler change; classic skin, `useStationActions`, and delete logic untouched.

### Design rationale

A first candidate (adding `flex-wrap` to the group only) was **empirically refuted**: because the footer itself wrapped, it still broke the line before Delete using the group's max-content size, leaving Delete orphaned and making the footer taller. `flex: 1 1 auto` and `min-width: 0` on the group were evaluated and rejected as unnecessary (and `min-width: 0` would actually let the nowrap buttons overflow the group) — the group's min-content is its widest single button (~112px), which always fits.

### Verification

- **Quality gates (`ui/web`)**: prettier `--check` ✓ · eslint 0 errors ✓ · `vue-tsc --noEmit` ✓ · `vite build` ✓ · `vitest run` 601/601 ✓.
- **Visual (real component in a browser)**: mounted the actual `StationCard.vue` with `modern.css` and measured geometry + captured screenshots at card widths 342/422/482/562/702px.
  - **Before**: at 342/422/482px Delete sat on its own line, bottom-right (orphaned).
  - **After**: at **all** widths Delete stays inline with the group (top offset 13px = first action row), pinned to the right padding (16px), never overflowing, danger variant preserved. Footer degrades cleanly 3→2→1 rows as width grows.
  - Wide (≥562px): all actions on one row, Delete distinct far-right. Narrow (≤482px): group wraps left, Delete a clean top-right anchor — no orphan.

### Risks

- Below ~222px card content width the group cannot shrink past its widest single button, so with the footer set to `nowrap` the footer content would **overflow horizontally** (rather than Delete wrapping). Unreachable in practice: the responsive grid uses `minmax(min(100%, 420px), 1fr)`, so even on a ~320px phone (where the column collapses to 100% viewport width) the footer still has ~256–288px of content width, comfortably above the threshold.
- Layout is color-token-independent, so both light/dark themes are unaffected; only the modern skin is touched.