### PR TITLE
refactor(webui): order station action buttons by CSO lifecycle

### DIFF
--- a/ui/web/src/skins/classic/components/charging-stations/CSData.vue
+++ b/ui/web/src/skins/classic/components/charging-stations/CSData.vue
@@ -71,31 +71,6 @@
         Set Supervision Url
       </ToggleButton>
       <ToggleButton
-        :id="`${chargingStation.stationInfo.hashId}-show-details`"
-        :off="
-          () => {
-            $router.push({ name: ROUTE_NAMES.CHARGING_STATIONS }).catch(() => undefined)
-          }
-        "
-        :on="
-          () => {
-            $router
-              .push({
-                name: ROUTE_NAMES.SHOW_DETAILS,
-                params: {
-                  hashId: chargingStation.stationInfo.hashId,
-                  chargingStationId: chargingStation.stationInfo.chargingStationId,
-                },
-              })
-              .catch(() => undefined)
-          }
-        "
-        :shared="true"
-        @clicked="$emit('need-refresh')"
-      >
-        Show Details
-      </ToggleButton>
-      <ToggleButton
         :id="`${chargingStation.stationInfo.hashId}-change-configuration`"
         :off="
           () => {
@@ -119,6 +94,31 @@
         @clicked="$emit('need-refresh')"
       >
         Change Configuration
+      </ToggleButton>
+      <ToggleButton
+        :id="`${chargingStation.stationInfo.hashId}-show-details`"
+        :off="
+          () => {
+            $router.push({ name: ROUTE_NAMES.CHARGING_STATIONS }).catch(() => undefined)
+          }
+        "
+        :on="
+          () => {
+            $router
+              .push({
+                name: ROUTE_NAMES.SHOW_DETAILS,
+                params: {
+                  hashId: chargingStation.stationInfo.hashId,
+                  chargingStationId: chargingStation.stationInfo.chargingStationId,
+                },
+              })
+              .catch(() => undefined)
+          }
+        "
+        :shared="true"
+        @clicked="$emit('need-refresh')"
+      >
+        Show Details
       </ToggleButton>
       <Button @click="deleteChargingStation()">
         Delete Charging Station

--- a/ui/web/src/skins/modern/components/StationCard.vue
+++ b/ui/web/src/skins/modern/components/StationCard.vue
@@ -132,6 +132,12 @@
         </ActionButton>
         <ActionButton
           variant="ghost"
+          @click="emitOpenChangeConfig"
+        >
+          Configuration
+        </ActionButton>
+        <ActionButton
+          variant="ghost"
           @click="emitOpenAuthorize"
         >
           Authorize
@@ -141,12 +147,6 @@
           @click="emitOpenDetails"
         >
           Details
-        </ActionButton>
-        <ActionButton
-          variant="ghost"
-          @click="emitOpenChangeConfig"
-        >
-          Configuration
         </ActionButton>
       </div>
       <ActionButton

--- a/ui/web/tests/unit/skins/classic/CSData.test.ts
+++ b/ui/web/tests/unit/skins/classic/CSData.test.ts
@@ -290,14 +290,21 @@ describe('CSData', () => {
     it('should render set-supervision-url toggle button', () => {
       const wrapper = mountCSData()
       const toggleButtons = wrapper.findAllComponents(ToggleButtonStub)
-      expect(toggleButtons.length).toBeGreaterThanOrEqual(1)
-      expect(toggleButtons[0].props('shared')).toBe(true)
+      const setSupervisionUrlToggle = toggleButtons.find(
+        toggleButton => toggleButton.props('id') === `${TEST_HASH_ID}-set-supervision-url`
+      )
+      expect(setSupervisionUrlToggle).toBeDefined()
+      expect(setSupervisionUrlToggle?.props('shared')).toBe(true)
     })
 
     it('should trigger router push to set-supervision-url on toggle on', () => {
       const wrapper = mountCSData()
       const toggleButtons = wrapper.findAllComponents(ToggleButtonStub)
-      const toggleProps = toggleButtons[0].props() as unknown as StubProps
+      const setSupervisionUrlToggle = toggleButtons.find(
+        toggleButton => toggleButton.props('id') === `${TEST_HASH_ID}-set-supervision-url`
+      )
+      expect(setSupervisionUrlToggle).toBeDefined()
+      const toggleProps = setSupervisionUrlToggle?.props() as unknown as StubProps
       toggleProps.on?.()
       expect(mockPush).toHaveBeenCalledOnce()
       const callArg = mockPush.mock.calls[0][0] as { name: string; params: Record<string, string> }
@@ -309,7 +316,11 @@ describe('CSData', () => {
     it('should trigger router push to charging-stations on toggle off', () => {
       const wrapper = mountCSData()
       const toggleButtons = wrapper.findAllComponents(ToggleButtonStub)
-      const toggleProps = toggleButtons[0].props() as unknown as StubProps
+      const setSupervisionUrlToggle = toggleButtons.find(
+        toggleButton => toggleButton.props('id') === `${TEST_HASH_ID}-set-supervision-url`
+      )
+      expect(setSupervisionUrlToggle).toBeDefined()
+      const toggleProps = setSupervisionUrlToggle?.props() as unknown as StubProps
       toggleProps.off?.()
       expect(mockPush).toHaveBeenCalledWith({ name: 'charging-stations' })
     })

--- a/ui/web/tests/unit/skins/classic/CSData.test.ts
+++ b/ui/web/tests/unit/skins/classic/CSData.test.ts
@@ -314,6 +314,34 @@ describe('CSData', () => {
       expect(mockPush).toHaveBeenCalledWith({ name: 'charging-stations' })
     })
 
+    it('should trigger router push to change-configuration on toggle on', () => {
+      const wrapper = mountCSData()
+      const toggleButtons = wrapper.findAllComponents(ToggleButtonStub)
+      const changeConfigurationToggle = toggleButtons.find(
+        toggleButton => toggleButton.props('id') === `${TEST_HASH_ID}-change-configuration`
+      )
+      expect(changeConfigurationToggle).toBeDefined()
+      const toggleProps = changeConfigurationToggle?.props() as unknown as StubProps
+      toggleProps.on?.()
+      expect(mockPush).toHaveBeenCalledOnce()
+      const callArg = mockPush.mock.calls[0][0] as { name: string; params: Record<string, string> }
+      expect(callArg.name).toBe('change-configuration')
+      expect(callArg.params.hashId).toBe(TEST_HASH_ID)
+      expect(callArg.params.chargingStationId).toBe(TEST_STATION_ID)
+    })
+
+    it('should trigger router push to charging-stations on change-configuration toggle off', () => {
+      const wrapper = mountCSData()
+      const toggleButtons = wrapper.findAllComponents(ToggleButtonStub)
+      const changeConfigurationToggle = toggleButtons.find(
+        toggleButton => toggleButton.props('id') === `${TEST_HASH_ID}-change-configuration`
+      )
+      expect(changeConfigurationToggle).toBeDefined()
+      const toggleProps = changeConfigurationToggle?.props() as unknown as StubProps
+      toggleProps.off?.()
+      expect(mockPush).toHaveBeenCalledWith({ name: 'charging-stations' })
+    })
+
     it('should trigger router push to show-details on toggle on', () => {
       const wrapper = mountCSData()
       const toggleButtons = wrapper.findAllComponents(ToggleButtonStub)

--- a/ui/web/tests/unit/skins/classic/CSData.test.ts
+++ b/ui/web/tests/unit/skins/classic/CSData.test.ts
@@ -317,8 +317,11 @@ describe('CSData', () => {
     it('should trigger router push to show-details on toggle on', () => {
       const wrapper = mountCSData()
       const toggleButtons = wrapper.findAllComponents(ToggleButtonStub)
-      expect(toggleButtons[1].props('id')).toBe(`${TEST_HASH_ID}-show-details`)
-      const toggleProps = toggleButtons[1].props() as unknown as StubProps
+      const showDetailsToggle = toggleButtons.find(
+        toggleButton => toggleButton.props('id') === `${TEST_HASH_ID}-show-details`
+      )
+      expect(showDetailsToggle).toBeDefined()
+      const toggleProps = showDetailsToggle?.props() as unknown as StubProps
       toggleProps.on?.()
       expect(mockPush).toHaveBeenCalledOnce()
       const callArg = mockPush.mock.calls[0][0] as { name: string; params: Record<string, string> }
@@ -330,8 +333,11 @@ describe('CSData', () => {
     it('should trigger router push to charging-stations on show-details toggle off', () => {
       const wrapper = mountCSData()
       const toggleButtons = wrapper.findAllComponents(ToggleButtonStub)
-      expect(toggleButtons[1].props('id')).toBe(`${TEST_HASH_ID}-show-details`)
-      const toggleProps = toggleButtons[1].props() as unknown as StubProps
+      const showDetailsToggle = toggleButtons.find(
+        toggleButton => toggleButton.props('id') === `${TEST_HASH_ID}-show-details`
+      )
+      expect(showDetailsToggle).toBeDefined()
+      const toggleProps = showDetailsToggle?.props() as unknown as StubProps
       toggleProps.off?.()
       expect(mockPush).toHaveBeenCalledWith({ name: 'charging-stations' })
     })


### PR DESCRIPTION
## PR Checklist

- [x] Please add a description of your changes.
- [x] Please ensure title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] We need your changes to come with unit tests in order to keep this project in quality and easy to maintain.
- [x] If your changes contain any new feature please be sure to document it. (N/A — no new feature, ordering-only refactor.)
- [ ] Please add a link to the open issue or task that this pull request will resolve. (No tracking issue; internal UX consistency task.)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

---

## Summary

Reorder the station-card action buttons in **both** skins so they follow the Charging Station Operator (CSO) lifecycle, left→right: **bring-up → provisioning → exploitation → observability**. This is an ordering-only change. Action sets, labels, handlers, routes, styling and the isolated **Delete** button are all unchanged. The two skins are intentionally **not** unified (their action sets differ).

### Before → After

**Modern** (`ui/web/src/skins/modern/components/StationCard.vue`, `.modern-card__foot-group`)

| Before | After |
| --- | --- |
| Start/Stop, Connect/Disconnect, **Authorize, Details, Configuration** | Start/Stop, Connect/Disconnect, **Configuration, Authorize, Details** |

**Classic** (`ui/web/src/skins/classic/components/charging-stations/CSData.vue`)

| Before | After |
| --- | --- |
| Start/Stop, Connection, Set Supervision Url, **Show Details, Change Configuration** | Start/Stop, Connection, Set Supervision Url, **Change Configuration, Show Details** |

Delete stays isolated on the right (modern, outside `.modern-card__foot-group`) and last (classic) in both skins — untouched, so the #2083 alignment fix is preserved.

## Rationale

The order maps to the CSO lifecycle: **bring-up** (Start → Connect) → **provisioning** (Configuration; classic: Set Supervision Url then Change Configuration) → **exploitation** (Authorize; classic has no Authorize in the group) → **observability** (Details / Show Details, last in the group). This corrects two defects in the previous order:

1. **Authorize (runtime) preceded Configuration (provisioning)** — lifecycle-inverted.
2. **Details was wedged between two active commands** instead of terminating the group.

## Tests

The classic `CSData.test.ts` `show-details` toggle assertions were coupled to a fixed toggle index (`toggleButtons[1]`), which shifts to index `2` after the swap. They were made **id-based** (`toggleButtons.find(tb => tb.props('id') === \`${TEST_HASH_ID}-show-details\`)`) so they are robust to ordering and discriminating. No other order-coupled consumer exists (modern `StationCard.test.ts` locates buttons by label; no snapshot/e2e/positional-CSS consumers repo-wide).

## Verification (ui/web quality gates)

- `pnpm typecheck` — pass (exit 0)
- `pnpm lint` — pass (0 errors on changed files)
- `pnpm build` — pass
- `pnpm test` (vitest) — 601 passed / 34 files
- **Visual (real running app, headless browser against a live simulator UI server):**
  - Modern card foot-group renders `Stop, Connect, Configuration, Authorize, Details`; Delete isolated at right.
  - Classic action cell renders `Stop Charging Station, Open Connection, Set Supervision Url, Change Configuration, Show Details, Delete Charging Station`.

## Notes / risks

- `pnpm format` (Prettier) is a non-blocking, bot-applied step (`autofix.yml`), not a CI gate (`ci.yml` runs typecheck/lint/build/test). The installed Prettier 3.9.6 reports ~67/97 pre-existing `ui/web` files as reformattable — an environment/version artifact unrelated to this change. To avoid unrelated churn and local style inconsistency, no `prettier --write` was run; edited code matches the surrounding committed style and passes ESLint.
